### PR TITLE
Allow fixing re-deployment errors

### DIFF
--- a/content/src/service/validations/ValidationContext.ts
+++ b/content/src/service/validations/ValidationContext.ts
@@ -19,11 +19,11 @@ export class ValidationContext {
     static readonly ALL: ValidationContext = new ValidationContext(Object.keys(Validation).map(key => Validation[key]))
     static readonly LOCAL: ValidationContext = ValidationContext.ALL.without(Validation.MUST_HAVE_FAILED_BEFORE, Validation.DECENTRALAND_ADDRESS, Validation.LEGACY_ENTITY)
     static readonly LOCAL_LEGACY_ENTITY: ValidationContext = ValidationContext.ALL.without(Validation.MUST_HAVE_FAILED_BEFORE, Validation.REQUEST_SIZE, Validation.ACCESS)
-    static readonly SYNCED: ValidationContext = ValidationContext.LOCAL.without(Validation.NO_NEWER, Validation.RECENT, Validation.REQUEST_SIZE)
-    static readonly SYNCED_LEGACY_ENTITY: ValidationContext = ValidationContext.LOCAL_LEGACY_ENTITY.without(Validation.NO_NEWER, Validation.RECENT)
+    static readonly SYNCED: ValidationContext = ValidationContext.LOCAL.without(Validation.NO_NEWER, Validation.RECENT, Validation.REQUEST_SIZE, Validation.NO_REDEPLOYS)
+    static readonly SYNCED_LEGACY_ENTITY: ValidationContext = ValidationContext.LOCAL_LEGACY_ENTITY.without(Validation.NO_NEWER, Validation.RECENT, Validation.NO_REDEPLOYS)
     static readonly OVERWRITTEN: ValidationContext = ValidationContext.SYNCED.without(Validation.CONTENT)
     static readonly OVERWRITTEN_LEGACY_ENTITY: ValidationContext = ValidationContext.SYNCED_LEGACY_ENTITY.without(Validation.CONTENT)
-    static readonly FIX_ATTEMPT: ValidationContext = ValidationContext.ALL.without(Validation.REQUEST_SIZE, Validation.NO_NEWER, Validation.RECENT, Validation.DECENTRALAND_ADDRESS, Validation.LEGACY_ENTITY)
+    static readonly FIX_ATTEMPT: ValidationContext = ValidationContext.ALL.without(Validation.REQUEST_SIZE, Validation.NO_NEWER, Validation.RECENT, Validation.DECENTRALAND_ADDRESS, Validation.LEGACY_ENTITY, Validation.NO_REDEPLOYS)
 
     private readonly toExecute: Set<Validation>;
     private constructor (toExecute: Validation[]) {

--- a/content/src/service/validations/Validations.ts
+++ b/content/src/service/validations/Validations.ts
@@ -48,9 +48,8 @@ export class ValidatorInstance {
     }
 
     /** Validate if the entity can be re deployed or not */
-    async validateThatEntityCanBeRedeployed(entity: Entity, deploymentCheck: (entityId: EntityId) => Promise<boolean>, validationContext: ValidationContext) {
+    async validateThatEntityCanBeRedeployed(wasEntityAlreadyDeployed: boolean, validationContext: ValidationContext) {
         if (validationContext.shouldValidate(Validation.NO_REDEPLOYS)) {
-            const wasEntityAlreadyDeployed = await deploymentCheck(entity.id)
             if (wasEntityAlreadyDeployed) {
                 this.errors.push(`This entity was already deployed. You can't redeploy it`)
             }

--- a/content/test/integration/syncronization/error-handling.spec.ts
+++ b/content/test/integration/syncronization/error-handling.spec.ts
@@ -98,7 +98,7 @@ describe("End 2 end - Error handling", () => {
         await server1.deploy(deployData)
 
         // Try to fix the entity, and fail
-        await assertDeploymentFailsWith(() => server1.deploy(deployData, true), "This entity was already deployed. You can't redeploy it\nYou are trying to fix an entity that is not marked as failed")
+        await assertDeploymentFailsWith(() => server1.deploy(deployData, true), "You are trying to fix an entity that is not marked as failed")
     });
 
     async function runTest(errorType: FailureReason, causeOfFailure: (entity: ControllerEntity) => Promise<void>, removeCauseOfFailure?: () => Promise<void>, ) {

--- a/content/test/unit/service/deployments/NoOpDeploymentManager.ts
+++ b/content/test/unit/service/deployments/NoOpDeploymentManager.ts
@@ -1,10 +1,11 @@
-import { mock, instance } from "ts-mockito"
+import { mock, instance, when, anything } from "ts-mockito"
 import { DeploymentManager } from "@katalyst/content/service/deployments/DeploymentManager"
 
 export class NoOpDeploymentManager {
 
     static build(): DeploymentManager {
         const mockedManager: DeploymentManager = mock(DeploymentManager)
+        when(mockedManager.areEntitiesDeployed(anything(), anything())).thenCall((_, ids) => Promise.resolve(new Map(ids.map(id => [id, false]))))
         return instance(mockedManager)
     }
 }


### PR DESCRIPTION
**Problem**:
As of now, all entities that are re-deployed fail. The problem with this is that during sync, there could be a race condition that causes these failures. Even though the chances after #139 should be really really small, we need to prevent these types of errors and give ourselves the opportunity to fix these deployments that are already marked as failed.

**Solution**
We are basically doing one small change with the following impact:
1. We are no longer failing when entities are re-deployed during sync of fix deployments. In those cases, we will just not deploy it. However, during local/direct deployments, we will continue to fail.
2. Since fix deployments allow re-deploys, if we trigger one with a failed deployment (even if it was a re-deployment error), it will be fixed and removed from the failed deployments list.