### PR TITLE
fix: handle concurrent requests correctly

### DIFF
--- a/content/src/service/ServiceImpl.ts
+++ b/content/src/service/ServiceImpl.ts
@@ -96,106 +96,108 @@ export class ServiceImpl implements MetaverseContentService, ClusterDeploymentsS
         // Validate the entity's content property
         validation.validateContent(entity, hashes, alreadyStoredContent, validationContext)
 
-        const { auditInfoComplete, wasEntityDeployed } = await repository.txIf(async transaction => {
-            const isEntityAlreadyDeployed = await this.isEntityAlreadyDeployed(entityId, transaction)
-
-            // Validate if the entity can be re deployed
-            await validation.validateThatEntityCanBeRedeployed(isEntityAlreadyDeployed, validationContext)
-
-            // Validate that there is no entity with a higher version
-            await validation.validateLegacyEntity(entity, auditInfo, (filters) => this.getDeployments(filters, undefined, undefined, transaction), validationContext)
-
-            // Validate that there are no newer entities on pointers
-            await validation.validateNoNewerEntitiesOnPointers(entity, (entity: Entity) => this.areThereNewerEntitiesOnPointers(entity, transaction), validationContext)
-
-            // Validate that if the entity was already deployed, the status it was left is what we expect
-            await validation.validateThatEntityFailedBefore(entity, (type, id) => this.failedDeploymentsManager.getDeploymentStatus(transaction.failedDeployments, type, id), validationContext)
-
-            if (validation.getErrors().length > 0) {
-                throw new Error(validation.getErrors().join('\n'))
-            }
-
-            // Validate that the entity's pointers are not being modified by a concurrent transaction
-            const pointersCurrentlyBeingDeployed = this.pointersBeingDeployed.get(entity.type) ?? new Set()
-            const overlappingPointers = entity.pointers.filter(pointer => pointersCurrentlyBeingDeployed.has(pointer))
-            if (overlappingPointers.length > 0) {
-                throw new Error(`The following pointers are currently being deployed: '${overlappingPointers.join()}'. Please try again in a few seconds.`)
-            }
-
-            // Update the current list of pointers being deployed
-            entity.pointers.forEach(pointer => pointersCurrentlyBeingDeployed.add(pointer))
-            this.pointersBeingDeployed.set(entity.type, pointersCurrentlyBeingDeployed)
-            try {
-                const localTimestamp = Date.now()
-
-                let auditInfoComplete: AuditInfo;
-
-                if (fix) {
-                    const failedDeployment = (await this.failedDeploymentsManager.getFailedDeployment(transaction.failedDeployments, entity.type, entity.id))!!
-                    auditInfoComplete = {
-                        ...auditInfo,
-                        originTimestamp: failedDeployment.originTimestamp,
-                        originServerUrl: failedDeployment.originServerUrl,
-                        localTimestamp,
-                    }
-                } else {
-                    auditInfoComplete = {
-                        originTimestamp: localTimestamp,
-                        originServerUrl: this.identityProvider.getIdentityInDAO()?.address ?? 'https://peer.decentraland.org/content',
-                        ...auditInfo,
-                        localTimestamp,
-                    }
-                }
-
-                if (!isEntityAlreadyDeployed) {
-                    // IF THIS POINT WAS REACHED, THEN THE DEPLOYMENT WILL BE COMMITTED
-
-                    // Calculate overwrites
-                    const { overwrote, overwrittenBy } = await this.pointerManager.calculateOverwrites(transaction.pointerHistory, entity)
-
-                    // Store the deployment
-                    const deploymentId = await this.deploymentManager.saveDeployment(transaction.deployments, transaction.migrationData, transaction.content, entity, auditInfoComplete, overwrittenBy)
-
-                    // Modify active pointers
-                    const result = await this.pointerManager.referenceEntityFromPointers(transaction.lastDeployedPointers, deploymentId, entity)
-
-                    // Save deployment pointer changes
-                    await this.deploymentManager.savePointerChanges(transaction.deploymentPointerChanges, deploymentId, result)
-
-                    // Add to pointer history
-                    await this.pointerManager.addToHistory(transaction.pointerHistory, deploymentId, entity)
-
-                    // Set who overwrote who
-                    await this.deploymentManager.setEntitiesAsOverwritten(transaction.deployments, overwrote, deploymentId)
-
-                    // Store the entity's content
-                    await this.storeEntityContent(hashes, alreadyStoredContent)
-
-                    // Since we are still reporting the history size, add one to it
-                    await this.historyManager.reportDeployment(transaction.deployments)
-
-                }
-
-                // Mark deployment as successful (this does nothing it if hadn't failed on the first place)
-                await this.failedDeploymentsManager.reportSuccessfulDeployment(transaction.failedDeployments, entity.type, entity.id)
-
-                return { auditInfoComplete, wasEntityDeployed: !isEntityAlreadyDeployed }
-            } catch (error) {
-                throw error
-            } finally {
-                // Update the current list of pointers being deployed
-                const pointersCurrentlyBeingDeployed = this.pointersBeingDeployed.get(entity.type)!!
-                entity.pointers.forEach(pointer => pointersCurrentlyBeingDeployed.delete(pointer))
-            }
-        })
-
-        // Report deployment to listeners
-        if (wasEntityDeployed) {
-            await Promise.all(this.listeners.map(listener => listener({ entity, auditInfo: auditInfoComplete, origin })))
+        // Validate that the entity's pointers are not being modified by a concurrent transaction
+        const pointersCurrentlyBeingDeployed = this.pointersBeingDeployed.get(entity.type) ?? new Set()
+        const overlappingPointers = entity.pointers.filter(pointer => pointersCurrentlyBeingDeployed.has(pointer))
+        if (overlappingPointers.length > 0) {
+            throw new Error(`The following pointers are currently being deployed: '${overlappingPointers.join()}'. Please try again in a few seconds.`)
         }
 
-        return auditInfoComplete.localTimestamp
+        // Update the current list of pointers being deployed
+        entity.pointers.forEach(pointer => pointersCurrentlyBeingDeployed.add(pointer))
+        this.pointersBeingDeployed.set(entity.type, pointersCurrentlyBeingDeployed)
+        try {
+            const { auditInfoComplete, wasEntityDeployed } = await repository.txIf(async transaction => {
+                const isEntityAlreadyDeployed = await this.isEntityAlreadyDeployed(entityId, transaction)
 
+                // Validate if the entity can be re deployed
+                await validation.validateThatEntityCanBeRedeployed(isEntityAlreadyDeployed, validationContext)
+
+                // Validate that there is no entity with a higher version
+                await validation.validateLegacyEntity(entity, auditInfo, (filters) => this.getDeployments(filters, undefined, undefined, transaction), validationContext)
+
+                // Validate that there are no newer entities on pointers
+                await validation.validateNoNewerEntitiesOnPointers(entity, (entity: Entity) => this.areThereNewerEntitiesOnPointers(entity, transaction), validationContext)
+
+                // Validate that if the entity was already deployed, the status it was left is what we expect
+                await validation.validateThatEntityFailedBefore(entity, (type, id) => this.failedDeploymentsManager.getDeploymentStatus(transaction.failedDeployments, type, id), validationContext)
+
+                if (validation.getErrors().length > 0) {
+                    throw new Error(validation.getErrors().join('\n'))
+                }
+
+                try {
+                    const localTimestamp = Date.now()
+
+                    let auditInfoComplete: AuditInfo;
+
+                    if (fix) {
+                        const failedDeployment = (await this.failedDeploymentsManager.getFailedDeployment(transaction.failedDeployments, entity.type, entity.id))!!
+                        auditInfoComplete = {
+                            ...auditInfo,
+                            originTimestamp: failedDeployment.originTimestamp,
+                            originServerUrl: failedDeployment.originServerUrl,
+                            localTimestamp,
+                        }
+                    } else {
+                        auditInfoComplete = {
+                            originTimestamp: localTimestamp,
+                            originServerUrl: this.identityProvider.getIdentityInDAO()?.address ?? 'https://peer.decentraland.org/content',
+                            ...auditInfo,
+                            localTimestamp,
+                        }
+                    }
+
+                    if (!isEntityAlreadyDeployed) {
+                        // IF THIS POINT WAS REACHED, THEN THE DEPLOYMENT WILL BE COMMITTED
+
+                        // Calculate overwrites
+                        const { overwrote, overwrittenBy } = await this.pointerManager.calculateOverwrites(transaction.pointerHistory, entity)
+
+                        // Store the deployment
+                        const deploymentId = await this.deploymentManager.saveDeployment(transaction.deployments, transaction.migrationData, transaction.content, entity, auditInfoComplete, overwrittenBy)
+
+                        // Modify active pointers
+                        const result = await this.pointerManager.referenceEntityFromPointers(transaction.lastDeployedPointers, deploymentId, entity)
+
+                        // Save deployment pointer changes
+                        await this.deploymentManager.savePointerChanges(transaction.deploymentPointerChanges, deploymentId, result)
+
+                        // Add to pointer history
+                        await this.pointerManager.addToHistory(transaction.pointerHistory, deploymentId, entity)
+
+                        // Set who overwrote who
+                        await this.deploymentManager.setEntitiesAsOverwritten(transaction.deployments, overwrote, deploymentId)
+
+                        // Store the entity's content
+                        await this.storeEntityContent(hashes, alreadyStoredContent)
+
+                        // Since we are still reporting the history size, add one to it
+                        await this.historyManager.reportDeployment(transaction.deployments)
+
+                    }
+
+                    // Mark deployment as successful (this does nothing it if hadn't failed on the first place)
+                    await this.failedDeploymentsManager.reportSuccessfulDeployment(transaction.failedDeployments, entity.type, entity.id)
+
+                    return { auditInfoComplete, wasEntityDeployed: !isEntityAlreadyDeployed }
+                } catch (error) {
+                    throw error
+                }
+            })
+
+            // Report deployment to listeners
+            if (wasEntityDeployed) {
+                await Promise.all(this.listeners.map(listener => listener({ entity, auditInfo: auditInfoComplete, origin })))
+            }
+
+            return auditInfoComplete.localTimestamp
+
+        } finally {
+            // Update the current list of pointers being deployed
+            const pointersCurrentlyBeingDeployed = this.pointersBeingDeployed.get(entity.type)!!
+            entity.pointers.forEach(pointer => pointersCurrentlyBeingDeployed.delete(pointer))
+        }
     }
 
     reportErrorDuringSync(entityType: EntityType, entityId: EntityId, originTimestamp: Timestamp, originServerUrl: ServerAddress, reason: FailureReason, errorDescription?: string): Promise<null> {

--- a/content/test/integration/service/concurrent-deployments.spec.ts
+++ b/content/test/integration/service/concurrent-deployments.spec.ts
@@ -10,7 +10,7 @@ import { EntityCombo, buildDeployData, deployEntitiesCombo } from "../E2ETestUti
 describe("Integration - Concurrent deployments", () => {
 
     const P1 = "x1,y1"
-    const AMOUNT_OF_DEPLOYMENTS = 10
+    const AMOUNT_OF_DEPLOYMENTS = 500
     const type = EntityType.PROFILE
     const testEnv = loadTestEnvironment()
 


### PR DESCRIPTION
We had a check that prevented concurrent deployments in place, but it wasn't set correctly. The check was inside a transaction, so it would prevent some concurrent transactions. However, the lock would be released before the transaction ended, so we still had the original issue. The original problem was that concurrent deployments could be made, and they both would think that they were active.

The solution was simple. We flipped the code, and now the transaction is executed inside the check, so there can't be concurrent transactions at all