### PR TITLE
Wait until status can be reported

### DIFF
--- a/content/src/Environment.ts
+++ b/content/src/Environment.ts
@@ -112,6 +112,7 @@ export const enum EnvironmentConfig {
     PERFORM_MULTI_SERVER_ONBOARDING,
     CACHE_SIZES,
     REQUEST_TTL_BACKWARDS,
+    WAIT_UNTIL_STATUS_IS_REPORTED,
 }
 
 export class EnvironmentBuilder {
@@ -188,6 +189,7 @@ export class EnvironmentBuilder {
         this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.PERFORM_MULTI_SERVER_ONBOARDING, () => process.env.PERFORM_MULTI_SERVER_ONBOARDING === "true");
         this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.CACHE_SIZES               , () => new Map(Object.entries(process.env).filter(([name,]) => name.startsWith("CACHE"))));
         this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.REQUEST_TTL_BACKWARDS     , () => ms('20m'));
+        this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.WAIT_UNTIL_STATUS_IS_REPORTED, () => true);
 
         // Please put special attention on the bean registration order.
         // Some beans depend on other beans, so the required beans should be registered before

--- a/content/src/service/synchronization/ContentClusterFactory.ts
+++ b/content/src/service/synchronization/ContentClusterFactory.ts
@@ -9,7 +9,8 @@ export class ContentClusterFactory {
             env.getConfig(EnvironmentConfig.UPDATE_FROM_DAO_INTERVAL),
             env.getBean(Bean.NAME_KEEPER),
             env.getBean(Bean.FETCH_HELPER),
-            env.getConfig(EnvironmentConfig.REQUEST_TTL_BACKWARDS))
+            env.getConfig(EnvironmentConfig.REQUEST_TTL_BACKWARDS),
+            env.getConfig(EnvironmentConfig.WAIT_UNTIL_STATUS_IS_REPORTED))
     }
 
 }

--- a/content/test/integration/E2ETestUtils.ts
+++ b/content/test/integration/E2ETestUtils.ts
@@ -98,6 +98,7 @@ export function buildBaseEnv(namePrefix: string, port: number, syncInterval: num
         .withConfig(EnvironmentConfig.SYNC_WITH_SERVERS_INTERVAL, syncInterval)
         .withConfig(EnvironmentConfig.UPDATE_FROM_DAO_INTERVAL, syncInterval)
         .withConfig(EnvironmentConfig.LOG_LEVEL, "debug")
+        .withConfig(EnvironmentConfig.WAIT_UNTIL_STATUS_IS_REPORTED, false)
         .withBean(Bean.DAO_CLIENT, daoClient)
         .withAnalytics(new MockedContentAnalytics())
         .withAccessChecker(new MockedAccessChecker())


### PR DESCRIPTION
Before this change, it happened that the synchronization started before `nginx` did, so when the content server queried all servers on the DAO, it found itself to be unreachable.

Now, by default, we will wait until the status can be checked, or we tried a max amount of times 