### PR TITLE
fix: use known peers to ensure data availability when updating network

### DIFF
--- a/version.bzl
+++ b/version.bzl
@@ -1,3 +1,3 @@
 # NOTE: If you change the format of this line, you must change the bash command
 # in /scripts/publish to extract the version string correctly.
-LH_VERSION = "0.1.34"
+LH_VERSION = "0.1.35"


### PR DESCRIPTION
Making sure to use known peer data when updating network and choosing candidates to disconnect from.
In the existing codebase, the chosen peer might not be properly initialized (with known peer data), thus resulting in a null reference and an exception afterwards when trying to sort them out.