### PR TITLE
Add many content server tests

### DIFF
--- a/content/src/Environment.ts
+++ b/content/src/Environment.ts
@@ -25,6 +25,7 @@ import { AuthenticatorFactory } from "./service/auth/AuthenticatorFactory";
 import { AccessCheckerImplFactory } from "./service/access/AccessCheckerImplFactory";
 import { FailedDeploymentsManagerFactory } from "./service/errors/FailedDeploymentsManagerFactory";
 import { FetchHelperFactory } from "./helpers/FetchHelperFactory";
+import { ValidationsFactory } from "./service/validations/ValidationsFactory";
 
 export const CURRENT_CONTENT_VERSION: EntityVersion = EntityVersion.V3
 const DEFAULT_STORAGE_ROOT_FOLDER = "storage"
@@ -85,6 +86,7 @@ export const enum Bean {
     AUTHENTICATOR,
     FAILED_DEPLOYMENTS_MANAGER,
     FETCH_HELPER,
+    VALIDATIONS,
 }
 
 export const enum EnvironmentConfig {
@@ -106,6 +108,7 @@ export const enum EnvironmentConfig {
     FILE_DOWNLOAD_REQUEST_TIMEOUT,
     USE_COMPRESSION_MIDDLEWARE,
     PERFORM_MULTI_SERVER_ONBOARDING,
+    REQUEST_TTL_BACKWARDS,
 }
 
 export class EnvironmentBuilder {
@@ -180,6 +183,7 @@ export class EnvironmentBuilder {
         this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.FILE_DOWNLOAD_REQUEST_TIMEOUT, () => process.env.FILE_DOWNLOAD_REQUEST_TIMEOUT ?? ms('5m'))
         this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.USE_COMPRESSION_MIDDLEWARE, () => process.env.USE_COMPRESSION_MIDDLEWARE === "true");
         this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.PERFORM_MULTI_SERVER_ONBOARDING, () => process.env.PERFORM_MULTI_SERVER_ONBOARDING === "true");
+        this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.REQUEST_TTL_BACKWARDS     , () => ms('20m'));
 
         // Please put special attention on the bean registration order.
         // Some beans depend on other beans, so the required beans should be registered before
@@ -200,6 +204,7 @@ export class EnvironmentBuilder {
         this.registerBeanIfNotAlreadySet(env, Bean.POINTER_MANAGER             , () => PointerManagerFactory.create(env))
         this.registerBeanIfNotAlreadySet(env, Bean.ACCESS_CHECKER              , () => AccessCheckerImplFactory.create(env))
         this.registerBeanIfNotAlreadySet(env, Bean.FAILED_DEPLOYMENTS_MANAGER  , () => FailedDeploymentsManagerFactory.create(env))
+        this.registerBeanIfNotAlreadySet(env, Bean.VALIDATIONS                 , () => ValidationsFactory.create(env))
         const service = await ServiceFactory.create(env);
         this.registerBeanIfNotAlreadySet(env, Bean.SERVICE                     , () => service)
         this.registerBeanIfNotAlreadySet(env, Bean.EVENT_DEPLOYER              , () => EventDeployerFactory.create(env))

--- a/content/src/service/ServiceFactory.ts
+++ b/content/src/service/ServiceFactory.ts
@@ -13,11 +13,9 @@ export class ServiceFactory {
             env.getBean(Bean.POINTER_MANAGER),
             env.getBean(Bean.NAME_KEEPER),
             env.getBean(Bean.ANALYTICS),
-            env.getBean(Bean.ACCESS_CHECKER),
-            env.getBean(Bean.AUTHENTICATOR),
             env.getBean(Bean.FAILED_DEPLOYMENTS_MANAGER),
-            env.getConfig(EnvironmentConfig.IGNORE_VALIDATION_ERRORS),
-            env.getConfig(EnvironmentConfig.ETH_NETWORK));
+            env.getBean(Bean.VALIDATIONS),
+            env.getConfig(EnvironmentConfig.IGNORE_VALIDATION_ERRORS));
     }
 }
 

--- a/content/src/service/synchronization/ClusterSynchronizationManagerFactory.ts
+++ b/content/src/service/synchronization/ClusterSynchronizationManagerFactory.ts
@@ -9,7 +9,8 @@ export class ClusterSynchronizationManagerFactory {
             env.getBean(Bean.SERVICE),
             env.getBean(Bean.EVENT_DEPLOYER),
             env.getConfig(EnvironmentConfig.SYNC_WITH_SERVERS_INTERVAL),
-            env.getConfig(EnvironmentConfig.PERFORM_MULTI_SERVER_ONBOARDING))
+            env.getConfig(EnvironmentConfig.PERFORM_MULTI_SERVER_ONBOARDING),
+            env.getConfig(EnvironmentConfig.REQUEST_TTL_BACKWARDS))
     }
 
 }

--- a/content/src/service/synchronization/ContentCluster.ts
+++ b/content/src/service/synchronization/ContentCluster.ts
@@ -33,7 +33,8 @@ export class ContentCluster {
     constructor(private readonly dao: DAOClient,
         private readonly timeBetweenSyncs: number,
         private readonly nameKeeper: NameKeeper,
-        private readonly fetchHelper: FetchHelper) { }
+        private readonly fetchHelper: FetchHelper,
+        private readonly requestTtlBackwards: number) { }
 
     /** Connect to the DAO for the first time */
     async connect(lastImmutableTime: Timestamp): Promise<void> {
@@ -117,11 +118,11 @@ export class ContentCluster {
                     } else if (previousClient.getConnectionState() !== ConnectionState.CONNECTED) {
                         // Create new client
                         ContentCluster.LOGGER.info(`Could re-connect to server ${newName} on ${address}`)
-                        newClient = getClient(this.fetchHelper, address, newName, previousClient.getEstimatedLocalImmutableTime())
+                        newClient = getClient(this.fetchHelper, address, this.requestTtlBackwards, newName, previousClient.getEstimatedLocalImmutableTime())
                     } else if (previousClient.getName() !== newName) {
                         // Update known name to new one
                         ContentCluster.LOGGER.warn(`Server's name changed on ${address}. It was ${previousClient.getName()} and now it is ${newName}.`)
-                        newClient = getClient(this.fetchHelper, address, newName, previousClient.getEstimatedLocalImmutableTime())
+                        newClient = getClient(this.fetchHelper, address, this.requestTtlBackwards, newName, previousClient.getEstimatedLocalImmutableTime())
                     }
                 } else {
                     if (newName === UNREACHABLE) {
@@ -129,7 +130,7 @@ export class ContentCluster {
                         newClient = getUnreachableClient()
                     } else {
                         // Create new client
-                        newClient = getClient(this.fetchHelper, address, newName, this.lastImmutableTime)
+                        newClient = getClient(this.fetchHelper, address, this.requestTtlBackwards, newName, this.lastImmutableTime)
                         ContentCluster.LOGGER.info(`Connected to new server ${newName} on ${address}`)
                     }
                 }

--- a/content/src/service/synchronization/ContentClusterFactory.ts
+++ b/content/src/service/synchronization/ContentClusterFactory.ts
@@ -8,7 +8,8 @@ export class ContentClusterFactory {
             env.getBean(Bean.DAO_CLIENT),
             env.getConfig(EnvironmentConfig.UPDATE_FROM_DAO_INTERVAL),
             env.getBean(Bean.NAME_KEEPER),
-            env.getBean(Bean.FETCH_HELPER))
+            env.getBean(Bean.FETCH_HELPER),
+            env.getConfig(EnvironmentConfig.REQUEST_TTL_BACKWARDS))
     }
 
 }

--- a/content/src/service/synchronization/SynchronizationManager.ts
+++ b/content/src/service/synchronization/SynchronizationManager.ts
@@ -10,7 +10,6 @@ import { EventDeployer } from "./EventDeployer";
 import { MultiServerHistoryRequest } from "./MultiServerHistoryRequest";
 import { Bootstrapper } from "./Bootstrapper";
 import { Disposable } from "./events/ClusterEvent";
-import { Validations } from "../validations/Validations";
 import { delay } from "decentraland-katalyst-commons/src/util";
 
 export interface SynchronizationManager {
@@ -32,7 +31,8 @@ export class ClusterSynchronizationManager implements SynchronizationManager {
         private readonly service: TimeKeepingService,
         private readonly deployer: EventDeployer,
         private readonly timeBetweenSyncs: number,
-        private readonly performMultiServerOnboarding: boolean) { }
+        private readonly performMultiServerOnboarding: boolean,
+        private readonly requestTtlBackwards: number) { }
 
     async start(): Promise<void> {
         // Make sure the stopping flag is set to false
@@ -84,7 +84,7 @@ export class ClusterSynchronizationManager implements SynchronizationManager {
 
             // Find the minimum timestamp between all servers
             const minTimestamp: Timestamp = contentServers.map(contentServer => contentServer.getEstimatedLocalImmutableTime())
-                .reduce((min, current) => Math.min(min, current), Date.now() - Validations.REQUEST_TTL_BACKWARDS)
+                .reduce((min, current) => Math.min(min, current), Date.now() - this.requestTtlBackwards)
 
             if (minTimestamp > this.lastImmutableTime) {
                 // Set this new minimum timestamp as the latest immutable time

--- a/content/src/service/validations/ValidationsFactory.ts
+++ b/content/src/service/validations/ValidationsFactory.ts
@@ -1,0 +1,13 @@
+import { Environment, Bean, EnvironmentConfig } from "@katalyst/content/Environment";
+import { Validations } from "./Validations";
+
+export class ValidationsFactory {
+
+    static create(env: Environment): Validations {
+        return new Validations(env.getBean(Bean.ACCESS_CHECKER),
+            env.getBean(Bean.AUTHENTICATOR),
+            env.getBean(Bean.FAILED_DEPLOYMENTS_MANAGER),
+            env.getConfig(EnvironmentConfig.ETH_NETWORK),
+            env.getConfig(EnvironmentConfig.REQUEST_TTL_BACKWARDS))
+    }
+}

--- a/content/test/helpers/service/MockedMetaverseContentService.ts
+++ b/content/test/helpers/service/MockedMetaverseContentService.ts
@@ -49,8 +49,9 @@ export class MockedMetaverseContentService implements MetaverseContentService {
         return Promise.resolve(pointers)
     }
 
-    getPointerHistory(type: EntityType, pointer: Pointer): Promise<PointerHistory> {
-        return Promise.resolve([])
+    async getPointerHistory(type: EntityType, pointer: Pointer): Promise<PointerHistory> {
+        const entities = await this.getEntitiesByPointers(type, [pointer])
+        return entities.map(entity => ({ entityId: entity.id, timestamp: entity.timestamp }))
     }
 
     deployEntity(files: ContentFile[], entityId: EntityId, auditInfo: AuditInfo): Promise<Timestamp> {

--- a/content/test/integration/E2ETestUtils.ts
+++ b/content/test/integration/E2ETestUtils.ts
@@ -21,7 +21,7 @@ export function buildDeployData(pointers: Pointer[], metadata: any, ...contentPa
     return buildDeployDataInternal(pointers, metadata, contentPaths, createIdentity())
 }
 
-export async function buildDeployDataAfterEntity(pointers: Pointer[], metadata: any, afterEntity?: ControllerEntity, ...contentPaths: string[]): Promise<[DeployData, ControllerEntity]> {
+export async function buildDeployDataAfterEntity(pointers: Pointer[], metadata: any, afterEntity: ControllerEntity, ...contentPaths: string[]): Promise<[DeployData, ControllerEntity]> {
     return buildDeployDataInternal(pointers, metadata, contentPaths, createIdentity(), afterEntity)
 }
 

--- a/content/test/integration/E2ETestUtils.ts
+++ b/content/test/integration/E2ETestUtils.ts
@@ -35,7 +35,7 @@ async function buildDeployDataInternal(pointers: Pointer[], metadata: any, conte
     const [entity, entityFile] = await buildControllerEntityAndFile(
         EntityType.SCENE,
         pointers.map(pointer => pointer.toLocaleLowerCase()),
-        (afterEntity?.timestamp ?? Date.now()) + 1,
+        Math.max(Date.now(), afterEntity?.timestamp ?? 0 + 1),
         content,
         metadata)
 

--- a/content/test/integration/TestServer.ts
+++ b/content/test/integration/TestServer.ts
@@ -1,7 +1,7 @@
 import fetch from "node-fetch"
 import FormData from "form-data"
 import { Server } from "@katalyst/content/Server"
-import { Environment, EnvironmentConfig } from "@katalyst/content/Environment"
+import { Environment, EnvironmentConfig, Bean } from "@katalyst/content/Environment"
 import { ServerAddress, ContentServerClient } from "@katalyst/content/service/synchronization/clients/contentserver/ContentServerClient"
 import { EntityType, Pointer, EntityId } from "@katalyst/content/service/Entity"
 import { ControllerEntity } from "@katalyst/content/controller/Controller"
@@ -32,7 +32,9 @@ export class TestServer extends Server {
         this.serverPort = env.getConfig(EnvironmentConfig.SERVER_PORT)
         this.namePrefix = env.getConfig(EnvironmentConfig.NAME_PREFIX)
         this.storageFolder = env.getConfig(EnvironmentConfig.STORAGE_ROOT_FOLDER)
-        this.client = getClient(new FetchHelper(), this.getAddress(), this.namePrefix, 0)
+        const fetchHelper: FetchHelper = env.getBean(Bean.FETCH_HELPER)
+        const requestTtlBackwards: number = env.getConfig(EnvironmentConfig.REQUEST_TTL_BACKWARDS)
+        this.client = getClient(fetchHelper, this.getAddress(), requestTtlBackwards, this.namePrefix, 0)
     }
 
     getAddress(): ServerAddress {

--- a/content/test/integration/syncronization/cluster-synchronization.spec.ts
+++ b/content/test/integration/syncronization/cluster-synchronization.spec.ts
@@ -3,7 +3,7 @@ import { Timestamp } from "@katalyst/content/service/time/TimeSorting"
 import { DAOClient } from "decentraland-katalyst-commons/src/DAOClient"
 import { Environment } from "@katalyst/content/Environment"
 import { TestServer } from "../TestServer"
-import { buildDeployData, deleteServerStorage, buildDeployDataAfterEntity, buildBaseEnv } from "../E2ETestUtils"
+import { buildDeployData, deleteServerStorage, buildDeployDataAfterEntity, buildBaseEnv, stopServers } from "../E2ETestUtils"
 import { assertEntitiesAreActiveOnServer, assertEntitiesAreDeployedButNotActive, assertHistoryOnServerHasEvents, assertEntityIsOverwrittenBy, assertEntityIsNotOverwritten, buildEvent } from "../E2EAssertions"
 import { MockedDAOClient } from "./clients/MockedDAOClient"
 import { delay } from "decentraland-katalyst-commons/src/util"
@@ -31,9 +31,7 @@ describe("End 2 end synchronization tests", function() {
     })
 
     afterEach(async function() {
-        await server1.stop()
-        await server2.stop()
-        await server3.stop()
+        await stopServers(server1, server2, server3)
         deleteServerStorage(server1, server2, server3)
     })
 

--- a/content/test/integration/syncronization/error-handling.spec.ts
+++ b/content/test/integration/syncronization/error-handling.spec.ts
@@ -58,15 +58,14 @@ describe("End 2 end - Error handling", () => {
             () => { accessChecker.stopReturningErrors(); return Promise.resolve() })
     });
 
-    it(`When a user tries to fix an entity, it doesn't matter if there is already a newer entity deployer`, async () => {
+    it(`When a user tries to fix an entity, it doesn't matter if there is already a newer entity deployed`, async () => {
         // Start servers
         await server1.start()
         await server2.start()
 
-        // Prepare entities to deploy
+        // Prepare entity to deploy
         const [deployData1, entityBeingDeployed1] = await buildDeployData(["0,0", "0,1"], 'metadata', 'content/test/integration/resources/some-binary-file.png')
         const entity1Content = entityBeingDeployed1.content!![0].hash
-        const [deployData2, entityBeingDeployed2] = await buildDeployDataAfterEntity(["0,1"], 'metadata2', entityBeingDeployed1)
 
         // Deploy entity 1
         await server1.deploy(deployData1)
@@ -80,6 +79,9 @@ describe("End 2 end - Error handling", () => {
         // Assert deployment is marked as failed on server 2
         const failedDeployments: FailedDeployment[] = await server2.getFailedDeployments()
         expect(failedDeployments.length).toBe(1)
+
+        // Prepare entity to deploy
+        const [deployData2, entityBeingDeployed2] = await buildDeployDataAfterEntity(["0,1"], 'metadata2', entityBeingDeployed1)
 
         // Deploy entity 2 on server 2
         await server2.deploy(deployData2)
@@ -179,6 +181,7 @@ describe("End 2 end - Error handling", () => {
     async function buildServer(namePrefix: string, port: number, syncInterval: number, daoClient: DAOClient) {
         const env: Environment = await buildBaseEnv(namePrefix, port, syncInterval, daoClient)
             .withConfig(EnvironmentConfig.DECENTRALAND_ADDRESS, identity.address)
+            .withConfig(EnvironmentConfig.REQUEST_TTL_BACKWARDS, ms('5s'))
             .withAccessChecker(accessChecker)
             .build()
         return new TestServer(env)

--- a/content/test/integration/syncronization/error-handling.spec.ts
+++ b/content/test/integration/syncronization/error-handling.spec.ts
@@ -1,12 +1,12 @@
 import ms from "ms"
-import { buildEvent, assertEqualsDeployment, assertEntityWasNotDeployed, assertEntitiesAreActiveOnServer, assertHistoryOnServerHasEvents } from "../E2EAssertions"
+import { buildEvent, assertEqualsDeployment, assertEntityWasNotDeployed, assertEntitiesAreActiveOnServer, assertHistoryOnServerHasEvents, assertEntitiesAreDeployedButNotActive } from "../E2EAssertions"
 import { Environment, EnvironmentConfig } from "@katalyst/content/Environment"
 import { DAOClient } from "decentraland-katalyst-commons/src/DAOClient";
 import { Timestamp } from "@katalyst/content/service/time/TimeSorting"
-import { ControllerEntityContent, ControllerEntity } from "@katalyst/content/controller/Controller"
+import { ControllerEntity } from "@katalyst/content/controller/Controller"
 import { MockedDAOClient } from "./clients/MockedDAOClient"
 import { TestServer } from "../TestServer"
-import { buildBaseEnv, buildDeployData, deleteServerStorage, createIdentity } from "../E2ETestUtils"
+import { buildBaseEnv, buildDeployData, deleteServerStorage, createIdentity, buildDeployDataAfterEntity, stopServers } from "../E2ETestUtils"
 import { FailedDeployment, FailureReason } from "@katalyst/content/service/errors/FailedDeploymentsManager"
 import { MockedAccessChecker } from "@katalyst/test-helpers/service/access/MockedAccessChecker"
 import { assertPromiseRejectionIs } from "@katalyst/test-helpers/PromiseAssertions"
@@ -38,8 +38,7 @@ describe("End 2 end - Error handling", () => {
     })
 
     afterEach(async function() {
-        await server1.stop()
-        await server2.stop()
+        await stopServers(server1, server2)
         deleteServerStorage(server1, server2)
     })
 
@@ -50,13 +49,56 @@ describe("End 2 end - Error handling", () => {
 
     it(`When content can't be retrieved, then the error is recorded and no entity is created`, async () => {
         await runTest(FailureReason.FETCH_PROBLEM,
-            entity => server1.denylistContent((entity.content as ControllerEntityContent[])[0].hash, identity))
+            entity => server1.denylistContent(entity.content!![0].hash, identity))
     });
 
     it(`When an error happens during deployment, then the error is recorded and no entity is created`, async () => {
         await runTest(FailureReason.DEPLOYMENT_ERROR,
             _ => { accessChecker.startReturningErrors(); return Promise.resolve() },
             () => { accessChecker.stopReturningErrors(); return Promise.resolve() })
+    });
+
+    it(`When a user tries to fix an entity, it doesn't matter if there is already a newer entity deployer`, async () => {
+        // Start servers
+        await server1.start()
+        await server2.start()
+
+        // Prepare entity to deploy
+        const [deployData1, entityBeingDeployed1] = await buildDeployData(["0,0", "0,1"], 'metadata', 'content/test/integration/resources/some-binary-file.png')
+        const entity1Content = entityBeingDeployed1.content!![0].hash
+        const [deployData2, entityBeingDeployed2] = await buildDeployDataAfterEntity(["0,1"], 'metadata2')
+
+        // Deploy entity 1
+        await server1.deploy(deployData1)
+
+        // Cause failure
+        await server1.denylistContent(entity1Content, identity)
+
+        // Wait for servers to sync
+        await delay(SYNC_INTERVAL * 2)
+
+        // Assert deployment is marked as failed
+        const failedDeployments: FailedDeployment[] = await server2.getFailedDeployments()
+        expect(failedDeployments.length).toBe(1)
+
+        // Deploy entity 2
+        await server2.deploy(deployData2)
+
+        // Fix entity 1
+        await server2.deploy(deployData1, true)
+
+        // Assert there are no more failed deployments
+        const newFailedDeployments: FailedDeployment[] = await server2.getFailedDeployments()
+        expect(newFailedDeployments.length).toBe(0)
+
+        // Wait for servers to sync
+        await delay(SYNC_INTERVAL * 2)
+
+        // Assert entity 2 is the active entity
+        await assertEntitiesAreActiveOnServer(server1, entityBeingDeployed2)
+        await assertEntitiesAreActiveOnServer(server2, entityBeingDeployed2)
+        await assertEntitiesAreDeployedButNotActive(server1, entityBeingDeployed1)
+        await assertEntitiesAreDeployedButNotActive(server2, entityBeingDeployed1)
     });
 
     it(`When a user tries to fix an entity that didn't exist, then an error is thrown`, async () => {

--- a/content/test/integration/syncronization/name-change-handling.spec.ts
+++ b/content/test/integration/syncronization/name-change-handling.spec.ts
@@ -47,7 +47,6 @@ describe("End 2 end - Name change handling", function() {
 
         // Prepare data to be deployed
         const [deployData1, entity1] = await buildDeployData(["X1,Y1", "X2,Y2"], "metadata")
-        const [deployData2, entity2] = await buildDeployDataAfterEntity(["X2,Y2"], "metadata2", entity1)
 
         // Deploy entity1 on server 1
         const deploymentTimestamp1: Timestamp = await server1.deploy(deployData1)
@@ -65,6 +64,9 @@ describe("End 2 end - Name change handling", function() {
         await server1.stop()
         server1 = await buildServer("Server1_", 6060, SYNC_INTERVAL, dao)
         await server1.start()
+
+        // Prepare data to be deployed
+        const [deployData2, entity2] = await buildDeployDataAfterEntity(["X2,Y2"], "metadata2", entity1)
 
         // Deploy entity2 on server 1
         const deploymentTimestamp2: Timestamp = await server1.deploy(deployData2)
@@ -85,6 +87,7 @@ describe("End 2 end - Name change handling", function() {
     async function buildServer(namePrefix: string, port: number, syncInterval: number, daoClient: DAOClient) {
         const env: Environment = await buildBaseEnv(namePrefix, port, syncInterval, daoClient)
             .withConfig(EnvironmentConfig.UPDATE_FROM_DAO_INTERVAL, DAO_SYNC_INTERVAL)
+            .withConfig(EnvironmentConfig.REQUEST_TTL_BACKWARDS, ms('5s'))
             .build()
         return new TestServer(env)
     }

--- a/content/test/unit/denylist/DenylistServiceDecorator.spec.ts
+++ b/content/test/unit/denylist/DenylistServiceDecorator.spec.ts
@@ -10,7 +10,7 @@ import { assertPromiseIsRejected, assertPromiseRejectionIs } from "@katalyst/tes
 import { EntityVersion, AuditInfo, NO_TIMESTAMP } from "@katalyst/content/service/audit/Audit";
 import { Authenticator } from "dcl-crypto";
 
-describe("DenylistServiceDecorator", () => {
+fdescribe("DenylistServiceDecorator", () => {
 
     const P1: Pointer = "p1"
     const P2: Pointer = "p2"
@@ -66,6 +66,24 @@ describe("DenylistServiceDecorator", () => {
         const entities = await decorator.getEntitiesByPointers(entity2.type, entity2.pointers);
 
         expect(entities).toEqual([entity2])
+    })
+
+    it(`When a pointer is denylisted, then the history is empty`, async () => {
+        const denylist = denylistWith(P1Target)
+        const decorator = new DenylistServiceDecorator(service, denylist)
+
+        const entities = await decorator.getPointerHistory(entity1.type, P1);
+
+        expect(entities.length).toBe(0)
+    })
+
+    it(`When a pointer is not denylisted, then it reports the history correctly`, async () => {
+        const denylist = denylistWith()
+        const decorator = new DenylistServiceDecorator(service, denylist)
+
+        const history = await decorator.getPointerHistory(entity1.type, P1);
+
+        expect(history).toEqual([{ entityId: entity1.id, timestamp: entity1.timestamp }])
     })
 
     it(`When an entity is denylisted, then it is returned by pointers, but without content or metadata`, async () => {

--- a/content/test/unit/denylist/DenylistServiceDecorator.spec.ts
+++ b/content/test/unit/denylist/DenylistServiceDecorator.spec.ts
@@ -10,7 +10,7 @@ import { assertPromiseIsRejected, assertPromiseRejectionIs } from "@katalyst/tes
 import { EntityVersion, AuditInfo, NO_TIMESTAMP } from "@katalyst/content/service/audit/Audit";
 import { Authenticator } from "dcl-crypto";
 
-fdescribe("DenylistServiceDecorator", () => {
+describe("DenylistServiceDecorator", () => {
 
     const P1: Pointer = "p1"
     const P2: Pointer = "p2"

--- a/content/test/unit/service/validations/Validator.spec.ts
+++ b/content/test/unit/service/validations/Validator.spec.ts
@@ -283,11 +283,20 @@ const notReferencedHashMessage = hash => {
 
 function getValidatorWithRealAccess() {
   const authenticator = new ContentAuthenticator();
-  return new Validations(new AccessCheckerImpl(authenticator, "unused_url", new FetchHelper()), authenticator, mockedFailedDeploymentsManager(), "ropsten");
+  return new Validations(new AccessCheckerImpl(authenticator, "unused_url",
+    new FetchHelper()),
+    authenticator,
+    mockedFailedDeploymentsManager(),
+    "ropsten",
+    ms('10m')).getInstance();
 }
 
 function getValidatorWithMockedAccess() {
-  return new Validations(new MockedAccessChecker(), new ContentAuthenticator(), mockedFailedDeploymentsManager(), "ropsten");
+  return new Validations(new MockedAccessChecker(),
+    new ContentAuthenticator(),
+    mockedFailedDeploymentsManager(),
+    "ropsten",
+    ms('10m')).getInstance();
 }
 
 function mockedFailedDeploymentsManager() {


### PR DESCRIPTION
Changes:
A. We made TTL backwards time configurable, but not by env variable. We did this so that we can modify it in tests
B. We added a few tests:
1. `When a server finds a new deployment with already known content, it can still deploy it successfully`
2. `When a user tries to fix an entity, it doesn't matter if there is already a newer entity deployed`
3. `When a pointer is denylisted, then the history is empty`
4. `When a pointer is not denylisted, then it reports the history correctly`