### PR TITLE
fix: avoid flakiness in test

### DIFF
--- a/content/test/integration/syncronization/cluster-synchronization.spec.ts
+++ b/content/test/integration/syncronization/cluster-synchronization.spec.ts
@@ -96,18 +96,18 @@ describe('End 2 end synchronization tests', function () {
 
   /**
    * This test verifies a very corner case where:
-   * A. An entity E1 is deployed first, with some pointers P1, P2
-   * B. A new entity E2 is deployed on a server S, with pointers P2, P3. But the server where it was deployed,
+   * A. entityTimestamp(E1) < entityTimestamp(E2) < entityTimestamp(E3)
+   * B. Entity E2 is deployed on a server S, with pointers P2, P3. But the server where it was deployed,
    *    quickly goes down, before the others can see the update
-   * C. A new entity E3 is deployed on one of the servers that is up, with pointers P3, P4.
-   *
+   * C. Entity E1 is then deployed on one of the servers that is up, with same pointers P1, P2
+   * D. Entity E3 is deployed on one of the servers that is up, with pointers P3, P4.
    * Now, until S comes up again, all other servers in the cluster should see E1 and E3. But when S starts, then
    * only E3 should be present on all servers.
    *
    */
   it("When a lost update is detected, previous entities are deleted but new ones aren't", async () => {
-    // Start server 1, 2 and 3
-    await Promise.all([server1.start(), server2.start(), server3.start()])
+    // Start server 2
+    await Promise.all([server2.start()])
 
     // Prepare data to be deployed
     const { deployData: deployData1, controllerEntity: entity1 } = await buildDeployData(['X1,Y1', 'X2,Y2'], {
@@ -124,11 +124,7 @@ describe('End 2 end synchronization tests', function () {
       { metadata: 'metadata3' }
     )
 
-    // Deploy the entities 1 and 2
-    const deploymentTimestamp1: Timestamp = await server1.deploy(deployData1)
-    const deploymentEvent1 = buildEvent(entity1, server1, deploymentTimestamp1)
-    const deployment1 = buildDeployment(deployData1, entity1, server1, deploymentTimestamp1)
-
+    // Deploy entity 2
     const deploymentTimestamp2: Timestamp = await server2.deploy(deployData2)
     const deploymentEvent2 = buildEvent(entity2, server2, deploymentTimestamp2)
     const deployment2 = buildDeployment(deployData2, entity2, server2, deploymentTimestamp2)
@@ -136,18 +132,25 @@ describe('End 2 end synchronization tests', function () {
     // Stop server 2
     await server2.stop({ deleteStorage: false })
 
-    // Deploy entity 3
+    // Start servers 1 and 3
+    await Promise.all([server1.start(), server3.start()])
+
+    // Deploy entities 1 and 3
+    const deploymentTimestamp1: Timestamp = await server1.deploy(deployData1)
+    const deploymentEvent1 = buildEvent(entity1, server1, deploymentTimestamp1)
+    const deployment1 = buildDeployment(deployData1, entity1, server1, deploymentTimestamp1)
+
     const deploymentTimestamp3: Timestamp = await server3.deploy(deployData3)
     const deploymentEvent3 = buildEvent(entity3, server3, deploymentTimestamp3)
     const deployment3 = buildDeployment(deployData3, entity3, server3, deploymentTimestamp3)
 
-    // Wait for servers to sync
+    // Wait for servers 1 and 3 to sync
     await awaitUntil(() => assertHistoryOnServerHasEvents(server1, deploymentEvent1, deploymentEvent3))
     await awaitUntil(() => assertHistoryOnServerHasEvents(server3, deploymentEvent1, deploymentEvent3))
     await awaitUntil(() => assertDeploymentsAreReported(server1, deployment1, deployment3))
     await awaitUntil(() => assertDeploymentsAreReported(server3, deployment1, deployment3))
 
-    // Make sure that both server 1 and 3 have entity 1 and 3 currently active
+    // Make sure that both server 1 and 3 have entity E1 and E3 currently active
     await assertEntitiesAreActiveOnServer(server1, entity1, entity3)
     await assertEntitiesAreActiveOnServer(server3, entity1, entity3)
 
@@ -156,17 +159,17 @@ describe('End 2 end synchronization tests', function () {
 
     // Wait for servers to sync
     await awaitUntil(() =>
-      assertHistoryOnServerHasEvents(server1, deploymentEvent1, deploymentEvent2, deploymentEvent3)
+      assertHistoryOnServerHasEvents(server1, deploymentEvent2, deploymentEvent1, deploymentEvent3)
     )
     await awaitUntil(() =>
-      assertHistoryOnServerHasEvents(server2, deploymentEvent1, deploymentEvent2, deploymentEvent3)
+      assertHistoryOnServerHasEvents(server2, deploymentEvent2, deploymentEvent1, deploymentEvent3)
     )
     await awaitUntil(() =>
-      assertHistoryOnServerHasEvents(server3, deploymentEvent1, deploymentEvent2, deploymentEvent3)
+      assertHistoryOnServerHasEvents(server3, deploymentEvent2, deploymentEvent1, deploymentEvent3)
     )
-    await awaitUntil(() => assertDeploymentsAreReported(server1, deployment1, deployment2, deployment3))
-    await awaitUntil(() => assertDeploymentsAreReported(server2, deployment1, deployment2, deployment3))
-    await awaitUntil(() => assertDeploymentsAreReported(server3, deployment1, deployment2, deployment3))
+    await awaitUntil(() => assertDeploymentsAreReported(server1, deployment2, deployment1, deployment3))
+    await awaitUntil(() => assertDeploymentsAreReported(server2, deployment2, deployment1, deployment3))
+    await awaitUntil(() => assertDeploymentsAreReported(server3, deployment2, deployment1, deployment3))
 
     // Make assertions on Server 1
     await assertEntitiesAreActiveOnServer(server1, entity3)


### PR DESCRIPTION
This test that was modified was flaky. It was flaky because we hoped that servers 1 and 3 didn't learn about the updates in server 2 before it was shut down. Now, we:
1. Start only server 2
1. Deploy E2 on it
1. Shut it down
1. Start servers 1 and 3. 

By doing this, there is no way that servers 1 and 3 learn about E2 until server 2 is restarted