### PR TITLE
Replace WebSockets with HTTP to connect to infura

### DIFF
--- a/commons/servers/DAOClient.ts
+++ b/commons/servers/DAOClient.ts
@@ -4,14 +4,12 @@ import { Catalyst } from "decentraland-katalyst-contracts/Catalyst";
 
 export class DAOClient {
   private contract: Catalyst;
-  private triggerDisconnect;
 
   constructor(networkName: string) {
     const handler = handlerForNetwork(networkName, "catalyst");
     if (handler) {
-      const { contract, disconnect } = handler;
+      const { contract } = handler;
       this.contract = contract;
-      this.triggerDisconnect = disconnect;
     } else {
       throw new Error(`Can not find a network handler for Network="${networkName}`);
     }
@@ -50,7 +48,4 @@ export class DAOClient {
     return result;
   }
 
-  disconnect() {
-    this.triggerDisconnect();
-  }
 }

--- a/content/src/service/synchronization/ContentCluster.ts
+++ b/content/src/service/synchronization/ContentCluster.ts
@@ -64,7 +64,6 @@ export class ContentCluster implements IdentityProvider {
     /** Stop syncing with DAO */
     disconnect() {
         clearTimeout(this.syncTimeout)
-        this.dao.disconnect()
     }
 
     getStatus() {

--- a/contracts/utils.ts
+++ b/contracts/utils.ts
@@ -1,6 +1,6 @@
 import { Address } from "web3x/address";
 import { Eth } from "web3x/eth";
-import { WebsocketProvider, HttpProvider } from "web3x/providers";
+import { HttpProvider } from "web3x/providers";
 import { Catalyst } from "./Catalyst";
 
 export const networks = {
@@ -29,7 +29,8 @@ export const networks = {
 export function handlerForNetwork(networkKey: string, contractKey: string) {
   try {
     const network = networks[networkKey];
-    const provider = new WebsocketProvider(network.wss);
+    const url = network.http;
+    const provider = new HttpProvider(url);
     const eth = new Eth(provider);
     const contract = network.contracts[contractKey];
     const address = Address.fromString(contract.address);
@@ -39,9 +40,6 @@ export function handlerForNetwork(networkKey: string, contractKey: string) {
       provider,
       network,
       contract: contractInstance,
-      disconnect: () => {
-        provider.disconnect();
-      }
     };
   } catch (error) {
     return undefined;

--- a/contracts/utils.ts
+++ b/contracts/utils.ts
@@ -28,10 +28,9 @@ export const networks = {
 
 export function handlerForNetwork(networkKey: string, contractKey: string) {
   try {
-    const network = networks[networkKey];
-    const url = network.http;
-    const provider = new HttpProvider(url);
+    const provider = httpProviderForNetwork(networkKey)
     const eth = new Eth(provider);
+    const network = networks[networkKey];
     const contract = network.contracts[contractKey];
     const address = Address.fromString(contract.address);
     const contractInstance = new contract.class(eth, address);


### PR DESCRIPTION
Stop using WebSockets to connect to infura, and use HTTP instead.

I manually verified that when the connections goes down, and then goes up again, the server can still sync correctly