### PR TITLE
feat: many minor changes

### DIFF
--- a/content/src/denylist/DenylistServiceDecorator.ts
+++ b/content/src/denylist/DenylistServiceDecorator.ts
@@ -150,29 +150,47 @@ export class DenylistServiceDecorator implements MetaverseContentService {
 
   async getDeployments(filters?: DeploymentFilters, offset?: number, limit?: number): Promise<PartialDeploymentHistory<Deployment>> {
     return this.repository.task(async task => {
-      // TODO: Filter denylisted pointers from filters, when added
       const deploymentHistory = await this.service.getDeployments(filters, offset, limit, task)
 
       // Prepare holders
       const entityTargetsByEntity: Map<EntityId, DenylistTarget> = new Map()
       const contentTargetsByEntity: Map<EntityId, Map<ContentFileHash, DenylistTarget>> = new Map()
+      const pointerTargetsByEntity: Map<EntityId, Map<Pointer, DenylistTarget>> = new Map()
       const allTargets: DenylistTarget[] = []
 
       // Calculate and group targets by entity
-      deploymentHistory.deployments.forEach(({ entityId, entityType, content }) => {
+      deploymentHistory.deployments.forEach(({ entityId, entityType, content, pointers }) => {
         const entityTarget = buildEntityTarget(entityType, entityId);
         const hashTargets: Map<ContentFileHash, DenylistTarget> = !content ? new Map() : new Map(Array.from(content.entries())
           .map(([, hash]) => [hash, buildContentTarget(hash)]))
+        const pointerTargets: Map<Pointer, DenylistTarget> = new Map(pointers.map(pointer => [pointer, buildPointerTarget(entityType, pointer)]))
         entityTargetsByEntity.set(entityId, entityTarget);
         contentTargetsByEntity.set(entityId, hashTargets);
-        allTargets.push(entityTarget, ...hashTargets.values())
+        pointerTargetsByEntity.set(entityId, pointerTargets);
+        allTargets.push(entityTarget, ...hashTargets.values(), ...pointerTargets.values())
       })
 
       // Check which targets are denylisted
       const queryResult = await this.denylist.areTargetsDenylisted(task.denylist, allTargets)
 
+      // Filter out deployments with blacklisted pointers
+      const filteredDeployments = deploymentHistory.deployments.filter(({ entityId, pointers }) => {
+        if (filters?.pointers && filters.pointers.length > 0) {
+          // Calculate the intersection between the pointers used to filter, and the deployment's pointers. Consider that the intersection can't be empty
+          const intersection = filters.pointers.filter(pointer => pointers.includes(pointer))
+          const pointerTargets: Map<Pointer, DenylistTarget> = pointerTargetsByEntity.get(entityId)!!
+          // Check if there is at least one pointer on the intersection that is not denylisted
+          const isAtLeastOnePointerNotDenylisted = intersection
+            .map(pointer => pointerTargets.get(pointer)!!)
+            .some(target => !isTargetDenylisted(target, queryResult))
+          // If there is one pointer on the intersection that is not denylisted, then the entity shouldn't be filtered out
+          return isAtLeastOnePointerNotDenylisted
+        }
+        return true
+      })
+
       // Perform sanitization
-      const sanitizedDeployments = deploymentHistory.deployments.map(deployment => {
+      const sanitizedDeployments = filteredDeployments.map(deployment => {
         const { entityId } = deployment
         const entityTarget = entityTargetsByEntity.get(entityId)!!
         const contentTargets = contentTargetsByEntity.get(entityId)!!

--- a/content/src/service/synchronization/ClusterUtils.ts
+++ b/content/src/service/synchronization/ClusterUtils.ts
@@ -40,12 +40,21 @@ export function legacyDeploymentEventToDeploymentEventBase(cluster: ContentClust
 }
 
 function reorderAccordingToPreference(activeServers: ContentServerClient[], preferred: ContentServerClient | undefined): ContentServerClient[] {
+    const shuffled = shuffleArray(activeServers)
     if (preferred) {
-        const newOrder = activeServers.filter(server => server.getName() != preferred.getName())
-        newOrder.unshift(preferred);
-        return newOrder
+        const withPriority = shuffled.filter(server => server.getName() != preferred.getName())
+        withPriority.unshift(preferred);
+        return withPriority
     } else {
-        return activeServers
+        return shuffled
     }
+}
+
+function shuffleArray<T>(arr: T[]): T[] {
+    for (let i = arr.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [arr[i], arr[j]] = [arr[j], arr[i]];
+    }
+    return arr;
 }
 

--- a/content/src/service/synchronization/ClusterUtils.ts
+++ b/content/src/service/synchronization/ClusterUtils.ts
@@ -40,17 +40,16 @@ export function legacyDeploymentEventToDeploymentEventBase(cluster: ContentClust
 }
 
 function reorderAccordingToPreference(activeServers: ContentServerClient[], preferred: ContentServerClient | undefined): ContentServerClient[] {
-    const shuffled = shuffleArray(activeServers)
     if (preferred) {
-        const withPriority = shuffled.filter(server => server.getName() != preferred.getName())
-        withPriority.unshift(preferred);
-        return withPriority
+        const newOrder = activeServers.filter(server => server.getName() != preferred.getName())
+        newOrder.unshift(preferred);
+        return newOrder
     } else {
-        return shuffled
+        return activeServers
     }
 }
 
-function shuffleArray<T>(arr: T[]): T[] {
+export function shuffleArray<T>(arr: T[]): T[] {
     for (let i = arr.length - 1; i > 0; i--) {
         const j = Math.floor(Math.random() * (i + 1));
         [arr[i], arr[j]] = [arr[j], arr[i]];

--- a/content/src/service/synchronization/ContentCluster.ts
+++ b/content/src/service/synchronization/ContentCluster.ts
@@ -13,6 +13,7 @@ import { DAORemovalEvent, DAORemoval } from "./events/DAORemovalEvent";
 import { Listener, Disposable } from "./events/ClusterEvent";
 import { ServerMetadata } from "decentraland-katalyst-commons/ServerMetadata";
 import { ChallengeSupervisor, ChallengeText } from "./ChallengeSupervisor"
+import { shuffleArray } from "./ClusterUtils";
 
 export interface IdentityProvider {
     getIdentityInDAO(): ServerIdentity | undefined;
@@ -263,9 +264,12 @@ export class ContentCluster implements IdentityProvider {
     /** Returns all the addresses on the DAO, except for the current server's */
     private getAllOtherAddressesOnDAO(allServers: Set<ServerMetadata>): ServerAddress[] {
         // Filter myself out
-        return Array.from(allServers)
+        const addresses = Array.from(allServers)
             .map(({ address }) => address)
             .filter(address => address !== this.myIdentity?.address)
+
+        // We are sorting the array, so when we query the servers, we will choose a different one each time
+        return shuffleArray(addresses)
     }
 
     /** Return the server's name, or the text "UNREACHABLE" if it couldn't be reached */

--- a/content/src/service/synchronization/EventStreamProcessor.ts
+++ b/content/src/service/synchronization/EventStreamProcessor.ts
@@ -47,7 +47,7 @@ export class EventStreamProcessor {
      * We will download everything in parallel, but it will be deployed in order
      */
     private prepareDeploymentBuilder(historyLength: number, options?: HistoryDeploymentOptions) {
-        return parallelTransform(EventStreamProcessor.PARALLEL_DOWNLOAD_WORKERS, { objectMode: true, ordered: false }, async ([index, deploymentEvent], done) => {
+        return parallelTransform(EventStreamProcessor.PARALLEL_DOWNLOAD_WORKERS, { objectMode: true }, async ([index, deploymentEvent], done) => {
             try {
                 EventStreamProcessor.LOGGER.trace(`Preparing deployment for ${index + 1}/${historyLength}. Entity (${deploymentEvent.entityType}, ${deploymentEvent.entityId})`)
                 const execution = await this.deploymentBuilder(deploymentEvent, options?.preferredServer);

--- a/content/src/service/synchronization/EventStreamProcessor.ts
+++ b/content/src/service/synchronization/EventStreamProcessor.ts
@@ -47,7 +47,7 @@ export class EventStreamProcessor {
      * We will download everything in parallel, but it will be deployed in order
      */
     private prepareDeploymentBuilder(historyLength: number, options?: HistoryDeploymentOptions) {
-        return parallelTransform(EventStreamProcessor.PARALLEL_DOWNLOAD_WORKERS, { objectMode: true }, async ([index, deploymentEvent], done) => {
+        return parallelTransform(EventStreamProcessor.PARALLEL_DOWNLOAD_WORKERS, { objectMode: true, ordered: false }, async ([index, deploymentEvent], done) => {
             try {
                 EventStreamProcessor.LOGGER.trace(`Preparing deployment for ${index + 1}/${historyLength}. Entity (${deploymentEvent.entityType}, ${deploymentEvent.entityId})`)
                 const execution = await this.deploymentBuilder(deploymentEvent, options?.preferredServer);

--- a/content/test/helpers/service/MockedMetaverseContentService.ts
+++ b/content/test/helpers/service/MockedMetaverseContentService.ts
@@ -45,9 +45,9 @@ export class MockedMetaverseContentService implements MetaverseContentService {
         return Promise.resolve([])
     }
 
-    getDeployments(filters: DeploymentFilters, offset?: number, limit?: number): Promise<PartialDeploymentHistory<Deployment>> {
+    getDeployments(filters?: DeploymentFilters, offset?: number, limit?: number): Promise<PartialDeploymentHistory<Deployment>> {
         return Promise.resolve({
-            deployments: this.entities.map(entity => this.entityToDeployment(entity)),
+            deployments: this.entities.map(entity => this.entityToDeployment(entity)).filter(deployment => !filters?.entityIds || filters.entityIds.includes(deployment.entityId)),
             filters: { },
             pagination: {
                 offset: 0,

--- a/content/test/unit/denylist/DenylistServiceDecorator.spec.ts
+++ b/content/test/unit/denylist/DenylistServiceDecorator.spec.ts
@@ -12,7 +12,7 @@ import { Authenticator } from "dcl-crypto";
 import { MockedRepository } from "../storage/MockedRepository";
 import { Deployment } from "@katalyst/content/service/deployments/DeploymentManager";
 
-fdescribe("DenylistServiceDecorator", () => {
+describe("DenylistServiceDecorator", () => {
 
     const P1: Pointer = "p1"
     const P2: Pointer = "p2"

--- a/content/test/unit/denylist/DenylistServiceDecorator.spec.ts
+++ b/content/test/unit/denylist/DenylistServiceDecorator.spec.ts
@@ -12,10 +12,11 @@ import { Authenticator } from "dcl-crypto";
 import { MockedRepository } from "../storage/MockedRepository";
 import { Deployment } from "@katalyst/content/service/deployments/DeploymentManager";
 
-describe("DenylistServiceDecorator", () => {
+fdescribe("DenylistServiceDecorator", () => {
 
     const P1: Pointer = "p1"
     const P2: Pointer = "p2"
+    const P3: Pointer = "p3"
     const content1 = buildRandomContent()
     const content2 = buildRandomContent()
     const ethAddress = random.alphaNumeric(10)
@@ -37,7 +38,7 @@ describe("DenylistServiceDecorator", () => {
     let service: MockedMetaverseContentService;
 
     beforeAll(async () => {
-        [entity1, entityFile1] = await buildEntity([P1], content1);
+        [entity1, entityFile1] = await buildEntity([P1, P3], content1);
         [entity2, ] = await buildEntity([P2], content2);
 
         P1Target = buildPointerTarget(entity1.type, P1);
@@ -120,6 +121,45 @@ describe("DenylistServiceDecorator", () => {
         // Assert no content is marked as denylisted
         deploymentEquals(entity2, deployment2)
         expect(deployment2.auditInfo.denylistedContent).toBeUndefined
+    })
+
+    it(`When a pointer is denylisted, then deployments whose pointers fully match the filter are not returned`, async () => {
+        const denylist = denylistWith(P1Target)
+        const decorator = getDecorator(denylist)
+
+        const { deployments } = await decorator.getDeployments( { pointers: [P1] });
+
+        expect(deployments.length).toBe(0)
+    })
+
+    it(`When a pointer is denylisted, then deployments whose pointers partially match the filter are returned`, async () => {
+        const denylist = denylistWith(P1Target)
+        const decorator = getDecorator(denylist)
+
+        const { deployments } = await decorator.getDeployments( { pointers: entity1.pointers });
+
+        expect(deployments.length).toBe(1)
+        deploymentEquals(entity1, deployments[0])
+    })
+
+    it(`When a pointer is denylisted but it is not used as a pointer filter, then it has no effect`, async () => {
+        const denylist = denylistWith(P1Target)
+        const decorator = getDecorator(denylist)
+
+        const { deployments } = await decorator.getDeployments( { pointers: entity2.pointers });
+
+        expect(deployments.length).toBe(1)
+        deploymentEquals(entity2, deployments[0])
+    })
+
+    it(`When a pointer is denylisted but it is not used as filter, then it has no effect`, async () => {
+        const denylist = denylistWith(P1Target)
+        const decorator = getDecorator(denylist)
+
+        const { deployments } = await decorator.getDeployments( { entityIds: [ entity1.id ] });
+
+        expect(deployments.length).toBe(1)
+        deploymentEquals(entity1, deployments[0])
     })
 
     it(`When an entity is not denylisted, then it is returned by pointers correctly`, async () => {


### PR DESCRIPTION
Ok, so we are doing a few minor changes on this PR.

1. We are adding pointer denylist filtering to the `/deployments` endpoint. This was long overdue. The logic will remain consistent with the `/entities` endpoint. Applied to the `/deployments` endpoint, this means that: deployments will not be returned if all pointers in the intersection between the 'pointers' filter and the deployment's pointers are denylisted. If the 'pointers' filter is not used, then we won't filter anything out.

2. When array query params are used (and not set), then they will remain `undefined` by default. Before, they were set as an empty array. This caused some weird scenarios on the `/deployments` endpoint, since filters were marked as set, when they weren't

3. When executing a shuffle on the content server list, so when we execute a query to the cluster, it isn't always the same.