### PR TITLE
chore: NPM link support for peer library & added packet to packet callback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ yarn-error.log
 local/certbot/conf/**
 local/nginx/conf.d/00-katalyst.conf
 tmpbin
+linked-peer-package

--- a/comms/peer/src/Peer.ts
+++ b/comms/peer/src/Peer.ts
@@ -730,7 +730,7 @@ export class Peer implements IPeer {
     const messageData = packet.messageData;
     if (messageData) {
       if (this.isInRoom(messageData.room)) {
-        this.callback(packet.src, messageData.room, this.decodePayload(messageData.payload, messageData.encoding));
+        this.callback(packet.src, messageData.room, this.decodePayload(messageData.payload, messageData.encoding), packet);
       }
     }
 

--- a/comms/peer/src/PeerWebRTCHandler.ts
+++ b/comms/peer/src/PeerWebRTCHandler.ts
@@ -460,8 +460,8 @@ export class PeerWebRTCHandler extends EventEmitter<PeerWebRTCEvent> {
   sendPacketToPeer(peerId: string, data: Uint8Array) {
     const conn = this.connectedPeers[peerId]?.connection;
     if (conn) {
+      conn.send(data);
     }
-    conn.send(data);
   }
 
   private log(level: LogLevel, ...entries: any[]) {

--- a/comms/peer/src/types.ts
+++ b/comms/peer/src/types.ts
@@ -2,6 +2,7 @@ import { PeerMessageType } from "./messageTypes";
 import { Position } from "../../../commons/utils/Positions";
 import { SocketBuilder } from "./peerjs-server-connector/socket";
 import SimplePeer from "simple-peer";
+import { Packet } from "./proto/peer_protobuf";
 
 type PacketSubtypeData = {
   lastTimestamp: number;
@@ -29,7 +30,7 @@ export interface IPeer {
   peerIdOrFail(): string;
   currentRooms: Room[];
   logLevel: LogLevelString;
-  callback: (sender: string, room: string, payload: any) => void;
+  callback: PacketCallback;
   setLayer(layer: string): Promise<void>;
   joinRoom(room: string): Promise<void>;
   leaveRoom(roomId: string): Promise<void>;
@@ -125,7 +126,7 @@ export type PositionConfig = {
   disconnectDistance?: number;
 };
 
-export type PacketCallback = (sender: string, room: string, payload: any) => void;
+export type PacketCallback = (sender: string, room: string, payload: any, packet: Packet) => void;
 
 export type ReceivedRelayData = {
   hops: number;

--- a/npm-link-peer.sh
+++ b/npm-link-peer.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+BUILD_OUTPUT=$(yarn bazel run //comms/peer:package.pack 2>&1)
+
+REGEX='(decentraland-katalyst-peer-[0-9]*\.[0-9]*\.[0-9]*\.tgz)'
+
+if [[ $BUILD_OUTPUT =~ $REGEX ]] ; then
+    ZIP_FILENAME=${BASH_REMATCH[1]}
+    rm -rf linked-peer-package
+    tar -xzvf $ZIP_FILENAME
+    rm $ZIP_FILENAME
+    mv package linked-peer-package
+    cd linked-peer-package
+    npm link
+fi
+

--- a/npm-link-peer.sh
+++ b/npm-link-peer.sh
@@ -1,16 +1,24 @@
 #!/bin/bash
 
-BUILD_OUTPUT=$(yarn bazel run //comms/peer:package.pack 2>&1)
+show_separator() {
+    printf "\n------------------------------------------------------------\n$1\n------------------------------------------------------------\n"
+}
+
+show_separator "Building peer package..."
+
+BUILD_OUTPUT=$(yarn bazel run //comms/peer:package.pack 2>&1 | tee /dev/tty)
 
 REGEX='(decentraland-katalyst-peer-[0-9]*\.[0-9]*\.[0-9]*\.tgz)'
 
 if [[ $BUILD_OUTPUT =~ $REGEX ]] ; then
     ZIP_FILENAME=${BASH_REMATCH[1]}
     rm -rf linked-peer-package
+    show_separator "Unziping ${ZIP_FILENAME}"
     tar -xzvf $ZIP_FILENAME
     rm $ZIP_FILENAME
     mv package linked-peer-package
     cd linked-peer-package
+    show_separator "Making NPM Link"
     npm link
 fi
 


### PR DESCRIPTION
To be able to develop Peer library with Explorer more easily, added a script to create an NPM link.

Also added the low-level packet to packet callback. This can be useful if there is some information that the user of the peer library needs to use in the callback (for instance, the sequence id).