### PR TITLE
fix: encode peer id when leaving room

### DIFF
--- a/comms/peer/src/Peer.ts
+++ b/comms/peer/src/Peer.ts
@@ -671,7 +671,7 @@ export class Peer implements IPeer {
   async leaveRoom(roomId: string) {
     this.assertPeerInLayer();
 
-    await this.httpClient.fetch(`/layers/${this.currentLayer}/rooms/${roomId}/users/${this.peerIdOrFail()}`, { method: "DELETE" });
+    await this.httpClient.fetch(`/layers/${this.currentLayer}/rooms/${roomId}/users/${encodeURI(this.peerIdOrFail())}`, { method: "DELETE" });
 
     const index = this.currentRooms.findIndex((room) => room.id === roomId);
 

--- a/comms/peer/test/Peer.integration.spec.ts
+++ b/comms/peer/test/Peer.integration.spec.ts
@@ -184,11 +184,11 @@ describe("Peer Integration Test", function () {
           const segments = url.pathname.split("/");
           if (segments.length === 7) {
             const roomId = segments[segments.length - 3];
-            const userId = segments[segments.length - 1];
+            const userId = decodeURI(segments[segments.length - 1]);
             return leaveRoom(userId, roomId);
           } else {
             const layerId = segments[segments.length - 3];
-            const userId = segments[segments.length - 1];
+            const userId = decodeURI(segments[segments.length - 1]);
             return leaveLayer(userId, layerId);
           }
         }
@@ -341,6 +341,22 @@ describe("Peer Integration Test", function () {
     expect(peer.currentRooms.length).toBe(0);
   });
 
+  it("leaves a room successfully using a URI clashing peer id", async () => {
+    const [socket, mock] = await createPeer("mock");
+    await mock.joinRoom("room");
+
+    const [, peer] = await createPeer("peer%", layer, [socket]);
+
+    await peer.joinRoom("room");
+
+    expectPeerToBeInRoomWith(peer, "room", mock);
+
+    await peer.leaveRoom("room");
+
+    expect(roomPeers["room"].length).toBe(1);
+    expect(peer.currentRooms.length).toBe(0);
+  });
+
   it("leaves a room idempotently", async () => {
     const [, peer] = await createPeer("peer");
 
@@ -402,7 +418,7 @@ describe("Peer Integration Test", function () {
       socketBuilder: () => socket,
     });
 
-    socket.onmessage({data: JSON.stringify({ type: ServerMessageType.AssignedId, payload: { id: "assigned" } })});
+    socket.onmessage({ data: JSON.stringify({ type: ServerMessageType.AssignedId, payload: { id: "assigned" } }) });
 
     expect(peer.peerIdOrFail()).toBe("assigned");
   });

--- a/version.bzl
+++ b/version.bzl
@@ -1,3 +1,3 @@
 # NOTE: If you change the format of this line, you must change the bash command
 # in /scripts/publish to extract the version string correctly.
-LH_VERSION = "0.2.14"
+LH_VERSION = "0.2.15"


### PR DESCRIPTION
Encodes peer id as URI when doing an HTTP request to leave a room to avoid issues with potential special characters in the id alphabet (e.g. %) that were causing errors in the client.

