### PR TITLE
Chore/use multi server onboarding by default

### DIFF
--- a/content/src/Environment.ts
+++ b/content/src/Environment.ts
@@ -187,7 +187,7 @@ export class EnvironmentBuilder {
         this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.JSON_REQUEST_TIMEOUT           , () => process.env.JSON_REQUEST_TIMEOUT ?? ms('1m'))
         this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.FILE_DOWNLOAD_REQUEST_TIMEOUT  , () => process.env.FILE_DOWNLOAD_REQUEST_TIMEOUT ?? ms('5m'))
         this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.USE_COMPRESSION_MIDDLEWARE     , () => process.env.USE_COMPRESSION_MIDDLEWARE === "true");
-        this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.PERFORM_MULTI_SERVER_ONBOARDING, () => process.env.PERFORM_MULTI_SERVER_ONBOARDING === "true");
+        this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.PERFORM_MULTI_SERVER_ONBOARDING, () => process.env.PERFORM_MULTI_SERVER_ONBOARDING !== "false");
         this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.CACHE_SIZES                    , () => new Map(Object.entries(process.env).filter(([name,]) => name.startsWith("CACHE"))));
         this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.REQUEST_TTL_BACKWARDS          , () => ms('20m'));
         this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.DCL_PARCEL_ACCESS_URL          , () => process.env.DCL_PARCEL_ACCESS_URL ?? (env.getConfig(EnvironmentConfig.ETH_NETWORK) === 'mainnet' ? DEFAULT_DCL_PARCEL_ACCESS_URL_MAINNET : DEFAULT_DCL_PARCEL_ACCESS_URL_ROPSTEN))

--- a/content/src/Environment.ts
+++ b/content/src/Environment.ts
@@ -1,4 +1,5 @@
 import ms from "ms"
+import log4js from "log4js"
 import { ContentStorageFactory } from "./storage/ContentStorageFactory";
 import { ServiceFactory } from "./service/ServiceFactory";
 import { ControllerFactory } from "./controller/ControllerFactory";
@@ -39,6 +40,7 @@ const DEFAULT_DCL_PARCEL_ACCESS_URL_MAINNET = 'https://api.thegraph.com/subgraph
 export const CURRENT_COMMIT_HASH = process.env.COMMIT_HASH ?? "Unknown"
 
 export class Environment {
+    private static readonly LOGGER = log4js.getLogger("Environment");
     private configs: Map<EnvironmentConfig, any> = new Map();
     private beans: Map<Bean,any> = new Map();
 
@@ -58,6 +60,13 @@ export class Environment {
     registerBean<T>(type: Bean, bean: T): Environment {
         this.beans.set(type, bean);
         return this
+    }
+
+    logConfigValues() {
+        Environment.LOGGER.info("These are the configuration values:")
+        for (const [config, value] of this.configs.entries()) {
+            Environment.LOGGER.info(`${EnvironmentConfig[config]}: ${JSON.stringify(value)}`)
+        }
     }
 
     private static instance: Environment;
@@ -93,7 +102,7 @@ export const enum Bean {
     CHALLENGE_SUPERVISOR,
 }
 
-export const enum EnvironmentConfig {
+export enum EnvironmentConfig {
     STORAGE_ROOT_FOLDER,
     SERVER_PORT,
     METRICS,

--- a/content/src/Server.ts
+++ b/content/src/Server.ts
@@ -26,6 +26,8 @@ export class Server {
       categories: { default: { appenders: ["console"], level: env.getConfig<string>(EnvironmentConfig.LOG_LEVEL) } }
     });
 
+    env.logConfigValues()
+
     this.port = env.getConfig(EnvironmentConfig.SERVER_PORT);
 
     this.app = express();

--- a/content/test/integration/E2ETestUtils.ts
+++ b/content/test/integration/E2ETestUtils.ts
@@ -104,6 +104,7 @@ export function buildBaseEnv(namePrefix: string, port: number, syncInterval: num
         .withConfig(EnvironmentConfig.UPDATE_FROM_DAO_INTERVAL, syncInterval)
         .withConfig(EnvironmentConfig.LOG_LEVEL, "debug")
         .withConfig(EnvironmentConfig.ALLOW_DEPLOYMENTS_FOR_TESTING, true)
+        .withConfig(EnvironmentConfig.PERFORM_MULTI_SERVER_ONBOARDING, false)
         .withBean(Bean.DAO_CLIENT, daoClient)
         .withAnalytics(new MockedContentAnalytics())
         .withAccessChecker(new MockedAccessChecker())


### PR DESCRIPTION
We are doing two small changes on this PR:
1. By default, we will use multi server onboarding
2. We are now logging all the configuration when the server starts