### PR TITLE
fix: clear pointer blocker with errors

### DIFF
--- a/content/src/storage/FileSystemContentStorage.ts
+++ b/content/src/storage/FileSystemContentStorage.ts
@@ -15,9 +15,13 @@ export class FileSystemContentStorage implements ContentStorage {
         return new FileSystemContentStorage(root)
     }
 
-    store(id: string, content: StorageContent): Promise<void> {
+    async store(id: string, content: StorageContent): Promise<void> {
         if (content.path) {
-            return fs.promises.rename(content.path, this.getFilePath(id))
+            try {
+                return await fs.promises.rename(content.path, this.getFilePath(id))
+            } catch {
+                // Failed to move the file. Will try to write it instead
+            }
         }
         return fs.promises.writeFile(this.getFilePath(id), content.data)
     }

--- a/content/test/integration/service/concurrent-deployments.spec.ts
+++ b/content/test/integration/service/concurrent-deployments.spec.ts
@@ -28,7 +28,7 @@ describe("Integration - Concurrent deployments", () => {
         service = await testEnv.buildService()
     })
 
-    fit(`When deployments are executed concurrently, then only one remains active`, async () => {
+    it(`When deployments are executed concurrently, then only one remains active`, async () => {
         // Perform all the deployments concurrently
         await Promise.all(entities.map(entityCombo => deployEntity(entityCombo)))
 

--- a/content/test/integration/service/concurrent-deployments.spec.ts
+++ b/content/test/integration/service/concurrent-deployments.spec.ts
@@ -28,7 +28,7 @@ describe("Integration - Concurrent deployments", () => {
         service = await testEnv.buildService()
     })
 
-    it(`When deployments are executed concurrently, then only one remains active`, async () => {
+    fit(`When deployments are executed concurrently, then only one remains active`, async () => {
         // Perform all the deployments concurrently
         await Promise.all(entities.map(entityCombo => deployEntity(entityCombo)))
 


### PR DESCRIPTION
We are making the content server more reliable, as we are handling unexpected errors when:
* Moving a file
* A deployment fails