### PR TITLE
fix: Undefined peer connection error

### DIFF
--- a/version.bzl
+++ b/version.bzl
@@ -1,3 +1,3 @@
 # NOTE: If you change the format of this line, you must change the bash command
 # in /scripts/publish to extract the version string correctly.
-LH_VERSION = "0.2.18"
+LH_VERSION = "0.2.19"


### PR DESCRIPTION
There is an error that appears from time to time in Rollbar:

`Uncaught TypeError: Cannot read property 'setRemoteDescription' of undefined`

It seems it can occur if there is a problem when building the RTCPeerConnection while performing a handshake to establish a WebRTC connection. Not sure what could cause that, but we should handle it using the normal error flow, so maybe the Peer library can try to recover.