### PR TITLE
Now the content server can support name changes without problems

### DIFF
--- a/content/src/service/synchronization/ContentCluster.ts
+++ b/content/src/service/synchronization/ContentCluster.ts
@@ -120,7 +120,7 @@ export class ContentCluster {
                         newClient = getClient(this.fetchHelper, address, newName, previousClient.getEstimatedLocalImmutableTime())
                     } else if (previousClient.getName() !== newName) {
                         // Update known name to new one
-                        ContentCluster.LOGGER.warn(`Server's name changed on ${address}. It was ${previousClient.getName()} and know it is ${newName}.`)
+                        ContentCluster.LOGGER.warn(`Server's name changed on ${address}. It was ${previousClient.getName()} and now it is ${newName}.`)
                         newClient = getClient(this.fetchHelper, address, newName, previousClient.getEstimatedLocalImmutableTime())
                     }
                 } else {

--- a/content/src/service/synchronization/ContentCluster.ts
+++ b/content/src/service/synchronization/ContentCluster.ts
@@ -109,7 +109,7 @@ export class ContentCluster {
                 let newClient: ContentServerClient | undefined
                 // Check if we already knew the server
                 const previousClient: ContentServerClient | undefined = this.serversInDAO.get(address);
-                if (previousClient && previousClient.getName() !== UNREACHABLE) {
+                if (previousClient && previousClient.getConnectionState() !== ConnectionState.NEVER_REACHED) {
                     if (newName === UNREACHABLE) {
                         // Create redirect client
                         newClient = getRedirectClient(this, previousClient.getName(), previousClient.getEstimatedLocalImmutableTime())
@@ -117,6 +117,10 @@ export class ContentCluster {
                     } else if (previousClient.getConnectionState() !== ConnectionState.CONNECTED) {
                         // Create new client
                         ContentCluster.LOGGER.info(`Could re-connect to server ${newName} on ${address}`)
+                        newClient = getClient(this.fetchHelper, address, newName, previousClient.getEstimatedLocalImmutableTime())
+                    } else if (previousClient.getName() !== newName) {
+                        // Update known name to new one
+                        ContentCluster.LOGGER.warn(`Server's name changed on ${address}. It was ${previousClient.getName()} and know it is ${newName}.`)
                         newClient = getClient(this.fetchHelper, address, newName, previousClient.getEstimatedLocalImmutableTime())
                     }
                 } else {

--- a/content/src/service/synchronization/clients/contentserver/ActiveContentServerClient.ts
+++ b/content/src/service/synchronization/clients/contentserver/ActiveContentServerClient.ts
@@ -82,8 +82,16 @@ class ActiveContentServerClient extends ContentServerClient {
         throw new Error(`Failed to fetch file with hash ${fileHash}`)
     }
 
+    /**
+     * Check the current time on the status and report it. However, if the name is not as expected, then
+     * we shouldn't update the estimated immutable time. On the next DAO sync, the name will be updated correctly
+     */
     private async getCurrentTimestamp(): Promise<Timestamp> {
-        const { currentTime } = await this.fetchHelper.fetchJson(`${this.address}/status`)
-        return currentTime;
+        const { currentTime, name } = await this.getStatus()
+        if (name === this.getName()) {
+            return currentTime;
+        } else {
+            return -1
+        }
     }
 }

--- a/content/test/integration/E2ETestUtils.ts
+++ b/content/test/integration/E2ETestUtils.ts
@@ -84,6 +84,10 @@ export function deleteFolderRecursive(pathToDelete: string) {
     }
 }
 
+export async function stopServers(...servers: TestServer[]): Promise<void> {
+    await Promise.all(servers.map(server => server.stop()))
+}
+
 export function buildBaseEnv(namePrefix: string, port: number, syncInterval: number, daoClient: DAOClient): EnvironmentBuilder {
     return new EnvironmentBuilder()
         .withConfig(EnvironmentConfig.NAME_PREFIX, namePrefix)
@@ -93,6 +97,7 @@ export function buildBaseEnv(namePrefix: string, port: number, syncInterval: num
         .withConfig(EnvironmentConfig.LOG_REQUESTS, false)
         .withConfig(EnvironmentConfig.SYNC_WITH_SERVERS_INTERVAL, syncInterval)
         .withConfig(EnvironmentConfig.UPDATE_FROM_DAO_INTERVAL, syncInterval)
+        .withConfig(EnvironmentConfig.LOG_LEVEL, "debug")
         .withBean(Bean.DAO_CLIENT, daoClient)
         .withAnalytics(new MockedContentAnalytics())
         .withAccessChecker(new MockedAccessChecker())

--- a/content/test/integration/syncronization/name-change-handling.spec.ts
+++ b/content/test/integration/syncronization/name-change-handling.spec.ts
@@ -41,7 +41,7 @@ describe("End 2 end - Name change handling", function() {
         deleteServerStorage(server1, server2)
     })
 
-    it('When a node starts, it get all the previous history', async () => {
+    it('When a node\'s name changes, other nodes can handle it and continue to sync', async () => {
         // Start server 1 and 2
         await Promise.all([server1.start(), server2.start()])
 

--- a/content/test/integration/syncronization/name-change-handling.spec.ts
+++ b/content/test/integration/syncronization/name-change-handling.spec.ts
@@ -1,0 +1,101 @@
+import ms from "ms"
+import fs from "fs"
+import { Timestamp } from "@katalyst/content/service/time/TimeSorting"
+import { DAOClient } from "decentraland-katalyst-commons/src/DAOClient"
+import { Environment, EnvironmentConfig } from "@katalyst/content/Environment"
+import { TestServer } from "../TestServer"
+import { buildDeployData, buildBaseEnv, deleteServerStorage, buildDeployDataAfterEntity, stopServers } from "../E2ETestUtils"
+import { assertHistoryOnServerHasEvents, buildEvent } from "../E2EAssertions"
+import { MockedDAOClient } from "./clients/MockedDAOClient"
+import { delay } from "decentraland-katalyst-commons/src/util"
+import { ControllerEntity } from "@katalyst/content/controller/Controller"
+import { DeploymentEvent } from "@katalyst/content/service/history/HistoryManager"
+import { EntityType } from "@katalyst/content/service/Entity"
+
+
+describe("End 2 end - Name change handling", function() {
+
+    const SYNC_INTERVAL: number = ms("1s")
+    const DAO_SYNC_INTERVAL: number = ms("8s")
+    let jasmine_default_timeout
+    let server1: TestServer, server2: TestServer
+    let dao
+
+    beforeAll(() => {
+        jasmine_default_timeout = jasmine.DEFAULT_TIMEOUT_INTERVAL
+        jasmine.DEFAULT_TIMEOUT_INTERVAL = 100000
+    })
+
+    afterAll(() => {
+        jasmine.DEFAULT_TIMEOUT_INTERVAL = jasmine_default_timeout
+    })
+
+    beforeEach(async () => {
+        dao = MockedDAOClient.withAddresses('http://localhost:6060', 'http://localhost:7070')
+        server1 = await buildServer("Server1_", 6060, SYNC_INTERVAL, dao)
+        server2 = await buildServer("Server2_", 7070, SYNC_INTERVAL, dao)
+    })
+
+    afterEach(async () => {
+        await stopServers(server1, server2)
+        deleteServerStorage(server1, server2)
+    })
+
+    it('When a node starts, it get all the previous history', async () => {
+        // Start server 1 and 2
+        await Promise.all([server1.start(), server2.start()])
+
+        // Prepare data to be deployed
+        const [deployData1, entity1] = await buildDeployData(["X1,Y1", "X2,Y2"], "metadata")
+        const [deployData2, entity2] = await buildDeployDataAfterEntity(["X2,Y2"], "metadata2", entity1)
+
+        // Deploy entity1 on server 1
+        const deploymentTimestamp1: Timestamp = await server1.deploy(deployData1)
+        const deploymentEvent1 = buildEvent(entity1, server1, deploymentTimestamp1)
+
+        // Wait for sync to happen
+        await delay(SYNC_INTERVAL * 2)
+
+        // Assert servers 1 and 2 are synced
+        await assertHistoryOnServerHasEvents(server2, deploymentEvent1)
+
+        // Change name and do hard restart
+        const newName = "newName"
+        await changeNameInStorage(server1, newName)
+        await server1.stop()
+        server1 = await buildServer("Server1_", 6060, SYNC_INTERVAL, dao)
+        await server1.start()
+
+        // Deploy entity2 on server 1
+        const deploymentTimestamp2: Timestamp = await server1.deploy(deployData2)
+        const deploymentEvent2 = buildEventWithName(entity2, newName, deploymentTimestamp2)
+
+        // Wait for sync with DAO to happen
+        await delay(DAO_SYNC_INTERVAL)
+
+        // Assert servers 1 and 2 are synced
+        await assertHistoryOnServerHasEvents(server2, deploymentEvent1, deploymentEvent2)
+    })
+
+    function changeNameInStorage(server: TestServer, newName: string) {
+        const nameFile = server.storageFolder + '/naming/name.txt'
+        return fs.promises.writeFile(nameFile, Buffer.from(newName))
+    }
+
+    async function buildServer(namePrefix: string, port: number, syncInterval: number, daoClient: DAOClient) {
+        const env: Environment = await buildBaseEnv(namePrefix, port, syncInterval, daoClient)
+            .withConfig(EnvironmentConfig.UPDATE_FROM_DAO_INTERVAL, DAO_SYNC_INTERVAL)
+            .build()
+        return new TestServer(env)
+    }
+
+    function buildEventWithName(entity: ControllerEntity, serverName: string, timestamp: Timestamp): DeploymentEvent {
+        return {
+            serverName: serverName,
+            entityId: entity.id,
+            entityType: EntityType[entity.type.toUpperCase().trim()],
+            timestamp,
+        }
+    }
+
+})


### PR DESCRIPTION
This PR adds to content servers the ability to support name changes on other servers. It does so by changing two things:
1. When syncing with the DAO (every 5 min by default), if we detect a new name, we update it
2. When syncing with other servers, if there is no new deployment, we won't update it's estimated immutable time if the name is different from the expected one.