### PR TITLE
fix: shut down db after tests end

### DIFF
--- a/content/BUILD.bazel
+++ b/content/BUILD.bazel
@@ -83,6 +83,7 @@ ts_library(
         "@npm//@types/ms",
         "@npm//@types/node",
         "@npm//@types/node-fetch",
+        "@npm//@types/pg-promise",
         "@npm//dcl-catalyst-commons",
         "@npm//dcl-catalyst-client",
         "@npm//dcl-crypto",
@@ -93,6 +94,7 @@ ts_library(
         "@npm//node-fetch",
         "@npm//testcontainers",
         "@npm//ts-mockito",
+        "@npm//pg-promise",
     ],
 )
 

--- a/content/test/integration/E2ETestEnvironment.ts
+++ b/content/test/integration/E2ETestEnvironment.ts
@@ -19,6 +19,7 @@ import { Container } from 'testcontainers/dist/container'
 import { MigrationManagerFactory } from '@katalyst/content/migrations/MigrationManagerFactory'
 import { NoOpValidations } from '@katalyst/test-helpers/service/validations/NoOpValidations'
 import { MetaverseContentService } from '@katalyst/content/service/Service'
+import pgPromise from 'pg-promise'
 
 export class E2ETestEnvironment {
   private static TEST_SCHEMA = 'e2etest'
@@ -30,7 +31,7 @@ export class E2ETestEnvironment {
   private dao: MockedDAOClient
 
   async start(): Promise<void> {
-    this.postgresContainer = await new GenericContainer('postgres')
+    this.postgresContainer = await new GenericContainer('postgres', '12')
       .withName('postgres_test')
       .withEnv('POSTGRES_PASSWORD', DEFAULT_DATABASE_CONFIG.password)
       .withEnv('POSTGRES_USER', DEFAULT_DATABASE_CONFIG.user)
@@ -54,6 +55,8 @@ export class E2ETestEnvironment {
   }
 
   async stop(): Promise<void> {
+    const pgp = pgPromise()
+    pgp.end()
     await this.postgresContainer.stop()
   }
 


### PR DESCRIPTION
We recently started having the following errors being showed on the console when the content servers tests were run:
```
Failed to connect to the database. Error was error: terminating connection due to administrator command
```

This happened for two reasons:
1. A new version of postgres was release
2. We weren't closing the database connection properly

We now fixed (2), and we are setting a specific version of postgres. We will do the same in https://github.com/decentraland/catalyst-owner