### PR TITLE
feat: adding deployments endpoint

### DIFF
--- a/content/src/Server.ts
+++ b/content/src/Server.ts
@@ -133,7 +133,7 @@ export class Server {
 
   private async validateHistory() {
     // Validate last history entry is before Date.now()
-    const lastDeployments = await this.service.getDeployments(undefined, 0, 1)
+    const lastDeployments = await this.service.getDeployments({ }, 0, 1)
     if (lastDeployments.deployments.length > 0) {
         const currentTimestamp = Date.now()
         if (lastDeployments.deployments[0].auditInfo.localTimestamp > currentTimestamp) {

--- a/content/src/Server.ts
+++ b/content/src/Server.ts
@@ -61,6 +61,7 @@ export class Server {
     this.registerRoute("/available-content", controller, controller.getAvailableContent);
     this.registerRoute("/audit/:type/:entityId", controller, controller.getAudit);
     this.registerRoute("/history", controller, controller.getHistory);
+    this.registerRoute("/deployments", controller, controller.getDeployments);
     this.registerRoute("/status", controller, controller.getStatus);
     this.registerRoute("/denylist", controller, controller.getAllDenylistTargets);
     this.registerRoute("/denylist/:type/:id", controller, controller.addToDenylist, HttpMethod.PUT);
@@ -132,10 +133,10 @@ export class Server {
 
   private async validateHistory() {
     // Validate last history entry is before Date.now()
-    const lastEvents = await this.service.getDeployments(undefined, undefined, 0, 1)
-    if (lastEvents.events.length > 0) {
+    const lastDeployments = await this.service.getDeployments(undefined, 0, 1)
+    if (lastDeployments.deployments.length > 0) {
         const currentTimestamp = Date.now()
-        if (lastEvents.events[0].localTimestamp > currentTimestamp) {
+        if (lastDeployments.deployments[0].auditInfo.localTimestamp > currentTimestamp) {
             console.error("Last stored timestamp for this server is newer than current time. The server can not be started.")
             process.exit(1)
         }

--- a/content/src/controller/ControllerDeploymentFactory.ts
+++ b/content/src/controller/ControllerDeploymentFactory.ts
@@ -1,0 +1,11 @@
+import { ControllerDeployment } from "./Controller"
+import { Deployment } from "../service/deployments/DeploymentManager"
+
+export class ControllerDeploymentFactory {
+    static maskEntity(deployment: Deployment): ControllerDeployment {
+        return {
+            ...deployment,
+            content: deployment.content ? Array.from(deployment.content.entries()).map(([ key, hash ]) => ({ key, hash })) : []
+        }
+    }
+}

--- a/content/src/denylist/DenylistServiceDecorator.ts
+++ b/content/src/denylist/DenylistServiceDecorator.ts
@@ -240,12 +240,12 @@ export class DenylistServiceDecorator implements MetaverseContentService {
     const entityToTarget: Map<Entity, DenylistTarget> = new Map(entities.map(entity => [entity, buildEntityTarget(entity.type, entity.id)]));
 
     // Check if targets are denylisted
-    const queryResult = await this.denylist.areTargetsDenylisted(denylistRepo, Array.from(entityToTarget.values()));
+    const denylistQueryResult = await this.denylist.areTargetsDenylisted(denylistRepo, Array.from(entityToTarget.values()));
 
     // Sanitize denylisted entities
     return entities.map(entity => {
       const target = entityToTarget.get(entity)!!
-      const isDenylisted = isTargetDenylisted(target, queryResult)
+      const isDenylisted = isTargetDenylisted(target, denylistQueryResult)
       if (isDenylisted) {
         return new Entity(entity.id, entity.type, entity.pointers, entity.timestamp, undefined, DenylistServiceDecorator.DENYLISTED_METADATA);
       } else {

--- a/content/src/service/Service.ts
+++ b/content/src/service/Service.ts
@@ -8,7 +8,7 @@ import { FailureReason, FailedDeployment } from "./errors/FailedDeploymentsManag
 import { ServerAddress } from "./synchronization/clients/contentserver/ContentServerClient";
 import { PartialDeploymentLegacyHistory } from "./history/HistoryManager";
 import { RepositoryTask, Repository } from "../storage/Repository";
-import { PartialDeploymentHistory } from "./deployments/DeploymentManager";
+import { PartialDeploymentHistory, DeploymentFilters } from "./deployments/DeploymentManager";
 
 export const ENTITY_FILE_NAME = 'entity.json';
 
@@ -27,7 +27,7 @@ export interface MetaverseContentService {
     getContent(fileHash: ContentFileHash): Promise<ContentItem | undefined>;
     getStatus(): ServerStatus;
     getLegacyHistory(from?: Timestamp, to?: Timestamp, serverName?: ServerName, offset?: number, limit?: number): Promise<PartialDeploymentLegacyHistory>;
-    getDeployments(from?: Timestamp, to?: Timestamp, offset?: number, limit?: number): Promise<PartialDeploymentHistory>;
+    getDeployments(filters?: DeploymentFilters, offset?: number, limit?: number, repository?: RepositoryTask | Repository): Promise<PartialDeploymentHistory>;
     getAllFailedDeployments(): Promise<FailedDeployment[]>;
 }
 

--- a/content/src/service/deployments/client/DeploymentsClient.ts
+++ b/content/src/service/deployments/client/DeploymentsClient.ts
@@ -1,0 +1,38 @@
+import { ServerAddress } from "../../synchronization/clients/contentserver/ContentServerClient"
+import { FetchHelper } from "@katalyst/content/helpers/FetchHelper"
+import { retry } from "@katalyst/content/helpers/RetryHelper";
+import { DeploymentFilters, PartialDeploymentHistory, Deployment } from "../DeploymentManager"
+
+export class DeploymentsClient {
+
+    static async consumeAllDeployments(
+        fetchHelper: FetchHelper,
+        address: ServerAddress,
+        filters?: DeploymentFilters,
+        limit?: number,
+        partialCallback?: (url: string, res: PartialDeploymentHistory) => void)
+        : Promise<Deployment[]> {
+        let deployments: Deployment[] = []
+        let offset = 0
+        let keepRetrievingHistory = true
+        while(keepRetrievingHistory) {
+            let url = `${address}/deployments?offset=${offset}`
+            if (filters) {
+                for (const [filterName, filterValue] of Object.entries(filters)) {
+                    url += `&${filterName}=${filterValue}`
+                }
+            }
+            if (limit) {
+                url += `&limit=${limit}`
+            }
+            const partialHistory: PartialDeploymentHistory = await retry(() => fetchHelper.fetchJson(url), 3, `fetch deployments from ${address}`)
+            if (partialCallback) {
+                partialCallback(url, partialHistory)
+            }
+            deployments.push(...partialHistory.deployments)
+            offset = partialHistory.pagination.offset + partialHistory.pagination.limit
+            keepRetrievingHistory = partialHistory.pagination.moreData
+        }
+        return deployments
+    }
+}

--- a/content/src/service/history/HistoryManagerImpl.ts
+++ b/content/src/service/history/HistoryManagerImpl.ts
@@ -4,7 +4,6 @@ import { ServerName } from "../naming/NameKeeper"
 import { ContentCluster } from "../synchronization/ContentCluster"
 import { ServerAddress } from "../synchronization/clients/contentserver/ContentServerClient"
 import { DeploymentsRepository } from "@katalyst/content/storage/repositories/DeploymentsRepository"
-import { DeploymentEvent } from "../deployments/DeploymentManager"
 
 export class HistoryManagerImpl implements HistoryManager {
 
@@ -46,7 +45,7 @@ export class HistoryManagerImpl implements HistoryManager {
         const curatedOffset = (offset && offset>=0) ? offset : 0
         const curatedLimit = (limit && limit>0 && limit<=HistoryManagerImpl.MAX_HISTORY_LIMIT) ? limit : HistoryManagerImpl.DEFAULT_HISTORY_LIMIT
 
-        const deployments: DeploymentEvent[] = await deploymentsRepository.getHistoricalDeploymentsByOriginTimestamp(curatedOffset, curatedLimit + 1, from, to, address)
+        const deployments = await deploymentsRepository.getHistoricalDeploymentsByOriginTimestamp(curatedOffset, curatedLimit + 1, from, to, address)
         const moreData = deployments.length > curatedLimit
         const finalDeployments: LegacyDeploymentEvent[] = deployments.slice(0, curatedLimit)
             .map(deployment => ({

--- a/content/src/storage/repositories/MigrationDataRepository.ts
+++ b/content/src/storage/repositories/MigrationDataRepository.ts
@@ -9,7 +9,11 @@ export class MigrationDataRepository {
         return this.db.none('INSERT INTO migration_data (deployment, original_metadata) VALUES ($1, $2)', [deploymentId, originalMetadata])
     }
 
-    getMigrationData(deploymentId: DeploymentId): Promise<any | undefined> {
-        return this.db.oneOrNone('SELECT original_metadata FROM migration_data WHERE deployment = $1', [deploymentId], metadata => metadata ?? undefined)
+    async getMigrationData(deploymentIds: DeploymentId[]): Promise<Map<DeploymentId, any>> {
+        if (deploymentIds.length === 0) {
+            return new Map()
+        }
+        const queryResult = await this.db.any('SELECT deployment, original_metadata FROM migration_data WHERE deployment IN ($1:list)', [deploymentIds])
+        return new Map(queryResult.map(row => [ row.deployment, row.original_metadata ]))
     }
 }

--- a/content/test/helpers/service/MockedMetaverseContentService.ts
+++ b/content/test/helpers/service/MockedMetaverseContentService.ts
@@ -10,7 +10,7 @@ import { AuthLinkType } from "dcl-crypto"
 import { ContentItem, SimpleContentItem } from "@katalyst/content/storage/ContentStorage"
 import { RepositoryTask, Repository } from "@katalyst/content/storage/Repository"
 import { PartialDeploymentLegacyHistory } from "@katalyst/content/service/history/HistoryManager"
-import { PartialDeploymentHistory } from "@katalyst/content/service/deployments/DeploymentManager"
+import { PartialDeploymentHistory, DeploymentFilters, Deployment } from "@katalyst/content/service/deployments/DeploymentManager"
 import { FailedDeployment } from "@katalyst/content/service/errors/FailedDeploymentsManager"
 
 export class MockedMetaverseContentService implements MetaverseContentService {
@@ -39,9 +39,9 @@ export class MockedMetaverseContentService implements MetaverseContentService {
         this.content = builder.content
     }
 
-    getDeployments(from?: number, to?: number, offset?: number, limit?: number): Promise<PartialDeploymentHistory> {
+    getDeployments(filters: DeploymentFilters, offset?: number, limit?: number): Promise<PartialDeploymentHistory> {
         return Promise.resolve({
-            events: [],
+            deployments: this.entities.map(entity => this.entityToDeployment(entity)),
             filters: { },
             pagination: {
                 offset: 0,
@@ -103,6 +103,17 @@ export class MockedMetaverseContentService implements MetaverseContentService {
 
     getAllFailedDeployments(): Promise<FailedDeployment[]> {
         throw new Error("Method not implemented.")
+    }
+
+    private entityToDeployment(entity: Entity): Deployment {
+        return {
+            ...entity,
+            entityType: entity.type,
+            entityId: entity.id,
+            entityTimestamp: entity.timestamp,
+            deployedBy: '',
+            auditInfo: MockedMetaverseContentService.AUDIT_INFO,
+        }
     }
 
     private isThereAnEntityWithId(entityId: EntityId): boolean {

--- a/content/test/helpers/service/synchronization/MockedContentCluster.ts
+++ b/content/test/helpers/service/synchronization/MockedContentCluster.ts
@@ -19,4 +19,10 @@ export class MockedContentCluster {
         return instance(mockedCluster)
     }
 
+    static withName(name: string): ContentCluster {
+        let mockedCluster: ContentCluster = mock(ContentCluster)
+        when(mockedCluster.getIdentityInDAO()).thenReturn({ owner: '', address: "", id: "", name })
+        return instance(mockedCluster)
+    }
+
 }

--- a/content/test/integration/TestServer.ts
+++ b/content/test/integration/TestServer.ts
@@ -4,7 +4,7 @@ import { Server } from "@katalyst/content/Server"
 import { Environment, EnvironmentConfig, Bean } from "@katalyst/content/Environment"
 import { ServerAddress, ContentServerClient } from "@katalyst/content/service/synchronization/clients/contentserver/ContentServerClient"
 import { EntityType, Pointer, EntityId } from "@katalyst/content/service/Entity"
-import { ControllerEntity, ControllerDenylistData } from "@katalyst/content/controller/Controller"
+import { ControllerEntity, ControllerDenylistData, ControllerDeployment } from "@katalyst/content/controller/Controller"
 import { PartialDeploymentLegacyHistory } from "@katalyst/content/service/history/HistoryManager"
 import { ContentFileHash } from "@katalyst/content/service/Hashing"
 import { DeployData, hashAndSignMessage, Identity, parseEntityType, deleteFolderRecursive } from "./E2ETestUtils"
@@ -84,6 +84,10 @@ export class TestServer extends Server {
 
     getHistory(): Promise<PartialDeploymentLegacyHistory> {
         return this.makeRequest(`${this.getAddress()}/history`)
+    }
+
+    getDeployments(): Promise<{ deployments: ControllerDeployment[] }> {
+        return this.makeRequest(`${this.getAddress()}/deployments`)
     }
 
     getStatus(): Promise<ServerStatus> {

--- a/content/test/integration/service/deployments/client/DeploymentsClient.spec.ts
+++ b/content/test/integration/service/deployments/client/DeploymentsClient.spec.ts
@@ -21,7 +21,7 @@ describe("Integration - Deployments Client", function() {
         await server.start()
     })
 
-    it(`When history is consumed entirely, all the events are retrieved`, async () => {
+    it(`When deployments are consumed entirely, all the events are retrieved`, async () => {
         // Add some deployments
         for(let i=0; i<10; i=i+1) {
             const [deployData, ] = await buildDeployData(["X1,Y1"], "metadata")

--- a/content/test/integration/service/deployments/client/DeploymentsClient.spec.ts
+++ b/content/test/integration/service/deployments/client/DeploymentsClient.spec.ts
@@ -1,0 +1,75 @@
+import { TestServer } from "../../../TestServer"
+import { Bean } from "@katalyst/content/Environment"
+import { MockedSynchronizationManager } from "@katalyst/test-helpers/service/synchronization/MockedSynchronizationManager"
+import { buildDeployData } from "../../../E2ETestUtils"
+import { FetchHelper } from "@katalyst/content/helpers/FetchHelper"
+import { loadTestEnvironment } from "../../../E2ETestEnvironment"
+import { PartialDeploymentHistory } from "@katalyst/content/service/deployments/DeploymentManager"
+import { DeploymentsClient } from "@katalyst/content/service/deployments/client/DeploymentsClient"
+import { ControllerDeployment } from "@katalyst/content/controller/Controller"
+import { ControllerDeploymentFactory } from "@katalyst/content/controller/ControllerDeploymentFactory"
+
+describe("Integration - Deployments Client", function() {
+
+    const testEnv = loadTestEnvironment()
+    let server: TestServer
+
+    beforeEach(async () => {
+        server = await testEnv.configServer()
+            .withBean(Bean.SYNCHRONIZATION_MANAGER, new MockedSynchronizationManager())
+            .andBuild()
+        await server.start()
+    })
+
+    it(`When history is consumed entirely, all the events are retrieved`, async () => {
+        // Add some deployments
+        for(let i=0; i<10; i=i+1) {
+            const [deployData, ] = await buildDeployData(["X1,Y1"], "metadata")
+            await server.deploy(deployData)
+        }
+
+        const { deployments } = await server.getDeployments()
+
+        expect(deployments.length).toBe(10)
+
+        await validateHistoryThroughClient(server, deployments)
+        await validateHistoryThroughClient(server, deployments, 3)
+        await validateHistoryThroughClient(server, deployments, 5)
+        await validateHistoryThroughClient(server, deployments, 7)
+    })
+
+    async function validateHistoryThroughClient(server: TestServer, expectedDeployments: ControllerDeployment[], batchSize?: number): Promise<void> {
+        const executions: {url:string, res: PartialDeploymentHistory}[] = []
+
+        const deployments = await DeploymentsClient.consumeAllDeployments(new FetchHelper(), server.getAddress(), undefined, batchSize,
+        (url:string, res: PartialDeploymentHistory) => {
+            executions.push({
+                url: url,
+                res: res
+            })
+        })
+
+        expect(deployments.map(deployment => ControllerDeploymentFactory.maskEntity(deployment))).toEqual(expectedDeployments)
+
+        if (batchSize) {
+            expect(executions.length).toBe(Math.ceil(expectedDeployments.length / batchSize))
+            for(let i=0; i<executions.length-1; i++) {
+                expect(executions[i].res.deployments.length).toBe(batchSize)
+                expect(executions[i].res.pagination.offset).toBe(i*batchSize)
+                expect(executions[i].res.pagination.limit).toBe(batchSize)
+                expect(executions[i].res.pagination.moreData).toBe(true)
+            }
+            expect(executions[executions.length-1].res.deployments.length).toBeLessThanOrEqual(batchSize)
+            expect(executions[executions.length-1].res.pagination.offset).toBe((executions.length-1)*batchSize)
+            expect(executions[executions.length-1].res.pagination.limit).toBe(batchSize)
+            expect(executions[executions.length-1].res.pagination.moreData).toBe(false)
+        } else {
+            expect(executions.length).toBe(1)
+            expect(executions[0].res.deployments.length).toBeLessThanOrEqual(expectedDeployments.length)
+            expect(executions[0].res.pagination.offset).toBe(0)
+            expect(executions[0].res.pagination.limit).toBe(500)
+            expect(executions[0].res.pagination.moreData).toBe(false)
+        }
+
+    }
+})

--- a/content/test/integration/syncronization/cluster-synchronization.spec.ts
+++ b/content/test/integration/syncronization/cluster-synchronization.spec.ts
@@ -2,7 +2,7 @@ import ms from "ms"
 import { Timestamp } from "@katalyst/content/service/time/TimeSorting"
 import { TestServer } from "../TestServer"
 import { buildDeployData, buildDeployDataAfterEntity, awaitUntil } from "../E2ETestUtils"
-import { assertEntitiesAreActiveOnServer, assertEntitiesAreDeployedButNotActive, assertHistoryOnServerHasEvents, assertEntityIsOverwrittenBy, assertEntityIsNotOverwritten, buildEvent } from "../E2EAssertions"
+import { assertEntitiesAreActiveOnServer, assertEntitiesAreDeployedButNotActive, assertHistoryOnServerHasEvents, assertEntityIsOverwrittenBy, assertEntityIsNotOverwritten, buildEvent, buildDeployment, assertDeploymentsAreReported } from "../E2EAssertions"
 import { delay } from "decentraland-katalyst-utils/util"
 import { loadTestEnvironment } from "../E2ETestEnvironment"
 
@@ -26,20 +26,25 @@ describe("End 2 end synchronization tests", function() {
 
         // Make sure there are no deployments on server 1
         await assertHistoryOnServerHasEvents(server1, )
+        await assertDeploymentsAreReported(server1, )
 
         // Make sure there are no deployments on server 2
         await assertHistoryOnServerHasEvents(server2, )
+        await assertDeploymentsAreReported(server2, )
 
         // Deploy the entity to server 1
         const deploymentTimestamp: Timestamp = await server1.deploy(deployData)
         const deploymentEvent = buildEvent(entityBeingDeployed, server1, deploymentTimestamp)
+        const deployment = buildDeployment(deployData, entityBeingDeployed, server1, deploymentTimestamp)
 
         // Assert that the entity was deployed on server 1
         await assertHistoryOnServerHasEvents(server1, deploymentEvent)
+        await assertDeploymentsAreReported(server1, deployment)
 
         // Assert that the entity was synced from server 1 to server 2
         await awaitUntil(() => assertEntitiesAreActiveOnServer(server2, entityBeingDeployed))
         await assertHistoryOnServerHasEvents(server2, deploymentEvent)
+        await assertDeploymentsAreReported(server2, deployment)
     })
 
     it(`Even when there are no deployments, immutable time advances across all servers`, async () => {
@@ -126,17 +131,22 @@ describe("End 2 end synchronization tests", function() {
         // Deploy entity 1 on server 1
         const deploymentTimestamp1 = await server1.deploy(deployData1)
         const deploymentEvent1 = buildEvent(entityBeingDeployed1, server1, deploymentTimestamp1)
+        const deployment1 = buildDeployment(deployData1, entityBeingDeployed1, server1, deploymentTimestamp1)
 
         // Wait for servers to sync
         await awaitUntil(() => assertHistoryOnServerHasEvents(server2, deploymentEvent1))
+        await awaitUntil(() => assertDeploymentsAreReported(server2, deployment1))
 
         // Deploy entity 2 on server 2
         const deploymentTimestamp2 = await server2.deploy(deployData2)
         const deploymentEvent2 = buildEvent(entityBeingDeployed2, server2, deploymentTimestamp2)
+        const deployment2 = buildDeployment(deployData2, entityBeingDeployed2, server2, deploymentTimestamp2)
 
         // Assert that the entities were deployed on the servers
         await awaitUntil(() => assertHistoryOnServerHasEvents(server1, deploymentEvent1, deploymentEvent2))
         await assertHistoryOnServerHasEvents(server2, deploymentEvent1, deploymentEvent2)
+        await awaitUntil(() => assertDeploymentsAreReported(server1, deployment1, deployment2))
+        await assertDeploymentsAreReported(server2, deployment1, deployment2)
     })
 
      /**
@@ -163,9 +173,11 @@ describe("End 2 end synchronization tests", function() {
         // Deploy the entities 1 and 2
         const deploymentTimestamp1: Timestamp = await server1.deploy(deployData1)
         const deploymentEvent1 = buildEvent(entity1, server1, deploymentTimestamp1)
+        const deployment1 = buildDeployment(deployData1, entity1, server1, deploymentTimestamp1)
 
         const deploymentTimestamp2: Timestamp = await server2.deploy(deployData2)
         const deploymentEvent2 = buildEvent(entity2, server2, deploymentTimestamp2)
+        const deployment2 = buildDeployment(deployData2, entity2, server2, deploymentTimestamp2)
 
         // Stop server 2
         await server2.stop({ deleteStorage: false })
@@ -173,10 +185,13 @@ describe("End 2 end synchronization tests", function() {
         // Deploy entity 3
         const deploymentTimestamp3: Timestamp = await server3.deploy(deployData3)
         const deploymentEvent3 = buildEvent(entity3, server3, deploymentTimestamp3)
+        const deployment3 = buildDeployment(deployData3, entity3, server3, deploymentTimestamp3)
 
         // Wait for servers to sync
         await awaitUntil(() => assertHistoryOnServerHasEvents(server1, deploymentEvent1, deploymentEvent3))
         await awaitUntil(() => assertHistoryOnServerHasEvents(server3, deploymentEvent1, deploymentEvent3))
+        await awaitUntil(() => assertDeploymentsAreReported(server1, deployment1, deployment3))
+        await awaitUntil(() => assertDeploymentsAreReported(server3, deployment1, deployment3))
 
         // Make sure that both server 1 and 3 have entity 1 and 3 currently active
         await assertEntitiesAreActiveOnServer(server1, entity1, entity3)
@@ -189,6 +204,9 @@ describe("End 2 end synchronization tests", function() {
         await awaitUntil(() => assertHistoryOnServerHasEvents(server1, deploymentEvent1, deploymentEvent2, deploymentEvent3))
         await awaitUntil(() => assertHistoryOnServerHasEvents(server2, deploymentEvent1, deploymentEvent2, deploymentEvent3))
         await awaitUntil(() => assertHistoryOnServerHasEvents(server3, deploymentEvent1, deploymentEvent2, deploymentEvent3))
+        await awaitUntil(() => assertDeploymentsAreReported(server1, deployment1, deployment2, deployment3))
+        await awaitUntil(() => assertDeploymentsAreReported(server2, deployment1, deployment2, deployment3))
+        await awaitUntil(() => assertDeploymentsAreReported(server3, deployment1, deployment2, deployment3))
 
         // Make assertions on Server 1
         await assertEntitiesAreActiveOnServer(server1, entity3)

--- a/content/test/integration/syncronization/error-handling.spec.ts
+++ b/content/test/integration/syncronization/error-handling.spec.ts
@@ -1,5 +1,5 @@
 import ms from "ms"
-import { buildEvent, assertEntityWasNotDeployed, assertEntitiesAreActiveOnServer, assertHistoryOnServerHasEvents, assertEntitiesAreDeployedButNotActive, assertDeploymentFailed, assertThereIsAFailedDeployment } from "../E2EAssertions"
+import { buildEvent, assertEntityWasNotDeployed, assertEntitiesAreActiveOnServer, assertHistoryOnServerHasEvents, assertEntitiesAreDeployedButNotActive, assertDeploymentFailed, assertThereIsAFailedDeployment, assertDeploymentsAreReported, buildDeployment } from "../E2EAssertions"
 import { EnvironmentConfig, Bean } from "@katalyst/content/Environment"
 import { Timestamp } from "@katalyst/content/service/time/TimeSorting"
 import { ControllerEntity } from "@katalyst/content/controller/Controller"
@@ -114,6 +114,7 @@ describe("End 2 end - Error handling", () => {
         // Deploy the entity
         const deploymentTimestamp: Timestamp = await server1.deploy(deployData)
         const deploymentEvent = buildEvent(entityBeingDeployed, server1, deploymentTimestamp)
+        const deployment = buildDeployment(deployData, entityBeingDeployed, server1, deploymentTimestamp)
 
         // Cause failure
         await causeOfFailure(entityBeingDeployed)
@@ -126,6 +127,7 @@ describe("End 2 end - Error handling", () => {
 
         // Assert history was not modified
         await assertHistoryOnServerHasEvents(server2, )
+        await assertDeploymentsAreReported(server2, )
 
         // Assert immutable time is more recent than the entity
         const immutableTime = await server2.getStatus().then(status => status.lastImmutableTime)
@@ -147,6 +149,7 @@ describe("End 2 end - Error handling", () => {
 
         // Assert history was modified
         await assertHistoryOnServerHasEvents(server2, deploymentEvent)
+        await assertDeploymentsAreReported(server2, deployment)
     }
 
 })

--- a/content/test/integration/syncronization/node-onboarding.spec.ts
+++ b/content/test/integration/syncronization/node-onboarding.spec.ts
@@ -84,7 +84,7 @@ describe("End 2 end - Node onboarding", function() {
         // Start server 3
         await server3.start()
 
-        // Assert server 3 has all the history, but since the server is not available anymore, them name and origin server url are unknown
+        // Assert server 3 has all the history, but since the server is not available anymore, the name and origin server url are unknown
         const deploymentEventWithoutName = buildEventWithName(entity, HistoryManagerImpl.UNKNOWN_NAME, deploymentTimestamp)
         deployment.auditInfo.originServerUrl = 'https://peer.decentraland.org/content'
         await awaitUntil(() => assertHistoryOnServerHasEvents(server3, deploymentEventWithoutName))

--- a/content/test/integration/syncronization/node-onboarding.spec.ts
+++ b/content/test/integration/syncronization/node-onboarding.spec.ts
@@ -3,7 +3,7 @@ import { ControllerEntityContent } from "@katalyst/content/controller/Controller
 import { ContentFileHash } from "@katalyst/content/service/Hashing"
 import { TestServer } from "../TestServer"
 import { buildDeployData, buildDeployDataAfterEntity, awaitUntil } from "../E2ETestUtils"
-import { assertHistoryOnServerHasEvents, buildEvent, assertFileIsOnServer, assertFileIsNotOnServer, assertEntityIsOverwrittenBy, buildEventWithName } from "../E2EAssertions"
+import { assertHistoryOnServerHasEvents, buildEvent, assertFileIsOnServer, assertFileIsNotOnServer, assertEntityIsOverwrittenBy, buildEventWithName, assertDeploymentsAreReported, buildDeployment } from "../E2EAssertions"
 import { loadTestEnvironment } from "../E2ETestEnvironment"
 import { HistoryManagerImpl } from "@katalyst/content/service/history/HistoryManagerImpl"
 
@@ -30,14 +30,18 @@ describe("End 2 end - Node onboarding", function() {
         // Deploy entity1 on server 1
         const deploymentTimestamp1: Timestamp = await server1.deploy(deployData1)
         const deploymentEvent1 = buildEvent(entity1, server1, deploymentTimestamp1)
+        const deployment1 = buildDeployment(deployData1, entity1, server1, deploymentTimestamp1)
 
         // Deploy entity2 on server 2
         const deploymentTimestamp2: Timestamp = await server2.deploy(deployData2)
         const deploymentEvent2 = buildEvent(entity2, server2, deploymentTimestamp2)
+        const deployment2 = buildDeployment(deployData2, entity2, server2, deploymentTimestamp2)
 
         // Wait for servers to sync and assert servers 1 and 2 are synced
         await awaitUntil(() => assertHistoryOnServerHasEvents(server1, deploymentEvent1, deploymentEvent2))
         await awaitUntil(() => assertHistoryOnServerHasEvents(server2, deploymentEvent1, deploymentEvent2))
+        await awaitUntil(() => assertDeploymentsAreReported(server1, deployment1, deployment2))
+        await awaitUntil(() => assertDeploymentsAreReported(server2, deployment1, deployment2))
         await assertFileIsOnServer(server1, entity1ContentHash)
         await assertEntityIsOverwrittenBy(server1, entity1, entity2)
         await assertEntityIsOverwrittenBy(server2, entity1, entity2)
@@ -47,6 +51,7 @@ describe("End 2 end - Node onboarding", function() {
 
         // Assert server 3 has all the history
         await awaitUntil(() => assertHistoryOnServerHasEvents(server3, deploymentEvent1, deploymentEvent2))
+        await awaitUntil(() => assertDeploymentsAreReported(server3, deployment1, deployment2))
 
         // Make sure that is didn't download overwritten content
         await assertFileIsNotOnServer(server3, entity1ContentHash)
@@ -63,10 +68,13 @@ describe("End 2 end - Node onboarding", function() {
         // Deploy entity on server 1
         const deploymentTimestamp: Timestamp = await server1.deploy(deployData)
         const deploymentEvent = buildEvent(entity, server1, deploymentTimestamp)
+        const deployment = buildDeployment(deployData, entity, server1, deploymentTimestamp)
 
         // Wait for sync and assert servers 1 and 2 are synced
         await assertHistoryOnServerHasEvents(server1, deploymentEvent)
         await awaitUntil(() => assertHistoryOnServerHasEvents(server2, deploymentEvent))
+        await assertDeploymentsAreReported(server1, deployment)
+        await awaitUntil(() => assertDeploymentsAreReported(server2, deployment))
         await assertFileIsOnServer(server1, entityContentHash)
         await assertFileIsOnServer(server2, entityContentHash)
 
@@ -76,9 +84,11 @@ describe("End 2 end - Node onboarding", function() {
         // Start server 3
         await server3.start()
 
-        // Assert server 3 has all the history, but since the server is not available anymore, them name is unknown
+        // Assert server 3 has all the history, but since the server is not available anymore, them name and origin server url are unknown
         const deploymentEventWithoutName = buildEventWithName(entity, HistoryManagerImpl.UNKNOWN_NAME, deploymentTimestamp)
+        deployment.auditInfo.originServerUrl = 'https://peer.decentraland.org/content'
         await awaitUntil(() => assertHistoryOnServerHasEvents(server3, deploymentEventWithoutName))
+        await awaitUntil(() => assertDeploymentsAreReported(server3, deployment))
 
         // Make sure that even the content is properly propagated
         await assertFileIsOnServer(server1, entityContentHash)

--- a/content/test/integration/syncronization/unreachable-node.spec.ts
+++ b/content/test/integration/syncronization/unreachable-node.spec.ts
@@ -3,7 +3,7 @@ import { Timestamp } from "@katalyst/content/service/time/TimeSorting"
 import { EnvironmentConfig } from "@katalyst/content/Environment"
 import { TestServer } from "../TestServer"
 import { buildDeployData, awaitUntil } from "../E2ETestUtils"
-import { assertHistoryOnServerHasEvents, buildEvent } from "../E2EAssertions"
+import { assertHistoryOnServerHasEvents, buildEvent, assertDeploymentsAreReported, buildDeployment } from "../E2EAssertions"
 import { loadTestEnvironment } from "../E2ETestEnvironment"
 
 /**
@@ -39,18 +39,22 @@ describe("End 2 end - Unreachable node", function() {
         // Deploy the entity on server 1
         const deploymentTimestamp: Timestamp = await server1.deploy(deployData)
         const deploymentEvent = buildEvent(entity, server1, deploymentTimestamp)
+        const deployment = buildDeployment(deployData, entity, server1, deploymentTimestamp)
 
         // Wait until server 2 got the update
         await awaitUntil(() => assertHistoryOnServerHasEvents(server2, deploymentEvent))
+        await awaitUntil(() => assertDeploymentsAreReported(server2, deployment))
 
         // Stop server 1
         await server1.stop()
 
         // Assert server 3 didn't get the update
         await assertHistoryOnServerHasEvents(server3, )
+        await assertDeploymentsAreReported(server3, )
 
         // Now, server 3 detected that server 1 is down, and asked for its updated to server 2
         await awaitUntil(() => assertHistoryOnServerHasEvents(server3, deploymentEvent), 10, '3s')
+        await awaitUntil(() => assertDeploymentsAreReported(server3, deployment), 10, '3s')
     })
 
 })


### PR DESCRIPTION
We are adding a `/deployments` endpoint that exposes all deployments. Right now, they can only be filtered by: `fromLocalTimestamp` & `toLocalTimestamp`. Results are paginated similarly to the `/history` endpoint.

In the near future, we will add more filters to the endpoint and try to replace the `/entities` and `/audit` endpoints