### PR TITLE
chore: Enable docker image to be built on other OS than linux

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,5 +2,8 @@ dist
 bazel-out
 .git
 .gitignore
+.vscode
+node_modules
 *.log
-
+tmpbin
+comms/performance-test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,30 @@
 FROM node:12.18.1-slim
 
+RUN apt-get update && \
+    apt-get upgrade -yq && \
+    apt-get install -yq yarn git zlib1g zlib1g-dev
+
 WORKDIR /app
 
-ADD tmpbin .
 COPY entrypoint.sh .
+
+WORKDIR /app/build
+
+COPY . .
+
+# The following are all collapsed to reduce image size
+RUN yarn install &&\
+ yarn bazel clean &&\
+ yarn bazel build //comms/lighthouse:server &&\
+ yarn bazel build //content:server &&\
+ yarn bazel build //lambdas:server &&\
+ cp -L -R dist/bin/ ../bin &&\
+ yarn bazel clean --expunge && yarn cache clean &&\
+ cd .. &&\
+ rm -rf build &&\
+ rm -rf /root/.cache/bazel
+
+WORKDIR /app
 
 ENV COMMIT_HASH=bc34832282cfa746cfb1f27184cf3b53f321a164
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -eo pipefail
 
+cd bin
+
 if [ "$1" = 'comms' ]; then
     cd comms/lighthouse
 elif [ "$1" == 'content' ]; then

--- a/prepare_for_docker_image.sh
+++ b/prepare_for_docker_image.sh
@@ -1,15 +1,4 @@
-rm -rf tmpbin
-
 set -e
-
-yarn install
-
-yarn bazel clean
-yarn bazel build //comms/lighthouse:server && \
-  yarn bazel build //content:server && \
-  yarn bazel build //lambdas:server
-
-cp -L -R dist/bin/ tmpbin
 
 commit_hash=`git rev-parse HEAD`
 


### PR DESCRIPTION
Now docker image is built inside docker context, so it can be built on any OS that supports docker