### PR TITLE
feat: adding content server snapshots

### DIFF
--- a/content/src/Environment.ts
+++ b/content/src/Environment.ts
@@ -24,6 +24,7 @@ import { MigrationManagerFactory } from "./migrations/MigrationManagerFactory";
 import { DECENTRALAND_ADDRESS } from "decentraland-katalyst-commons/addresses";
 import { SystemPropertiesManagerFactory } from "./service/system-properties/SystemPropertiesManagerFactory";
 import { GarbageCollectionManagerFactory } from "./service/garbage-collection/GarbageCollectionManagerFactory";
+import { SnapshotManagerFactory } from "./service/snapshots/SnapshotManagerFactory";
 
 export const CURRENT_CONTENT_VERSION: EntityVersion = EntityVersion.V3
 const DEFAULT_STORAGE_ROOT_FOLDER = "storage"
@@ -109,6 +110,7 @@ export const enum Bean {
     MIGRATION_MANAGER,
     GARBAGE_COLLECTION_MANAGER,
     SYSTEM_PROPERTIES_MANAGER,
+    SNAPSHOT_MANAGER,
 }
 
 export enum EnvironmentConfig {
@@ -220,6 +222,7 @@ export class EnvironmentBuilder {
         this.registerBeanIfNotAlreadySet(env, Bean.FAILED_DEPLOYMENTS_MANAGER  , () => new FailedDeploymentsManager())
         this.registerBeanIfNotAlreadySet(env, Bean.VALIDATIONS                 , () => ValidationsFactory.create(env))
         this.registerBeanIfNotAlreadySet(env, Bean.SERVICE                     , () => ServiceFactory.create(env))
+        this.registerBeanIfNotAlreadySet(env, Bean.SNAPSHOT_MANAGER            , () => SnapshotManagerFactory.create(env))
         this.registerBeanIfNotAlreadySet(env, Bean.GARBAGE_COLLECTION_MANAGER  , () => GarbageCollectionManagerFactory.create(env))
         this.registerBeanIfNotAlreadySet(env, Bean.EVENT_DEPLOYER              , () => EventDeployerFactory.create(env))
         this.registerBeanIfNotAlreadySet(env, Bean.SYNCHRONIZATION_MANAGER     , () => ClusterSynchronizationManagerFactory.create(env))

--- a/content/src/Environment.ts
+++ b/content/src/Environment.ts
@@ -1,6 +1,6 @@
 import ms from "ms"
 import log4js from "log4js"
-import { EntityVersion } from "dcl-catalyst-commons";
+import { EntityVersion, EntityType } from "dcl-catalyst-commons";
 import { ContentStorageFactory } from "./storage/ContentStorageFactory";
 import { ServiceFactory } from "./service/ServiceFactory";
 import { ControllerFactory } from "./controller/ControllerFactory";
@@ -142,6 +142,7 @@ export enum EnvironmentConfig {
     PSQL_PORT,
     GARBAGE_COLLECTION,
     GARBAGE_COLLECTION_INTERVAL,
+    SNAPSHOT_FREQUENCY,
 }
 
 export class EnvironmentBuilder {
@@ -199,6 +200,7 @@ export class EnvironmentBuilder {
         this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.PSQL_PORT                      , () => process.env.POSTGRES_PORT ?? DEFAULT_DATABASE_CONFIG.port)
         this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.GARBAGE_COLLECTION             , () => process.env.GARBAGE_COLLECTION === 'true')
         this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.GARBAGE_COLLECTION_INTERVAL    , () => ms('6h'))
+        this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.SNAPSHOT_FREQUENCY             , () => new Map([[EntityType.SCENE, 100], [EntityType.PROFILE, 500]]))
 
         // Please put special attention on the bean registration order.
         // Some beans depend on other beans, so the required beans should be registered before

--- a/content/src/controller/Controller.ts
+++ b/content/src/controller/Controller.ts
@@ -346,7 +346,7 @@ export class Controller {
         const metadata = this.snapshotManager.getSnapshotMetadata(type)
 
         if (!metadata) {
-            res.send({ error: 'Snapshot not yet created' })
+            res.status(503).send({ error: 'Snapshot not yet created' })
         } else {
             res.send(metadata)
         }

--- a/content/src/controller/Controller.ts
+++ b/content/src/controller/Controller.ts
@@ -15,6 +15,7 @@ import { ChallengeSupervisor } from "../service/synchronization/ChallengeSupervi
 import { ContentAuthenticator } from "../service/auth/Authenticator";
 import { ControllerDeploymentFactory } from "./ControllerDeploymentFactory";
 import { Deployment, DeploymentPointerChanges } from "../service/deployments/DeploymentManager";
+import { SnapshotManager } from "../service/snapshots/SnapshotManager";
 
 export class Controller {
 
@@ -24,6 +25,7 @@ export class Controller {
         private readonly denylist: Denylist,
         private readonly synchronizationManager: SynchronizationManager,
         private readonly challengeSupervisor: ChallengeSupervisor,
+        private readonly snapshotManager: SnapshotManager,
         private readonly ethNetwork: string) { }
 
     async getEntities(req: express.Request, res: express.Response) {
@@ -327,6 +329,27 @@ export class Controller {
             commitHash: CURRENT_COMMIT_HASH,
             ethNetwork: this.ethNetwork,
          })
+    }
+
+    getSnapshot(req: express.Request, res: express.Response) {
+        // Method: GET
+        // Path: /snapshot/:type
+
+        const type = this.parseEntityType(req.params.type)
+
+        // Validate type is valid
+        if (!type) {
+            res.status(400).send({ error: `Unrecognized type: ${req.params.type}` });
+            return
+        }
+
+        const metadata = this.snapshotManager.getSnapshotMetadata(type)
+
+        if (!metadata) {
+            res.send({ error: 'Snapshot not yet created' })
+        } else {
+            res.send(metadata)
+        }
     }
 
     async addToDenylist(req: express.Request, res: express.Response) {

--- a/content/src/controller/ControllerFactory.ts
+++ b/content/src/controller/ControllerFactory.ts
@@ -6,6 +6,7 @@ import { MetaverseContentService } from "../service/Service";
 import { SynchronizationManager } from "../service/synchronization/SynchronizationManager";
 import { ChallengeSupervisor } from "../service/synchronization/ChallengeSupervisor";
 import { Repository } from "../storage/Repository";
+import { SnapshotManager } from "../service/snapshots/SnapshotManager";
 
 export class ControllerFactory {
     static create(env: Environment): Controller {
@@ -14,11 +15,12 @@ export class ControllerFactory {
         const denylist: Denylist = env.getBean(Bean.DENYLIST);
         const synchronizationManager: SynchronizationManager = env.getBean(Bean.SYNCHRONIZATION_MANAGER);
         const challengeSupervisor: ChallengeSupervisor = env.getBean(Bean.CHALLENGE_SUPERVISOR);
+        const snapshotManager: SnapshotManager = env.getBean(Bean.SNAPSHOT_MANAGER);
         const ethNetwork: string = env.getConfig(EnvironmentConfig.ETH_NETWORK);
         if (denylist && repository) {
-            return new Controller(new DenylistServiceDecorator(service, denylist, repository), denylist, synchronizationManager, challengeSupervisor, ethNetwork);
+            return new Controller(new DenylistServiceDecorator(service, denylist, repository), denylist, synchronizationManager, challengeSupervisor, snapshotManager, ethNetwork);
         } else {
-            return new Controller(service, denylist, synchronizationManager, challengeSupervisor, ethNetwork);
+            return new Controller(service, denylist, synchronizationManager, challengeSupervisor, snapshotManager, ethNetwork);
         }
     }
 }

--- a/content/src/denylist/DenylistServiceDecorator.ts
+++ b/content/src/denylist/DenylistServiceDecorator.ts
@@ -1,5 +1,5 @@
 import { EntityType, Pointer, EntityId, ContentFileHash, ContentFile, Timestamp, DeploymentFilters, PartialDeploymentHistory, ServerStatus, LegacyPartialDeploymentHistory } from "dcl-catalyst-commons";
-import { MetaverseContentService, LocalDeploymentAuditInfo } from "../service/Service";
+import { MetaverseContentService, LocalDeploymentAuditInfo, DeploymentListener } from "../service/Service";
 import { Entity } from "../service/Entity";
 import { Denylist } from "./Denylist";
 import { buildPointerTarget, buildEntityTarget, DenylistTarget, buildContentTarget, buildAddressTarget, DenylistTargetType, DenylistTargetId } from "./DenylistTarget";
@@ -179,6 +179,14 @@ export class DenylistServiceDecorator implements MetaverseContentService {
 
   getStatus(): ServerStatus {
     return this.service.getStatus();
+  }
+
+  storeContent(fileHash: string, content: Buffer): Promise<void> {
+    return this.service.storeContent(fileHash, content)
+  }
+
+  listenToDeployments(listener: DeploymentListener): void {
+    return this.service.listenToDeployments(listener)
   }
 
   private async validateDeployment(denylistRepo: DenylistRepository, files: ContentFile[], entityId: EntityId, auditInfo: LocalDeploymentAuditInfo) {

--- a/content/src/service/Service.ts
+++ b/content/src/service/Service.ts
@@ -3,6 +3,7 @@ import { ContentItem } from "../storage/ContentStorage";
 import { FailureReason, FailedDeployment } from "./errors/FailedDeploymentsManager";
 import { RepositoryTask, Repository } from "../storage/Repository";
 import { Deployment, PartialDeploymentPointerChanges, PointerChangesFilters } from "./deployments/DeploymentManager";
+import { Entity } from "./Entity";
 
 /**x
  * This version of the service can tell clients about the state of the Metaverse. It assumes that all deployments
@@ -15,11 +16,13 @@ export interface MetaverseContentService {
     isContentAvailable(fileHashes: ContentFileHash[]): Promise<Map<ContentFileHash, boolean>>;
     getContent(fileHash: ContentFileHash): Promise<ContentItem | undefined>;
     deleteContent(fileHashes: ContentFileHash[]): Promise<void>;
+    storeContent(fileHash: ContentFileHash, content: Buffer): Promise<void>;
     getStatus(): ServerStatus;
     getLegacyHistory(from?: Timestamp, to?: Timestamp, serverName?: ServerName, offset?: number, limit?: number): Promise<LegacyPartialDeploymentHistory>;
     getDeployments(filters?: DeploymentFilters, offset?: number, limit?: number, repository?: RepositoryTask | Repository): Promise<PartialDeploymentHistory<Deployment>>;
     getAllFailedDeployments(): Promise<FailedDeployment[]>;
     getPointerChanges(filters?: PointerChangesFilters, offset?: number, limit?: number, repository?: RepositoryTask | Repository): Promise<PartialDeploymentPointerChanges>;
+    listenToDeployments(listener: DeploymentListener): void;
 }
 
 /**
@@ -35,3 +38,10 @@ export interface ClusterDeploymentsService {
 }
 
 export type LocalDeploymentAuditInfo = Pick<AuditInfo, 'version'| 'authChain' | 'migrationData'>
+
+export type DeploymentEvent = {
+    entity: Entity,
+    auditInfo: AuditInfo,
+    origin: string,
+}
+export type DeploymentListener = (deployment: DeploymentEvent) => void

--- a/content/src/service/Service.ts
+++ b/content/src/service/Service.ts
@@ -44,4 +44,4 @@ export type DeploymentEvent = {
     auditInfo: AuditInfo,
     origin: string,
 }
-export type DeploymentListener = (deployment: DeploymentEvent) => void
+export type DeploymentListener = (deployment: DeploymentEvent) => void | Promise<void>

--- a/content/src/service/garbage-collection/GarbageCollectionManager.ts
+++ b/content/src/service/garbage-collection/GarbageCollectionManager.ts
@@ -1,9 +1,7 @@
 import log4js from 'log4js'
-import ms from 'ms';
-import { ContentFileHash, Timestamp } from 'dcl-catalyst-commons';
+import { ContentFileHash, Timestamp, delay } from 'dcl-catalyst-commons';
 import { Repository } from "@katalyst/content/storage/Repository";
 import { SystemPropertiesManager, SystemProperty } from "@katalyst/content/service/system-properties/SystemProperties";
-import { delay } from 'decentraland-katalyst-utils/util';
 import { MetaverseContentService } from '../Service';
 
 export class GarbageCollectionManager {
@@ -71,7 +69,7 @@ export class GarbageCollectionManager {
     private waitUntilSyncFinishes(): Promise<void> {
         return new Promise(async (resolve) => {
             while (this.sweeping === true) {
-                await delay(ms('1s'))
+                await delay('1s')
             }
             resolve()
         })

--- a/content/src/service/snapshots/SnapshotManager.ts
+++ b/content/src/service/snapshots/SnapshotManager.ts
@@ -1,0 +1,103 @@
+import log4js from 'log4js'
+import { ContentFileHash, Timestamp, EntityType, Hashing } from 'dcl-catalyst-commons';
+import { Repository, RepositoryTask } from "@katalyst/content/storage/Repository";
+import { SystemPropertiesManager, SystemProperty } from "@katalyst/content/service/system-properties/SystemProperties";
+import { MetaverseContentService } from '../Service';
+import { Entity } from '../Entity';
+
+export class SnapshotManager {
+
+    private static readonly ALLOWED_TYPES: EntityType[] = Object.values(EntityType)
+    private static readonly LOGGER = log4js.getLogger('SnapshotManager');
+    private static readonly FREQUENCY: Map<EntityType, number> = new Map([[EntityType.SCENE, 100], [EntityType.PROFILE, 500]]) // We will generate a snapshot every ${FREQUENCY} deployments
+    private readonly counter: Map<EntityType, number> = new Map()
+    private lastSnapshots: Map<EntityType, SnapshotMetadata> = new Map()
+
+    constructor(
+        private readonly systemPropertiesManager: SystemPropertiesManager,
+        private readonly repository: Repository,
+        private readonly service: MetaverseContentService) {
+            service.listenToDeployments((deployment) => this.onDeployment(deployment))
+        }
+
+    start(): Promise<void> {
+        return this.repository.txIf(async transaction => {
+            this.lastSnapshots = new Map(await this.systemPropertiesManager.getSystemProperty(SystemProperty.LAST_SNAPSHOT, transaction))
+            for (const entityType of SnapshotManager.ALLOWED_TYPES) {
+                const snapshot = this.lastSnapshots.get(entityType)
+                const typeFrequency = this.getFrequencyForType(entityType)
+                if (!snapshot || (await this.deploymentsSince(entityType, snapshot.timestamp, transaction)) > typeFrequency) {
+                    await this.generateSnapshot(entityType, transaction)
+                }
+            }
+        })
+    }
+
+    getSnapshotMetadata(entityType: EntityType): SnapshotMetadata | undefined {
+        return this.lastSnapshots.get(entityType)
+    }
+
+    private async onDeployment({ entity }: { entity: Entity }) {
+        const { type } = entity
+        // Update the counter
+        const updatedCounter = (this.counter.get(type) ?? 0) + 1
+        this.counter.set(type, updatedCounter)
+
+        // If the number of deployments reaches the frequency, then generate a snapshot
+        if (updatedCounter > this.getFrequencyForType(type)) {
+            await this.generateSnapshot(type)
+        }
+    }
+
+    /** This methods queries the database and builds the snapshots, stores it on the content storage, and saves the metadata */
+    private async generateSnapshot(entityType: EntityType, repository: RepositoryTask | Repository = this.repository): Promise<void> {
+
+        const previousSnapshot = this.lastSnapshots.get(entityType)
+
+        await repository.txIf(async transaction => {
+            // Get the active entities
+            const snapshot = await transaction.deployments.getSnapshot(entityType)
+
+            // Calculate the local deployment timestamp of the newest entity in the snapshot
+            const snapshotTimestamp = snapshot[0]?.localTimestamp ?? 0
+
+            // Format the snapshot in a buffer
+            const inArrayFormat = snapshot.map(({ entityId, pointers }) => [entityId, pointers])
+            const buffer = Buffer.from(JSON.stringify(inArrayFormat))
+
+            // Calculate the snapshot's hash
+            const hash = await Hashing.calculateBufferHash(buffer)
+
+            // Store the new snapshot
+            await this.service.storeContent(hash, buffer)
+
+            // Store the metadata
+            await this.storeSnapshotMetadata(entityType, hash, snapshotTimestamp, repository)
+
+            // Reset the counter
+            this.counter.set(entityType, 0)
+
+            // Log
+            SnapshotManager.LOGGER.debug(`Generated snapshot for type: '${entityType}'. It includes ${snapshot.length} active deployments. Last timestamp is ${snapshotTimestamp}`)
+        })
+
+        if (previousSnapshot) {
+            await this.service.deleteContent([ previousSnapshot.hash ])
+        }
+    }
+
+    private deploymentsSince(entityType: EntityType, timestamp: Timestamp, repository: RepositoryTask | Repository = this.repository): Promise<number> {
+        return repository.deployments.deploymentsSince(entityType, timestamp)
+    }
+
+    private storeSnapshotMetadata(entityType: EntityType, hash: ContentFileHash, timestamp: Timestamp, repository: RepositoryTask | Repository = this.repository) {
+        this.lastSnapshots.set(entityType, { hash, timestamp })
+        return this.systemPropertiesManager.setSystemProperty(SystemProperty.LAST_SNAPSHOT, Array.from(this.lastSnapshots.entries()), repository)
+    }
+
+    private getFrequencyForType(entityType: EntityType): number {
+        return SnapshotManager.FREQUENCY.get(entityType) ?? 100
+    }
+}
+
+export type SnapshotMetadata = { hash: ContentFileHash, timestamp: Timestamp }

--- a/content/src/service/snapshots/SnapshotManagerFactory.ts
+++ b/content/src/service/snapshots/SnapshotManagerFactory.ts
@@ -1,0 +1,12 @@
+import { Environment, Bean } from "@katalyst/content/Environment";
+import { SnapshotManager } from "./SnapshotManager";
+
+export class SnapshotManagerFactory {
+
+    static create(env: Environment): SnapshotManager {
+        return new SnapshotManager(
+            env.getBean(Bean.SYSTEM_PROPERTIES_MANAGER),
+            env.getBean(Bean.REPOSITORY),
+            env.getBean(Bean.SERVICE))
+    }
+}

--- a/content/src/service/snapshots/SnapshotManagerFactory.ts
+++ b/content/src/service/snapshots/SnapshotManagerFactory.ts
@@ -1,4 +1,4 @@
-import { Environment, Bean } from "@katalyst/content/Environment";
+import { Environment, Bean, EnvironmentConfig } from "@katalyst/content/Environment";
 import { SnapshotManager } from "./SnapshotManager";
 
 export class SnapshotManagerFactory {
@@ -7,6 +7,7 @@ export class SnapshotManagerFactory {
         return new SnapshotManager(
             env.getBean(Bean.SYSTEM_PROPERTIES_MANAGER),
             env.getBean(Bean.REPOSITORY),
-            env.getBean(Bean.SERVICE))
+            env.getBean(Bean.SERVICE),
+            env.getConfig(EnvironmentConfig.SNAPSHOT_FREQUENCY))
     }
 }

--- a/content/src/service/system-properties/SystemProperties.ts
+++ b/content/src/service/system-properties/SystemProperties.ts
@@ -6,7 +6,7 @@ import { SnapshotMetadata } from "../snapshots/SnapshotManager";
 export class SystemProperty<PropertyType> {
 
     static readonly LAST_KNOWN_LOCAL_DEPLOYMENTS: SystemProperty<[ServerAddress, Timestamp][] > = new SystemProperty('last_known_local_deployments', new JSONPropertyMapper())
-    static readonly LAST_SNAPSHOT: SystemProperty<[EntityType, SnapshotMetadata][]> = new SystemProperty('last_snapshot', new JSONPropertyMapper())
+    static readonly LAST_SNAPSHOTS: SystemProperty<[EntityType, SnapshotMetadata][]> = new SystemProperty('last_snapshot', new JSONPropertyMapper())
     static readonly LAST_GARBAGE_COLLECTION_TIME: SystemProperty<Timestamp> = new SystemProperty('last_garbage_collection_time', new IntPropertyMapper())
 
     constructor(

--- a/content/src/service/system-properties/SystemProperties.ts
+++ b/content/src/service/system-properties/SystemProperties.ts
@@ -1,10 +1,12 @@
-import { Timestamp, ServerAddress } from "dcl-catalyst-commons";
+import { Timestamp, ServerAddress, EntityType } from "dcl-catalyst-commons";
 import { Repository, RepositoryTask } from "@katalyst/content/storage/Repository";
 import { IntPropertyMapper, SystemPropertyMapper, JSONPropertyMapper } from "./SystemPropertyMappers";
+import { SnapshotMetadata } from "../snapshots/SnapshotManager";
 
 export class SystemProperty<PropertyType> {
 
     static readonly LAST_KNOWN_LOCAL_DEPLOYMENTS: SystemProperty<[ServerAddress, Timestamp][] > = new SystemProperty('last_known_local_deployments', new JSONPropertyMapper())
+    static readonly LAST_SNAPSHOT: SystemProperty<[EntityType, SnapshotMetadata][]> = new SystemProperty('last_snapshot', new JSONPropertyMapper())
     static readonly LAST_GARBAGE_COLLECTION_TIME: SystemProperty<Timestamp> = new SystemProperty('last_garbage_collection_time', new IntPropertyMapper())
 
     constructor(

--- a/content/src/storage/repositories/DeploymentsRepository.ts
+++ b/content/src/storage/repositories/DeploymentsRepository.ts
@@ -1,5 +1,5 @@
 import { Authenticator } from 'dcl-crypto';
-import { EntityId, AuditInfo } from 'dcl-catalyst-commons';
+import { EntityId, AuditInfo, EntityType, Timestamp, Pointer } from 'dcl-catalyst-commons';
 import { Entity } from '@katalyst/content/service/Entity';
 import { Repository } from '@katalyst/content/storage/Repository';
 import { ExtendedDeploymentFilters } from '@katalyst/content/service/deployments/DeploymentManager';
@@ -127,6 +127,30 @@ export class DeploymentsRepository {
             localTimestamp: row.local_timestamp,
             overwrittenBy: row.overwritten_by ?? undefined
         }))
+    }
+
+    getSnapshot(entityType: EntityType): Promise<{ entityId: EntityId, pointers: Pointer[], localTimestamp: Timestamp}[]> {
+        return this.db.map(`
+            SELECT
+                entity_id,
+                entity_pointers,
+                date_part('epoch', local_timestamp) * 1000 AS local_timestamp
+            FROM deployments
+            WHERE entity_type = $1 AND deleter_deployment IS NULL
+            ORDER BY local_timestamp DESC, entity_id DESC
+            `, [entityType], row => ({
+                entityId: row.entity_id,
+                pointers: row.entity_pointers,
+                localTimestamp: row.local_timestamp,
+            }))
+    }
+
+    deploymentsSince(entityType: EntityType, timestamp: Timestamp): Promise<number> {
+        return this.db.one(`
+            SELECT COUNT(*) AS count
+            FROM deployments
+            WHERE entity_type = $1 AND local_timestamp > to_timestamp($2 / 1000.0)`,
+            [entityType, timestamp], row => row.count)
     }
 
     saveDeployment(entity: Entity, auditInfo: AuditInfo, overwrittenBy: DeploymentId | null): Promise<DeploymentId> {

--- a/content/test/helpers/service/MockedMetaverseContentService.ts
+++ b/content/test/helpers/service/MockedMetaverseContentService.ts
@@ -1,6 +1,6 @@
 import { random } from "faker"
 import { ServerStatus, DeploymentFilters, PartialDeploymentHistory, EntityType, EntityId, ContentFile, Timestamp, Pointer, ContentFileHash, LegacyPartialDeploymentHistory, AuditInfo, LegacyAuditInfo } from "dcl-catalyst-commons"
-import { MetaverseContentService, LocalDeploymentAuditInfo } from "@katalyst/content/service/Service"
+import { MetaverseContentService, LocalDeploymentAuditInfo, DeploymentListener } from "@katalyst/content/service/Service"
 import { Entity } from "@katalyst/content/service/Entity"
 import { buildEntityAndFile } from "./EntityTestFactory"
 import { CURRENT_CONTENT_VERSION } from "@katalyst/content/Environment"
@@ -106,6 +106,13 @@ export class MockedMetaverseContentService implements MetaverseContentService {
     }
 
     getAllFailedDeployments(): Promise<FailedDeployment[]> {
+        throw new Error("Method not implemented.")
+    }
+
+    storeContent(fileHash: string, content: Buffer): Promise<void> {
+        throw new Error("Method not implemented.")
+    }
+    listenToDeployments(listener: DeploymentListener): void {
         throw new Error("Method not implemented.")
     }
 

--- a/content/test/helpers/service/snapshots/NoOpGarbageCollectionManager.ts
+++ b/content/test/helpers/service/snapshots/NoOpGarbageCollectionManager.ts
@@ -1,0 +1,11 @@
+import { mock, instance, when } from "ts-mockito"
+import { SnapshotManager } from "@katalyst/content/service/snapshots/SnapshotManager"
+
+export class NoOpSnapshotManager {
+
+    static build(): SnapshotManager {
+        const mockedManager: SnapshotManager = mock(SnapshotManager)
+        when(mockedManager.start()).thenReturn(Promise.resolve())
+        return instance(mockedManager)
+    }
+}

--- a/content/test/integration/E2ETestUtils.ts
+++ b/content/test/integration/E2ETestUtils.ts
@@ -76,10 +76,13 @@ export function awaitUntil(evaluation: () => Promise<any>, attempts: number = 10
     return retry(evaluation, attempts, 'perform assertion', waitBetweenAttempts)
 }
 
-export async function deployEntitiesCombo(service: MetaverseContentService, ...entitiesCombo: EntityCombo[]) {
+/** Returns the deployment timestamp of the last deployed entity */
+export async function deployEntitiesCombo(service: MetaverseContentService, ...entitiesCombo: EntityCombo[]): Promise<Timestamp> {
+    let timestamp: Timestamp = 0
     for (const { deployData } of entitiesCombo) {
-        await service.deployEntity(Array.from(deployData.files.values()), deployData.entityId, { authChain: deployData.authChain, version: EntityVersion.V2 }, '')
+        timestamp = await service.deployEntity(Array.from(deployData.files.values()), deployData.entityId, { authChain: deployData.authChain, version: EntityVersion.V2 }, '')
     }
+    return timestamp
 }
 
 export type DeployData = {

--- a/content/test/integration/Server.spec.ts
+++ b/content/test/integration/Server.spec.ts
@@ -11,6 +11,7 @@ import { NoOpMigrationManager } from "@katalyst/test-helpers/NoOpMigrationManage
 import { NoOpGarbageCollectionManager } from "@katalyst/test-helpers/service/garbage-collection/NoOpGarbageCollectionManager"
 import { DeploymentPointerChanges } from "@katalyst/content/service/deployments/DeploymentManager"
 import { ControllerPointerChanges } from "@katalyst/content/controller/Controller"
+import { NoOpSnapshotManager } from "@katalyst/test-helpers/service/snapshots/NoOpGarbageCollectionManager"
 
 describe("Integration - Server", function() {
     let server: Server
@@ -33,6 +34,7 @@ describe("Integration - Server", function() {
             .registerBean(Bean.SYNCHRONIZATION_MANAGER, new MockedSynchronizationManager())
             .registerBean(Bean.MIGRATION_MANAGER, new NoOpMigrationManager())
             .registerBean(Bean.GARBAGE_COLLECTION_MANAGER, NoOpGarbageCollectionManager.build())
+            .registerBean(Bean.SNAPSHOT_MANAGER, NoOpSnapshotManager.build())
             .setConfig(EnvironmentConfig.SERVER_PORT, port)
             .setConfig(EnvironmentConfig.LOG_LEVEL, 'debug')
 

--- a/content/test/integration/service/snapshots/SnapshotManager.spec.ts
+++ b/content/test/integration/service/snapshots/SnapshotManager.spec.ts
@@ -1,0 +1,98 @@
+import { EntityType, EntityId, Pointer } from "dcl-catalyst-commons";
+import { loadTestEnvironment } from "../../E2ETestEnvironment";
+import { MetaverseContentService } from "@katalyst/content/service/Service";
+import { EnvironmentBuilder, Bean, EnvironmentConfig } from "@katalyst/content/Environment";
+import { NoOpValidations } from "@katalyst/test-helpers/service/validations/NoOpValidations";
+import { EntityCombo, buildDeployData, buildDeployDataAfterEntity, deployEntitiesCombo } from "../../E2ETestUtils";
+import { SnapshotManager, SnapshotMetadata } from "@katalyst/content/service/snapshots/SnapshotManager";
+
+describe("Integration - Snapshot Manager", () => {
+
+    const P1 = "X1,Y1", P2 = "X2,Y2"
+    let E1: EntityCombo, E2: EntityCombo, E3: EntityCombo
+
+    const testEnv = loadTestEnvironment()
+    let service: MetaverseContentService
+    let snapshotManager: SnapshotManager
+
+    beforeAll(async () => {
+        E1 = await buildDeployData([P1], { type: EntityType.SCENE })
+        E2 = await buildDeployDataAfterEntity(E1, [P2], { type: EntityType.SCENE });
+        E3 = await buildDeployDataAfterEntity(E2, [P1]), { type: EntityType.SCENE };
+    })
+
+    beforeEach(async () => {
+        const baseEnv = await testEnv.getEnvForNewDatabase()
+        const env = await new EnvironmentBuilder(baseEnv)
+            .withConfig(EnvironmentConfig.SNAPSHOT_FREQUENCY, new Map([[EntityType.SCENE, 3]]))
+            .withConfig(EnvironmentConfig.LOG_LEVEL, 'debug')
+            .withBean(Bean.VALIDATIONS, new NoOpValidations())
+            .build()
+
+        service = env.getBean(Bean.SERVICE)
+        snapshotManager = env.getBean(Bean.SNAPSHOT_MANAGER)
+    })
+
+    it(`When snapshot manager starts, then a snapshot is generated if there wasn't one`, async () => {
+        // Deploy E1 and E2
+        const lastDeploymentTimestamp = await deployEntitiesCombo(service, E1, E2)
+
+        // Assert there is no snapshot
+        expect(snapshotManager.getSnapshotMetadata(EntityType.SCENE)).toBeUndefined()
+
+        // Start the snapshot manager
+        await snapshotManager.start()
+
+        // Assert snapshot was created
+        const snapshotMetadata = snapshotManager.getSnapshotMetadata(EntityType.SCENE)
+        expect(snapshotMetadata).toBeDefined()
+        expect(snapshotMetadata!!.lastIncludedDeploymentTimestamp).toEqual(lastDeploymentTimestamp)
+
+        // Assert snapshot content is correct
+        await assertSnapshotContains(snapshotMetadata, E1, E2)
+    })
+
+    it(`When snapshot manager starts, if there were no entities deployed, then the generated snapshot is empty`, async () => {
+        // Assert there is no snapshot
+        expect(snapshotManager.getSnapshotMetadata(EntityType.SCENE)).toBeUndefined()
+
+        // Start the snapshot manager
+        await snapshotManager.start()
+
+        // Assert snapshot was created
+        const snapshotMetadata = snapshotManager.getSnapshotMetadata(EntityType.SCENE)
+        expect(snapshotMetadata).toBeDefined()
+        expect(snapshotMetadata!!.lastIncludedDeploymentTimestamp).toEqual(0)
+
+        // Assert snapshot content is empty
+        await assertSnapshotContains(snapshotMetadata)
+    })
+
+    it(`When snapshot manager learns that the frequency of deployments is reached, then a new snapshot is generated`, async () => {
+        // Start the snapshot manager
+        await snapshotManager.start()
+
+        // Deploy E1, E2 and E3
+        const lastDeploymentTimestamp = await deployEntitiesCombo(service, E1, E2, E3)
+
+        // Assert snapshot was created
+        const snapshotMetadata = snapshotManager.getSnapshotMetadata(EntityType.SCENE)
+        expect(snapshotMetadata).toBeDefined()
+        expect(snapshotMetadata!!.lastIncludedDeploymentTimestamp).toEqual(lastDeploymentTimestamp)
+
+        // Assert snapshot content is empty
+        await assertSnapshotContains(snapshotMetadata, E2, E3)
+    })
+
+    async function assertSnapshotContains(snapshotMetadata: SnapshotMetadata | undefined, ...entitiesCombo: EntityCombo[]) {
+        const { hash } = snapshotMetadata!!
+        const content = (await service.getContent(hash))!!
+        const buffer = await content.asBuffer()
+        const snapshot: Map<EntityId, Pointer[]> = new Map(JSON.parse(buffer.toString()))
+        expect(snapshot.size).toBe(entitiesCombo.length)
+        for (const { entity } of entitiesCombo) {
+            expect(snapshot.get(entity.id)).toEqual(entity.pointers)
+        }
+    }
+
+})


### PR DESCRIPTION
We are now adding snapshots. These can be defined as a list of all the active entities on the content server, at a given time. By active, we mean entities that are currently referenced by at least one pointer.

Every N deployments (N depends on the entity type) we will create a snapshot, and add it to the storage. Snapshots will be a text file with a JSON array with the following type: `[EntityId, Pointer[]][]`. The good part about this, is that you could easy read this file into an ES6 Map like this:
```
const fileContent: Buffer = fs.readFile(...)
const array: [EntityId, Pointer[]][] = JSON.parse(fileContent.toString())
const asMap: Map<EntityId, Pointer[]> = new Map(array)
```

Then, we will expose a `/snapshot` endpoint that displays the hash of the latest snapshot, and the local deployment timestamp of the last deployment that was included in the snapshot