### PR TITLE
fix: add timeout when querying thegraph

### DIFF
--- a/content/src/service/access/AccessCheckerImplFactory.ts
+++ b/content/src/service/access/AccessCheckerImplFactory.ts
@@ -5,6 +5,7 @@ export class AccessCheckerImplFactory {
     static create(env: Environment): AccessCheckerImpl {
         return new AccessCheckerImpl(
             env.getBean(Bean.AUTHENTICATOR),
+            env.getBean(Bean.FETCHER),
             env.getConfig(EnvironmentConfig.DCL_PARCEL_ACCESS_URL))
     }
 }

--- a/content/test/integration/service/access/AccessCheckerImpl.spec.ts
+++ b/content/test/integration/service/access/AccessCheckerImpl.spec.ts
@@ -1,4 +1,4 @@
-import { EntityType } from "dcl-catalyst-commons";
+import { EntityType, Fetcher } from "dcl-catalyst-commons";
 import { AccessCheckerImpl } from "@katalyst/content/service/access/AccessCheckerImpl";
 import { ContentAuthenticator } from "@katalyst/content/service/auth/Authenticator";
 import { DEFAULT_DCL_PARCEL_ACCESS_URL_ROPSTEN } from "@katalyst/content/Environment";
@@ -6,7 +6,7 @@ import { DEFAULT_DCL_PARCEL_ACCESS_URL_ROPSTEN } from "@katalyst/content/Environ
 describe("Integration - AccessCheckerImpl", function () {
 
     it(`When access URL is wrong it reports an error`, async () => {
-        const accessChecker = new AccessCheckerImpl(new ContentAuthenticator(), "Wrong URL");
+        const accessChecker = new AccessCheckerImpl(new ContentAuthenticator(), new Fetcher(), "Wrong URL");
 
         const errors = await accessChecker.hasAccess(EntityType.SCENE, ["102,4"], Date.now(), "Some-address-without-permissions");
 
@@ -15,7 +15,7 @@ describe("Integration - AccessCheckerImpl", function () {
     })
 
     it(`When an address without permissions tries to deploy it fails`, async () => {
-        const accessChecker = new AccessCheckerImpl(new ContentAuthenticator(), DEFAULT_DCL_PARCEL_ACCESS_URL_ROPSTEN);
+        const accessChecker = new AccessCheckerImpl(new ContentAuthenticator(),new Fetcher(), DEFAULT_DCL_PARCEL_ACCESS_URL_ROPSTEN);
 
         const errors = await accessChecker.hasAccess(EntityType.SCENE, ["102,4"], Date.now(), "Some-address-without-permissions");
 

--- a/content/test/manual/check-failed-deployments.spec.ts
+++ b/content/test/manual/check-failed-deployments.spec.ts
@@ -10,6 +10,7 @@ import { DEFAULT_DCL_PARCEL_ACCESS_URL_MAINNET } from "@katalyst/content/Environ
 import fs from 'fs';
 import { httpProviderForNetwork } from "../../../contracts/utils"
 import ms from "ms"
+import { Fetcher } from "dcl-catalyst-commons"
 
 describe("Failed Deployments validations.", () => {
 
@@ -45,7 +46,7 @@ describe("Failed Deployments validations.", () => {
             })))
             .filter(notEmpty)
 
-        const accessChecker = new AccessCheckerImpl(new ContentAuthenticator(), DEFAULT_DCL_PARCEL_ACCESS_URL_MAINNET);
+        const accessChecker = new AccessCheckerImpl(new ContentAuthenticator(), new Fetcher(), DEFAULT_DCL_PARCEL_ACCESS_URL_MAINNET);
 
         if (reviewSceneErrors) {
             console.log('------------------------------')
@@ -142,7 +143,7 @@ describe("Failed Deployments validations.", () => {
         }, MAX_SAFE_TIMEOUT)
 
     it('Entity access check', async () => {
-        const accessChecker = new AccessCheckerImpl(new ContentAuthenticator(), 'https://api.thegraph.com/subgraphs/name/decentraland/land-manager');
+        const accessChecker = new AccessCheckerImpl(new ContentAuthenticator(), new Fetcher(), 'https://api.thegraph.com/subgraphs/name/decentraland/land-manager');
         const accessSnapshot = {
             pointers: ["55,-132"],
             ethAddress: '0xaabe0ecfaf9e028d63cf7ea7e772cf52d662691a',

--- a/content/test/unit/service/access/AccessCheckerImpl.spec.ts
+++ b/content/test/unit/service/access/AccessCheckerImpl.spec.ts
@@ -1,4 +1,4 @@
-import { EntityType } from "dcl-catalyst-commons";
+import { EntityType, Fetcher } from "dcl-catalyst-commons";
 import { AccessCheckerImpl } from "@katalyst/content/service/access/AccessCheckerImpl";
 import { ContentAuthenticator } from "@katalyst/content/service/auth/Authenticator";
 import { DECENTRALAND_ADDRESS } from "decentraland-katalyst-commons/addresses";
@@ -6,7 +6,7 @@ import { DECENTRALAND_ADDRESS } from "decentraland-katalyst-commons/addresses";
 describe("AccessCheckerImpl", function () {
 
     it(`When a non-decentraland address tries to deploy an default scene, then an error is returned`, async () => {
-        const accessChecker = new AccessCheckerImpl(new ContentAuthenticator(), 'unused_url');
+        const accessChecker = buildAccessChecker()
 
         const errors = await accessChecker.hasAccess(EntityType.SCENE, ["Default10"], Date.now(), "0xAddress");
 
@@ -14,7 +14,7 @@ describe("AccessCheckerImpl", function () {
     })
 
     it(`When a decentraland address tries to deploy an default scene, then it is allowed`, async () => {
-        const accessChecker = new AccessCheckerImpl(new ContentAuthenticator(), 'unused_url');
+        const accessChecker = buildAccessChecker()
 
         const errors = await accessChecker.hasAccess(EntityType.SCENE, ["Default10"], Date.now(), DECENTRALAND_ADDRESS);
 
@@ -22,7 +22,7 @@ describe("AccessCheckerImpl", function () {
     })
 
     it(`When a non-decentraland address tries to deploy an default profile, then an error is returned`, async () => {
-        const accessChecker = new AccessCheckerImpl(new ContentAuthenticator(), 'unused_url');
+        const accessChecker = buildAccessChecker()
 
         const errors = await accessChecker.hasAccess(EntityType.PROFILE, ["Default10"], Date.now(), "0xAddress");
 
@@ -30,11 +30,15 @@ describe("AccessCheckerImpl", function () {
     })
 
     it(`When a decentraland address tries to deploy an default profile, then it is allowed`, async () => {
-        const accessChecker = new AccessCheckerImpl(new ContentAuthenticator(), 'unused_url');
+        const accessChecker = buildAccessChecker();
 
         const errors = await accessChecker.hasAccess(EntityType.PROFILE, ["Default10"], Date.now(), DECENTRALAND_ADDRESS);
 
         expect(errors.length).toBe(0)
     })
+
+    function buildAccessChecker() {
+        return new AccessCheckerImpl(new ContentAuthenticator(), new Fetcher(), 'unused_url');
+    }
 
 })

--- a/content/test/unit/service/validations/Validations.spec.ts
+++ b/content/test/unit/service/validations/Validations.spec.ts
@@ -1,5 +1,5 @@
 import * as EthCrypto from "eth-crypto";
-import { EntityType, Timestamp, EntityVersion, Entity, AuditInfo } from "dcl-catalyst-commons";
+import { EntityType, Timestamp, EntityVersion, Entity, AuditInfo, Fetcher } from "dcl-catalyst-commons";
 import { Validations } from "@katalyst/content/service/validations/Validations";
 import { MockedAccessChecker } from "@katalyst/test-helpers/service/access/MockedAccessChecker";
 import { ValidationContext } from "@katalyst/content/service/validations/ValidationContext";
@@ -366,7 +366,7 @@ function buildEntity(options?: { timestamp?: Timestamp, content?: Map<string, st
 
 function getValidatorWithRealAccess() {
   const authenticator = new ContentAuthenticator();
-  return new Validations(new AccessCheckerImpl(authenticator, "unused_url"),
+  return new Validations(new AccessCheckerImpl(authenticator, new Fetcher(), "unused_url"),
     authenticator,
     "ropsten",
     ms('10m')).getInstance();

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "compression": "^1.7.4",
     "cors": "^2.8.5",
     "dcl-catalyst-client": "^1.3.11",
-    "dcl-catalyst-commons": "1.3.3",
+    "dcl-catalyst-commons": "^1.4.0",
     "dcl-crypto": "2.2.0",
     "decentraland-commons": "^5.1.0",
     "decentraland-ui": "^2.10.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2489,10 +2489,10 @@ dcl-catalyst-client@^1.3.11:
     ms "^2.1.2"
     multihashing-async "^0.8.1"
 
-dcl-catalyst-commons@1.3.3:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/dcl-catalyst-commons/-/dcl-catalyst-commons-1.3.3.tgz#fb065f731e657c7f97655c86da30f4d75ea5fc3c"
-  integrity sha512-iyzai0X3s+ZsshJfcomKLEtz0yCiVFNGeLPyLHjoA+uWp0VyKlVt9aldN14SA6pUhYbrzt7hhrUvzMwVhcQVOA==
+dcl-catalyst-commons@^1.3.5:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/dcl-catalyst-commons/-/dcl-catalyst-commons-1.3.5.tgz#4e7c5b3b3fc1126123897c7785a6d9c5d0632127"
+  integrity sha512-ISjoK4S4aZLaOJzX7K2lAi2H0WVu2XFSQxkbT+B5pr+NRwfLkdF5LUfZE+4+mPNZlQzxM0U191oM9AdS101itw==
   dependencies:
     "@types/isomorphic-fetch" "0.0.35"
     "@types/ms" "^0.7.31"
@@ -2503,10 +2503,10 @@ dcl-catalyst-commons@1.3.3:
     ms "^2.1.2"
     multihashing-async "^0.8.1"
 
-dcl-catalyst-commons@^1.3.5:
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/dcl-catalyst-commons/-/dcl-catalyst-commons-1.3.5.tgz#4e7c5b3b3fc1126123897c7785a6d9c5d0632127"
-  integrity sha512-ISjoK4S4aZLaOJzX7K2lAi2H0WVu2XFSQxkbT+B5pr+NRwfLkdF5LUfZE+4+mPNZlQzxM0U191oM9AdS101itw==
+dcl-catalyst-commons@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/dcl-catalyst-commons/-/dcl-catalyst-commons-1.4.0.tgz#c7c1a46051e9d07c9bceceadf2e912a5f71b465b"
+  integrity sha512-l2xd4lmQ5AbDfw19+Kc21XHcXVJSWLDKpGLXRHjk2+7vluHMZapV/nnl/AHRHHAJoIuSSk13Jqpc0PWQ/wsjLA==
   dependencies:
     "@types/isomorphic-fetch" "0.0.35"
     "@types/ms" "^0.7.31"


### PR DESCRIPTION
We are now calling the `Fetcher` on `dcl-catalyst-commons` when querying `thegraph`. This fetcher already uses a timeout for requests