### PR TITLE
feat: add filters to deployments endpoint

### DIFF
--- a/content/src/controller/Controller.ts
+++ b/content/src/controller/Controller.ts
@@ -231,16 +231,16 @@ export class Controller {
         // Path: /deployments
         // Query String: ?fromLocalTimestamp={timestamp}&toLocalTimestamp={timestamp}&entityType={entityType}&entityId={entityId}&onlyCurrentlyPointed={boolean}&deployedBy={ethAddress}
 
-        const entityTypes:(EntityType|undefined)[] = this.asArray<string>(req.query.entityType).map(type => this.parseEntityType(type))
-        const entityIds:EntityId[]                 = this.asArray<EntityId>(req.query.entityId)
-        const fromLocalTimestamp                   = this.asInt(req.query.fromLocalTimestamp)
-        const toLocalTimestamp                     = this.asInt(req.query.toLocalTimestamp)
-        const onlyCurrentlyPointed                 = this.asBoolean(req.query.onlyCurrentlyPointed)
-        const showAudit                            = this.asBoolean(req.query.showAudit) ?? false
-        const deployedBy                           = this.asArray<EthAddress>(req.query.deployedBy)
-        const pointers                             = this.asArray<Pointer>(req.query.pointer)
-        const offset                               = this.asInt(req.query.offset)
-        const limit                                = this.asInt(req.query.limit)
+        const entityTypes:(EntityType|undefined)[] | undefined = this.asArray<string>(req.query.entityType).map(type => this.parseEntityType(type))
+        const entityIds:EntityId[] | undefined       = this.asArray<EntityId>(req.query.entityId)
+        const fromLocalTimestamp: number | undefined = this.asInt(req.query.fromLocalTimestamp)
+        const toLocalTimestamp: number | undefined   = this.asInt(req.query.toLocalTimestamp)
+        const onlyCurrentlyPointed: boolean | undefined = this.asBoolean(req.query.onlyCurrentlyPointed)
+        const showAudit: boolean                     = this.asBoolean(req.query.showAudit) ?? false
+        const deployedBy: EthAddress[] | undefined   = this.asArray<EthAddress>(req.query.deployedBy)
+        const pointers: Pointer[] | undefined        = this.asArray<Pointer>(req.query.pointer)
+        const offset: number | undefined             = this.asInt(req.query.offset)
+        const limit: number | undefined              = this.asInt(req.query.limit)
 
         // Validate type is valid
         if (entityTypes.some(type => !type)) {

--- a/content/src/controller/Controller.ts
+++ b/content/src/controller/Controller.ts
@@ -229,19 +229,39 @@ export class Controller {
     async getDeployments(req: express.Request, res: express.Response) {
         // Method: GET
         // Path: /deployments
-        // Query String: ?fromLocalTimestamp={timestamp}&toLocalTimestamp={timestamp}
-        const fromLocalTimestamp = this.asInt(req.query.fromLocalTimestamp)
-        const toLocalTimestamp   = this.asInt(req.query.toLocalTimestamp)
-        const offset             = this.asInt(req.query.offset)
-        const limit              = this.asInt(req.query.limit)
+        // Query String: ?fromLocalTimestamp={timestamp}&toLocalTimestamp={timestamp}&entityType={entityType}&entityId={entityId}&onlyCurrentlyPointed={boolean}&deployedBy={ethAddress}
 
-        const { deployments, filters, pagination } = await this.service.getDeployments({ fromLocalTimestamp, toLocalTimestamp }, offset, limit)
+        const entityTypes:(EntityType|undefined)[] = this.asArray<string>(req.query.entityType).map(type => this.parseEntityType(type))
+        const entityIds:EntityId[]                 = this.asArray<EntityId>(req.query.entityId)
+        const fromLocalTimestamp                   = this.asInt(req.query.fromLocalTimestamp)
+        const toLocalTimestamp                     = this.asInt(req.query.toLocalTimestamp)
+        const onlyCurrentlyPointed                 = this.asBoolean(req.query.onlyCurrentlyPointed)
+        const showAudit                            = this.asBoolean(req.query.showAudit) ?? false
+        const deployedBy                           = this.asArray<EthAddress>(req.query.deployedBy)
+        const pointers                             = this.asArray<Pointer>(req.query.pointer)
+        const offset                               = this.asInt(req.query.offset)
+        const limit                                = this.asInt(req.query.limit)
+
+        // Validate type is valid
+        if (entityTypes.some(type => !type)) {
+            res.status(400).send({ error: `Found an unrecognized entity type` });
+            return
+        }
+
+        const requestFilters = { pointers, fromLocalTimestamp, toLocalTimestamp, entityTypes: (entityTypes as EntityType[]) , entityIds, deployedBy, onlyCurrentlyPointed }
+        const { deployments, filters, pagination } = await this.service.getDeployments(requestFilters, offset, limit)
         const controllerDeployments = deployments.map(deployment => ControllerDeploymentFactory.maskEntity(deployment))
+            .map(deployment => (!showAudit ? {...deployment, auditInfo: undefined } : deployment))
+
         res.send( { deployments: controllerDeployments, filters, pagination })
     }
 
     private asInt(value: any): number | undefined {
         return value ? parseInt(value) : undefined
+    }
+
+    private asBoolean(value: any): boolean | undefined {
+        return value ? (value === 'true') : undefined
     }
 
     async getStatus(req: express.Request, res: express.Response) {

--- a/content/src/migrations/scripts/1591278192053_add_indexes.ts
+++ b/content/src/migrations/scripts/1591278192053_add_indexes.ts
@@ -1,7 +1,4 @@
-/* eslint-disable @typescript-eslint/camelcase */
-import { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate';
-
-export const shorthands: ColumnDefinitions | undefined = undefined;
+import { MigrationBuilder } from 'node-pg-migrate';
 
 export async function up(pgm: MigrationBuilder): Promise<void> {
     pgm.addIndex('deployments', 'entity_type')

--- a/content/src/migrations/scripts/1591278192053_add_indexes.ts
+++ b/content/src/migrations/scripts/1591278192053_add_indexes.ts
@@ -1,0 +1,14 @@
+/* eslint-disable @typescript-eslint/camelcase */
+import { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate';
+
+export const shorthands: ColumnDefinitions | undefined = undefined;
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+    pgm.addIndex('deployments', 'entity_type')
+    pgm.addIndex('deployments', 'entity_pointers', { method: 'gin' })
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+    pgm.dropIndex('deployments', 'entity_pointers')
+    pgm.dropIndex('deployments', 'entity_type')
+}

--- a/content/src/service/deployments/DeploymentManager.ts
+++ b/content/src/service/deployments/DeploymentManager.ts
@@ -45,7 +45,7 @@ export class DeploymentManager {
         const curatedOffset = (offset && offset >= 0) ? offset : 0
         const curatedLimit = (limit && limit > 0 && limit <= DeploymentManager.MAX_HISTORY_LIMIT) ? limit : DeploymentManager.MAX_HISTORY_LIMIT
 
-        const deploymentsWithExtra = await deploymentsRepository.getHistoricalDeploymentsByLocalTimestamp(curatedOffset, curatedLimit + 1, filters?.fromLocalTimestamp, filters?.toLocalTimestamp)
+        const deploymentsWithExtra = await deploymentsRepository.getHistoricalDeploymentsByLocalTimestamp(curatedOffset, curatedLimit + 1, filters)
         const moreData = deploymentsWithExtra.length > curatedLimit
 
         const deploymentsResult = deploymentsWithExtra.slice(0, curatedLimit)
@@ -125,7 +125,7 @@ export class DeploymentManager {
     }
 
     async getDeltas(deploymentDeltasRepo: DeploymentDeltasRepository, deploymentsRepo: DeploymentsRepository): Promise<DeploymentDelta[]> {
-        const deploymentsWithExtra = await deploymentsRepo.getHistoricalDeploymentsByLocalTimestamp(0, DeploymentManager.MAX_HISTORY_LIMIT, undefined, undefined)
+        const deploymentsWithExtra = await deploymentsRepo.getHistoricalDeploymentsByLocalTimestamp(0, DeploymentManager.MAX_HISTORY_LIMIT, undefined)
         const deploymentIds = deploymentsWithExtra.map(({ deploymentId }) => deploymentId)
         const deltas = await deploymentDeltasRepo.getDeltasForDeployments(deploymentIds)
 
@@ -159,9 +159,17 @@ export type PartialDeploymentHistory = {
     },
 }
 
-export type DeploymentFilters = {
-    fromLocalTimestamp?: Timestamp
-    toLocalTimestamp?: Timestamp
+export type  DeploymentFilters = {
+    fromLocalTimestamp?: Timestamp,
+    toLocalTimestamp?: Timestamp,
+    fromOriginTimestamp?: Timestamp,
+    toOriginTimestamp?: Timestamp,
+    originServerUrl?: ServerAddress,
+    deployedBy?: EthAddress[],
+    entityTypes?: EntityType[],
+    entityIds?: EntityId[],
+    pointers?: Pointer[],
+    onlyCurrentlyPointed?: boolean,
 }
 
 export type Deployment = {

--- a/content/src/service/deployments/client/DeploymentsClient.ts
+++ b/content/src/service/deployments/client/DeploymentsClient.ts
@@ -10,6 +10,7 @@ export class DeploymentsClient {
         address: ServerAddress,
         filters?: DeploymentFilters,
         limit?: number,
+        showAudit: boolean = false,
         partialCallback?: (url: string, res: PartialDeploymentHistory) => void)
         : Promise<Deployment[]> {
         let deployments: Deployment[] = []
@@ -24,6 +25,9 @@ export class DeploymentsClient {
             }
             if (limit) {
                 url += `&limit=${limit}`
+            }
+            if (showAudit) {
+                url += `&showAudit=true`
             }
             const partialHistory: PartialDeploymentHistory = await retry(() => fetchHelper.fetchJson(url), 3, `fetch deployments from ${address}`)
             if (partialCallback) {

--- a/content/src/service/history/HistoryManagerImpl.ts
+++ b/content/src/service/history/HistoryManagerImpl.ts
@@ -44,8 +44,9 @@ export class HistoryManagerImpl implements HistoryManager {
         }
         const curatedOffset = (offset && offset>=0) ? offset : 0
         const curatedLimit = (limit && limit>0 && limit<=HistoryManagerImpl.MAX_HISTORY_LIMIT) ? limit : HistoryManagerImpl.DEFAULT_HISTORY_LIMIT
+        const filters = { fromOriginTimestamp: from, toOriginTimestamp: to, originServerUrl: address }
 
-        const deployments = await deploymentsRepository.getHistoricalDeploymentsByOriginTimestamp(curatedOffset, curatedLimit + 1, from, to, address)
+        const deployments = await deploymentsRepository.getHistoricalDeploymentsByOriginTimestamp(curatedOffset, curatedLimit + 1, filters)
         const moreData = deployments.length > curatedLimit
         const finalDeployments: LegacyDeploymentEvent[] = deployments.slice(0, curatedLimit)
             .map(deployment => ({

--- a/content/test/integration/E2ETestEnvironment.ts
+++ b/content/test/integration/E2ETestEnvironment.ts
@@ -12,6 +12,8 @@ import { ServerAddress } from '@katalyst/content/service/synchronization/clients
 import { LogWaitStrategy } from 'testcontainers/dist/wait-strategy'
 import { Container } from 'testcontainers/dist/container'
 import { MigrationManagerFactory } from '@katalyst/content/migrations/MigrationManagerFactory'
+import { NoOpValidations } from '@katalyst/test-helpers/service/validations/NoOpValidations'
+import { MetaverseContentService } from '@katalyst/content/service/Service'
 
 export class E2ETestEnvironment {
 
@@ -93,6 +95,15 @@ export class E2ETestEnvironment {
         const migrationManager = MigrationManagerFactory.create(env)
         await migrationManager.run()
         return env
+    }
+
+    /** Returns a service that connects to the database, with the migrations run */
+    async buildService(): Promise<MetaverseContentService> {
+        const baseEnv = await this.getEnvForNewDatabase()
+        const env = await new EnvironmentBuilder(baseEnv)
+            .withBean(Bean.VALIDATIONS, new NoOpValidations())
+            .build()
+        return env.getBean(Bean.SERVICE)
     }
 
     removeFromDAO(address: ServerAddress) {

--- a/content/test/integration/service/deployments/client/DeploymentsClient.spec.ts
+++ b/content/test/integration/service/deployments/client/DeploymentsClient.spec.ts
@@ -41,7 +41,7 @@ describe("Integration - Deployments Client", function() {
     async function validateHistoryThroughClient(server: TestServer, expectedDeployments: ControllerDeployment[], batchSize?: number): Promise<void> {
         const executions: {url:string, res: PartialDeploymentHistory}[] = []
 
-        const deployments = await DeploymentsClient.consumeAllDeployments(new FetchHelper(), server.getAddress(), undefined, batchSize,
+        const deployments = await DeploymentsClient.consumeAllDeployments(new FetchHelper(), server.getAddress(), undefined, batchSize, true,
         (url:string, res: PartialDeploymentHistory) => {
             executions.push({
                 url: url,

--- a/content/test/integration/service/deployments/deltas-check.spec.ts
+++ b/content/test/integration/service/deployments/deltas-check.spec.ts
@@ -1,10 +1,8 @@
 import { EntityType, Pointer } from "@katalyst/content/service/Entity";
-import { Bean, EnvironmentBuilder } from "@katalyst/content/Environment";
 import { MetaverseContentService, ContentFile } from "@katalyst/content/service/Service";
 import { AuditInfoBase, EntityVersion } from "@katalyst/content/service/Audit";
 import { buildControllerEntityAndFile } from "@katalyst/test-helpers/controller/ControllerEntityTestFactory";
 import { ControllerEntity } from "@katalyst/content/controller/Controller";
-import { NoOpValidations } from "@katalyst/test-helpers/service/validations/NoOpValidations";
 import { DeploymentDeltaChanges } from "@katalyst/content/service/deployments/DeploymentManager";
 import { loadTestEnvironment } from "../../E2ETestEnvironment";
 
@@ -30,11 +28,7 @@ describe("Integration - Deltas Check", () => {
     })
 
     beforeEach(async () => {
-        const baseEnv = await testEnv.getEnvForNewDatabase()
-        const env = await new EnvironmentBuilder(baseEnv)
-            .withBean(Bean.VALIDATIONS, new NoOpValidations())
-            .build()
-        service = env.getBean(Bean.SERVICE)
+        service = await testEnv.buildService()
     })
 
     it('When an entity is deployed and set as active but it has no one to overwrite, then it is reported correctly', async () => {

--- a/content/test/integration/service/deployments/deployment-filters.spec.ts
+++ b/content/test/integration/service/deployments/deployment-filters.spec.ts
@@ -1,0 +1,180 @@
+import { Authenticator } from "dcl-crypto";
+import { EntityType, Pointer } from "@katalyst/content/service/Entity";
+import { MetaverseContentService, ContentFile } from "@katalyst/content/service/Service";
+import { AuditInfoBase, EntityVersion, AuditInfo } from "@katalyst/content/service/Audit";
+import { buildControllerEntityAndFile } from "@katalyst/test-helpers/controller/ControllerEntityTestFactory";
+import { ControllerEntity } from "@katalyst/content/controller/Controller";
+import { DeploymentFilters } from "@katalyst/content/service/deployments/DeploymentManager";
+import { Timestamp } from "@katalyst/content/service/time/TimeSorting";
+import { loadTestEnvironment } from "../../E2ETestEnvironment";
+
+/**
+ * This test verifies that all deployment filters are working correctly
+ */
+describe("Integration - Deployment Filters", () => {
+
+    const P1 = "x1,y1"
+    const P2 = "x2,y2"
+    const P3 = "x3,y3"
+    let E1: EntityCombo, E2: EntityCombo, E3: EntityCombo
+
+    const testEnv = loadTestEnvironment()
+    let service: MetaverseContentService
+
+    beforeAll(async () => {
+        E1 = await buildEntityCombo(EntityType.PROFILE, P1)
+        E2 = await buildEntityComboAfter(EntityType.SCENE, E1, P2)
+        E3 = await buildEntityComboAfter(EntityType.PROFILE, E2, P1, P2, P3)
+    })
+
+    beforeEach(async () => {
+        service = await testEnv.buildService()
+    })
+
+    it('When local timestamp filter is set, then results are calculated correctly', async () => {
+        // Deploy E1 and E2
+        const [ E1Timestamp, E2Timestamp ] = await deploy(E1, E2)
+
+        // Deploy E3 with origin timestamp set between E1 and E2
+        const [ E3Timestamp ] = await deployWithOrigin((E1Timestamp + E2Timestamp) / 2, '', E3)
+
+        await assertDeploymentsWithFilterAre({ }, E1, E2, E3)
+        await assertDeploymentsWithFilterAre({ fromLocalTimestamp: E1Timestamp, toLocalTimestamp: E2Timestamp }, E1, E2)
+        await assertDeploymentsWithFilterAre({ fromLocalTimestamp: E2Timestamp }, E2, E3)
+        await assertDeploymentsWithFilterAre({ fromLocalTimestamp: E3Timestamp + 1 }, )
+    })
+
+    it('When origin timestamp filter is set, then results are calculated correctly', async () => {
+        // Deploy E1 and E2
+        const [ E1Timestamp, E2Timestamp ] = await deploy(E1, E2)
+
+        // Deploy E3 with origin timestamp set between E1 and E2
+        const betweenE1AndE2 = (E1Timestamp + E2Timestamp) / 2;
+        await deployWithOrigin(betweenE1AndE2, '', E3)
+
+        await assertDeploymentsWithFilterAre({ }, E1, E2, E3)
+        await assertDeploymentsWithFilterAre({ fromOriginTimestamp: E1Timestamp, toOriginTimestamp: E2Timestamp }, E1, E2, E3)
+        await assertDeploymentsWithFilterAre({ fromOriginTimestamp: betweenE1AndE2 }, E2, E3)
+        await assertDeploymentsWithFilterAre({ fromOriginTimestamp: betweenE1AndE2 }, E2, E3)
+        await assertDeploymentsWithFilterAre({ fromOriginTimestamp: E2Timestamp + 1 }, )
+    })
+
+    it('When origin server url filter is set, then results are calculated correctly', async () => {
+        const serverUrl = "some-server-url"
+
+        // Deploy E1
+        await deploy(E1)
+
+        // Deploy E2
+        await deployWithOrigin(Date.now(), serverUrl, E2)
+
+        await assertDeploymentsWithFilterAre({ }, E1, E2)
+        await assertDeploymentsWithFilterAre({ originServerUrl: 'something' }, )
+        await assertDeploymentsWithFilterAre({ originServerUrl: serverUrl }, E2)
+    })
+
+    it('When entity types filter is set, then results are calculated correctly', async () => {
+        // Deploy E1 and E2
+        await deploy(E1, E2)
+
+        await assertDeploymentsWithFilterAre({ }, E1, E2)
+        await assertDeploymentsWithFilterAre({ entityTypes: [ EntityType.PROFILE ] }, E1)
+        await assertDeploymentsWithFilterAre({ entityTypes: [ EntityType.SCENE ] }, E2)
+        await assertDeploymentsWithFilterAre({ entityTypes: [ EntityType.PROFILE, EntityType.SCENE ] }, E1, E2)
+    })
+
+    it('When entity ids filter is set, then results are calculated correctly', async () => {
+        // Deploy E1 and E2
+        await deploy(E1, E2)
+
+        await assertDeploymentsWithFilterAre({ }, E1, E2)
+        await assertDeploymentsWithFilterAre({ entityIds: [ E1.entity.id ] }, E1)
+        await assertDeploymentsWithFilterAre({ entityIds: [ E2.entity.id ] }, E2)
+        await assertDeploymentsWithFilterAre({ entityIds: [ E1.entity.id, E2.entity.id ] }, E1, E2)
+    })
+
+    it('When deployed by filter is set, then results are calculated correctly', async () => {
+        const identity1 = 'some-identity'
+        const identity2 = 'another-identity'
+
+        // Deploy E1 and E2
+        await deployWithIdentity(identity1, E1)
+        await deployWithIdentity(identity2, E2)
+
+        await assertDeploymentsWithFilterAre({ }, E1, E2)
+        await assertDeploymentsWithFilterAre({ deployedBy: [ identity1 ] }, E1)
+        await assertDeploymentsWithFilterAre({ deployedBy: [ identity2 ] }, E2)
+        await assertDeploymentsWithFilterAre({ deployedBy: [ identity1, identity2 ] }, E1, E2)
+        await assertDeploymentsWithFilterAre({ deployedBy: [ 'not-and-identity' ] }, )
+    })
+
+    it('When deployed by filter is set, then results are calculated correctly', async () => {
+        await deploy(E1, E2, E3)
+
+        await assertDeploymentsWithFilterAre({ }, E1, E2, E3)
+        await assertDeploymentsWithFilterAre({ onlyCurrentlyPointed: true }, E2, E3)
+        await assertDeploymentsWithFilterAre({ onlyCurrentlyPointed: false }, E1, E2, E3)
+    })
+
+    it('When pointers filter is set, then results are calculated correctly', async () => {
+        await deploy(E1, E2, E3)
+
+        await assertDeploymentsWithFilterAre({ }, E1, E2, E3)
+        await assertDeploymentsWithFilterAre({ pointers: [ P1 ] }, E1, E3)
+        await assertDeploymentsWithFilterAre({ pointers: [ P2 ] }, E2, E3)
+        await assertDeploymentsWithFilterAre({ pointers: [ P3 ] }, E3)
+        await assertDeploymentsWithFilterAre({ pointers: [ P1, P2, P3 ] }, E1, E2, E3)
+    })
+
+    async function assertDeploymentsWithFilterAre(filter: DeploymentFilters, ...expectedEntities: EntityCombo[]) {
+        const actualDeployments = await service.getDeployments(filter)
+        const expectedEntityIds = expectedEntities.map(entityCombo => entityCombo.entity.id).sort()
+        const actualEntityIds = actualDeployments.deployments.map(({ entityId }) => entityId).sort()
+        expect(actualEntityIds).toEqual(expectedEntityIds)
+    }
+
+    async function deploy(...entities: EntityCombo[]): Promise<Timestamp[]> {
+        return deployWithAuditInfo(entities, { })
+    }
+
+    async function deployWithOrigin(originTimestamp: Timestamp, originServerUrl: string, ...entities: EntityCombo[]): Promise<Timestamp[]> {
+        return deployWithAuditInfo(entities, { originTimestamp, originServerUrl  })
+    }
+
+    async function deployWithIdentity(deployedBy: string, ...entities: EntityCombo[]): Promise<Timestamp[]> {
+        const authChain = Authenticator.createSimpleAuthChain('', deployedBy, '')
+        return deployWithAuditInfo(entities, { authChain })
+    }
+
+    async function deployWithAuditInfo(entities: EntityCombo[], overrideAuditInfo?: Partial<AuditInfo>) {
+        const result: Timestamp[] = []
+        for (const { entity, entityFile, auditInfo } of entities) {
+            const newAuditInfo = { ...auditInfo, ...overrideAuditInfo }
+            const deploymentTimestamp = await service.deployEntity([entityFile], entity.id, newAuditInfo, '')
+            result.push(deploymentTimestamp)
+        }
+        return result
+    }
+
+    async function buildEntityCombo(type: EntityType, ...pointers: Pointer[]): Promise<EntityCombo> {
+        return buildEntityComboAfter(type, undefined, ...pointers)
+    }
+
+    async function buildEntityComboAfter(type: EntityType, entityCombo?: EntityCombo, ...pointers: Pointer[]): Promise<EntityCombo> {
+        const timestamp = entityCombo ? entityCombo.entity.timestamp + 1 : Date.now()
+        const [ entity, entityFile ] = await buildControllerEntityAndFile(type, pointers, timestamp)
+        const auditInfo: AuditInfoBase = { version: EntityVersion.V2, authChain: [] }
+        return {
+            entity,
+            entityFile,
+            auditInfo
+        }
+    }
+
+})
+
+type EntityCombo = {
+    entity: ControllerEntity,
+    entityFile: ContentFile,
+    auditInfo: AuditInfoBase,
+}

--- a/content/test/integration/service/order-check.spec.ts
+++ b/content/test/integration/service/order-check.spec.ts
@@ -1,12 +1,10 @@
 import { EntityType, Pointer } from "@katalyst/content/service/Entity";
 import { loadTestEnvironment } from "../E2ETestEnvironment";
-import { Bean, EnvironmentBuilder } from "@katalyst/content/Environment";
 import { MetaverseContentService, ContentFile } from "@katalyst/content/service/Service";
 import { AuditInfoBase, EntityVersion } from "@katalyst/content/service/Audit";
 import { buildControllerEntityAndFile } from "@katalyst/test-helpers/controller/ControllerEntityTestFactory";
 import { ControllerEntity } from "@katalyst/content/controller/Controller";
 import { parseEntityType } from "../E2ETestUtils";
-import { NoOpValidations } from "@katalyst/test-helpers/service/validations/NoOpValidations";
 
 /**
  * This test verifies that the active entity and overwrites are calculated correctly, regardless of the order in which the entities where deployed.
@@ -36,11 +34,7 @@ describe("Integration - Order Check", () => {
     })
 
     beforeEach(async () => {
-        const baseEnv = await testEnv.getEnvForNewDatabase()
-        const env = await new EnvironmentBuilder(baseEnv)
-            .withBean(Bean.VALIDATIONS, new NoOpValidations())
-            .build()
-        service = env.getBean(Bean.SERVICE)
+        service = await testEnv.buildService()
     })
 
     permutator([0, 1, 2, 3, 4])

--- a/content/test/integration/service/same-timestamp-check.spec.ts
+++ b/content/test/integration/service/same-timestamp-check.spec.ts
@@ -1,12 +1,10 @@
 import { EntityType, Pointer } from "@katalyst/content/service/Entity";
 import { loadTestEnvironment } from "../E2ETestEnvironment";
-import { Bean, EnvironmentBuilder } from "@katalyst/content/Environment";
 import { MetaverseContentService, ContentFile } from "@katalyst/content/service/Service";
 import { AuditInfoBase, EntityVersion } from "@katalyst/content/service/Audit";
 import { buildControllerEntityAndFile } from "@katalyst/test-helpers/controller/ControllerEntityTestFactory";
 import { ControllerEntity } from "@katalyst/content/controller/Controller";
 import { parseEntityType } from "../E2ETestUtils";
-import { NoOpValidations } from "@katalyst/test-helpers/service/validations/NoOpValidations";
 import { Timestamp } from "@katalyst/content/service/time/TimeSorting";
 
 /**
@@ -35,11 +33,7 @@ describe("Integration - Same Timestamp Check", () => {
     })
 
     beforeEach(async () => {
-        const baseEnv = await testEnv.getEnvForNewDatabase()
-        const env = await new EnvironmentBuilder(baseEnv)
-            .withBean(Bean.VALIDATIONS, new NoOpValidations())
-            .build()
-        service = env.getBean(Bean.SERVICE)
+        service = await testEnv.buildService()
     })
 
     it(`When oldest is deployed first, they overwrites are calculated correctly correctly`, async () => {


### PR DESCRIPTION
We are adding a few filters to the `/deployments` endpoint. Previously, we only had:
* fromLocalTimestamp
* toLocalTimestamp

Now, we are adding:
* deployedBy
* entityTypes
* entityIds
* pointers
* onlyCurrentlyPointed

Also, now, by default we won't show the `auditInfo` unless a query param called `showAudit` is set to true. In the near future, we will replace this query param with a `fields` parameter, where you can specify the fields you would like to retrieve.