### PR TITLE
Remove pointers and files from segment reporting

### DIFF
--- a/content/src/service/reporters/SegmentIoAnalytics.ts
+++ b/content/src/service/reporters/SegmentIoAnalytics.ts
@@ -23,14 +23,11 @@ export class SegmentIoAnalytics {
   }
 
   private reportDeployment(entity: Entity, ethAddress: EthAddress, origin: string): void {
-    this.segmentClient.track(
-      SegmentIoAnalytics.createRecordEvent(entity, ethAddress, origin),
-      (err: Error, data: any) => {
-        if (err) {
-          SegmentIoAnalytics.LOGGER.warn(`There was an error while reporting metrics: ${err.message}`)
-        }
+    this.segmentClient.track(SegmentIoAnalytics.createRecordEvent(entity, ethAddress, origin), (err: Error) => {
+      if (err) {
+        SegmentIoAnalytics.LOGGER.warn(`There was an error while reporting metrics: ${err.message}`)
       }
-    )
+    })
   }
 
   private static createRecordEvent(entity: Entity, ethAddress: EthAddress, origin: string): any {
@@ -40,13 +37,6 @@ export class SegmentIoAnalytics {
       properties: {
         type: entity.type,
         cid: entity.id,
-        pointers: entity.pointers,
-        files: Array.from(entity.content?.entries() || []).map((entry) => {
-          return {
-            path: entry[0],
-            cid: entry[1]
-          }
-        }),
         origin: origin
       }
     }


### PR DESCRIPTION
This PR Fixes https://github.com/decentraland/catalyst/issues/56

### Description
As the payload sent to [Segment](https://segment.com/) was bigger than 32kb, then the error shown in issue #56 was being triggered. 

### Solution
Remove pointers and files from the reporting to Segment.
