### PR TITLE
Reading immutable history only if necessary

### DIFF
--- a/content/src/service/history/HistoryManager.ts
+++ b/content/src/service/history/HistoryManager.ts
@@ -5,9 +5,9 @@ import { ServerName } from "../naming/NameKeeper"
 export interface HistoryManager {
     newEntityDeployment(serverName: ServerName, entityType: EntityType, entityId: EntityId, timestamp: Timestamp): Promise<void>;
     setTimeAsImmutable(immutableTime: Timestamp): Promise<void>;
-    getLastImmutableTime(): Promise<Timestamp | undefined>;
+    getLastImmutableTime(): Timestamp;
     getHistory(from?: Timestamp, to?: Timestamp, serverName?: ServerName, offset?: number, limit?: number): Promise<PartialDeploymentHistory>;
-    getHistorySize(): Promise<number>;
+    getHistorySize(): number;
 }
 
 export type DeploymentEvent = {

--- a/content/src/service/history/HistoryManagerImpl.ts
+++ b/content/src/service/history/HistoryManagerImpl.ts
@@ -7,7 +7,8 @@ import { happenedBeforeTime, happenedBefore, sortFromOldestToNewest } from "../t
 
 export class HistoryManagerImpl implements HistoryManager {
 
-    private constructor(private readonly storage: HistoryStorage,
+    private constructor(
+        private readonly storage: HistoryStorage,
         private tempHistory: DeploymentHistory, // This history is sorted from newest to oldest
         private immutableTime: Timestamp,
         private immutableHistorySize: number) { }

--- a/content/test/integration/E2EAssertions.ts
+++ b/content/test/integration/E2EAssertions.ts
@@ -38,6 +38,8 @@ export async function assertEntitiesAreActiveOnServer(server: TestServer, ...ent
 export async function assertHistoryOnServerHasEvents(server: TestServer, ...expectedEvents: DeploymentEvent[]) {
     const deploymentHistory: DeploymentHistory = (await server.getHistory()).events
     expect(deploymentHistory.length).toEqual(expectedEvents.length, `Expected ${server.namePrefix} to have ${expectedEvents.length} deployments in history`)
+    const { historySize } = await server.getStatus()
+    expect(historySize).toEqual(expectedEvents.length, `Expected ${server.namePrefix} to report a history of size ${expectedEvents.length} on the status`)
     for (let i = 0; i < expectedEvents.length; i++) {
         const expectedEvent: DeploymentEvent = expectedEvents[expectedEvents.length - 1 - i]
         const actualEvent: DeploymentEvent = deploymentHistory[i]

--- a/content/test/unit/service/history/MockedHistoryManager.ts
+++ b/content/test/unit/service/history/MockedHistoryManager.ts
@@ -5,8 +5,8 @@ import { Timestamp } from "@katalyst/content/service/time/TimeSorting";
 
 export class MockedHistoryManager implements HistoryManager {
 
-    getLastImmutableTime(): Promise<number | undefined> {
-        return Promise.resolve(undefined)
+    getLastImmutableTime(): Timestamp {
+        return 0
     }
 
     newEntityDeployment(serverName: ServerName, entity: EntityType, entityId: EntityId, timestamp: Timestamp): Promise<void> {
@@ -21,7 +21,7 @@ export class MockedHistoryManager implements HistoryManager {
         throw new Error("Method not implemented.");
     }
 
-    getHistorySize(): Promise<number> {
+    getHistorySize(): number {
         throw new Error("Method not implemented.");
     }
 


### PR DESCRIPTION
We are now checking if we need to read and parse the immutable history before actually doing so. Previously, we would always read it.