### PR TITLE
feat: enable fetching multiple profiles with one request

### DIFF
--- a/lambdas/BUILD.bazel
+++ b/lambdas/BUILD.bazel
@@ -24,6 +24,8 @@ ts_library(
         "@npm//morgan",
         "@npm//multer",
         "@npm//@types/multer",
+        "@npm//@types/lru-cache",
+        "@npm//lru-cache",
         "@npm//node-fetch",
         "@npm//@types/node-fetch",
         "@npm//decentraland-commons",

--- a/lambdas/src/Server.ts
+++ b/lambdas/src/Server.ts
@@ -11,7 +11,7 @@ import { initializeCryptoRoutes } from './apis/crypto/routes'
 import { initializeExploreRoutes } from './apis/explore/routes'
 import { initializeImagesRoutes } from './apis/images/routes'
 import { EnsOwnership } from './apis/profiles/EnsOwnership'
-import { initializeMultipleProfilesRoutes, initializeProfilesRoutes } from './apis/profiles/routes'
+import { initializeProfileRoutes, initializeProfilesRoutes } from './apis/profiles/routes'
 import { Controller } from './controller/Controller'
 import { Bean, Environment, EnvironmentConfig } from './Environment'
 import { SmartContentClient } from './utils/SmartContentClient'
@@ -55,8 +55,8 @@ export class Server {
     this.app.use('/contentv2', initializeContentV2Routes(express.Router(), fetcher))
 
     // Profile API implementation
-    this.app.use('/profile', initializeProfilesRoutes(express.Router(), contentClient, ensOwnership))
-    this.app.use('/profiles', initializeMultipleProfilesRoutes(express.Router(), contentClient, ensOwnership))
+    this.app.use('/profile', initializeProfileRoutes(express.Router(), contentClient, ensOwnership))
+    this.app.use('/profiles', initializeProfilesRoutes(express.Router(), contentClient, ensOwnership))
 
     // DCL-Crypto API implementation
     this.app.use('/crypto', initializeCryptoRoutes(express.Router(), env.getConfig(EnvironmentConfig.ETH_NETWORK)))

--- a/lambdas/src/Server.ts
+++ b/lambdas/src/Server.ts
@@ -11,7 +11,7 @@ import { initializeCryptoRoutes } from './apis/crypto/routes'
 import { initializeExploreRoutes } from './apis/explore/routes'
 import { initializeImagesRoutes } from './apis/images/routes'
 import { EnsOwnership } from './apis/profiles/EnsOwnership'
-import { initializeProfileRoutes, initializeProfilesRoutes } from './apis/profiles/routes'
+import { initializeIndividualProfileRoutes, initializeProfilesRoutes } from './apis/profiles/routes'
 import { Controller } from './controller/Controller'
 import { Bean, Environment, EnvironmentConfig } from './Environment'
 import { SmartContentClient } from './utils/SmartContentClient'
@@ -55,7 +55,7 @@ export class Server {
     this.app.use('/contentv2', initializeContentV2Routes(express.Router(), fetcher))
 
     // Profile API implementation
-    this.app.use('/profile', initializeProfileRoutes(express.Router(), contentClient, ensOwnership))
+    this.app.use('/profile', initializeIndividualProfileRoutes(express.Router(), contentClient, ensOwnership))
     this.app.use('/profiles', initializeProfilesRoutes(express.Router(), contentClient, ensOwnership))
 
     // DCL-Crypto API implementation

--- a/lambdas/src/Server.ts
+++ b/lambdas/src/Server.ts
@@ -11,7 +11,7 @@ import { initializeCryptoRoutes } from './apis/crypto/routes'
 import { initializeExploreRoutes } from './apis/explore/routes'
 import { initializeImagesRoutes } from './apis/images/routes'
 import { EnsOwnership } from './apis/profiles/EnsOwnership'
-import { initializeProfilesRoutes } from './apis/profiles/routes'
+import { initializeMultipleProfilesRoutes, initializeProfilesRoutes } from './apis/profiles/routes'
 import { Controller } from './controller/Controller'
 import { Bean, Environment, EnvironmentConfig } from './Environment'
 import { SmartContentClient } from './utils/SmartContentClient'
@@ -55,7 +55,8 @@ export class Server {
     this.app.use('/contentv2', initializeContentV2Routes(express.Router(), fetcher))
 
     // Profile API implementation
-    this.app.use('/profile', initializeProfilesRoutes(express.Router(), fetcher, ensOwnership))
+    this.app.use('/profile', initializeProfilesRoutes(express.Router(), contentClient, ensOwnership))
+    this.app.use('/profiles', initializeMultipleProfilesRoutes(express.Router(), contentClient, ensOwnership))
 
     // DCL-Crypto API implementation
     this.app.use('/crypto', initializeCryptoRoutes(express.Router(), env.getConfig(EnvironmentConfig.ETH_NETWORK)))

--- a/lambdas/src/apis/profiles/EnsOwnership.ts
+++ b/lambdas/src/apis/profiles/EnsOwnership.ts
@@ -10,7 +10,7 @@ export class EnsOwnership {
   private static readonly PAGE_SIZE = 1000 // The graph has a 1000 limit when return the response
   private static LOGGER = log4js.getLogger('EnsOwnership')
   private static readonly QUERY: string = `
-    query FetchNamesByOwner($names: [String]) {
+    query FetchOwnersByName($names: [String]) {
         nfts(
             where: {
                 name_in: $names,

--- a/lambdas/src/apis/profiles/EnsOwnership.ts
+++ b/lambdas/src/apis/profiles/EnsOwnership.ts
@@ -39,7 +39,7 @@ export class EnsOwnership {
   async areNamesOwnedByAddress(ethAddress: EthAddress, namesToCheck: Name[]): Promise<Map<Name, Owned>> {
     const map = new Map([[ethAddress, namesToCheck]])
     const result = await this.areNamesOwned(map)
-    return result.get(ethAddress)!
+    return result.get(ethAddress.toLowerCase())!
   }
 
   async areNamesOwned(check: Map<EthAddress, Name[]>): Promise<Map<EthAddress, Map<Name, Owned>>> {

--- a/lambdas/src/apis/profiles/controllers/profiles.ts
+++ b/lambdas/src/apis/profiles/controllers/profiles.ts
@@ -7,7 +7,7 @@ import { EnsOwnership } from '../EnsOwnership'
 
 const LOGGER = log4js.getLogger('profiles')
 
-export async function getProfileById(
+export async function getIndividualProfileById(
   client: SmartContentClient,
   ensOwnership: EnsOwnership,
   req: Request,

--- a/lambdas/src/apis/profiles/controllers/profiles.ts
+++ b/lambdas/src/apis/profiles/controllers/profiles.ts
@@ -1,10 +1,14 @@
-import { Entity } from 'dcl-catalyst-commons'
+import { Entity, EntityType } from 'dcl-catalyst-commons'
+import { EthAddress } from 'dcl-crypto'
 import { Request, Response } from 'express'
-import { SmartContentServerFetcher } from '../../../utils/SmartContentServerFetcher'
+import log4js from 'log4js'
+import { SmartContentClient } from '../../../utils/SmartContentClient'
 import { EnsOwnership } from '../EnsOwnership'
 
+const LOGGER = log4js.getLogger('profiles')
+
 export async function getProfileById(
-  fetcher: SmartContentServerFetcher,
+  client: SmartContentClient,
   ensOwnership: EnsOwnership,
   req: Request,
   res: Response
@@ -12,72 +16,98 @@ export async function getProfileById(
   // Method: GET
   // Path: /:id
   const profileId: string = req.params.id
-  let returnProfile: ProfileMetadata = { avatars: [] }
-  try {
-    const entities: Entity[] = await fetcher.fetchJsonFromContentServer(`/entities/profile?pointer=${profileId}`)
-    if (entities && entities.length > 0 && entities[0].metadata) {
-      const profile: ProfileMetadata = entities[0].metadata
-      returnProfile = profile
-      returnProfile = await markOwnedNames(ensOwnership, profileId, returnProfile)
-      returnProfile = addBaseUrlToSnapshots(fetcher.getExternalContentServerUrl(), returnProfile)
-    }
-  } catch {}
+  const profiles = await fetchProfiles([profileId], client, ensOwnership)
+  const returnProfile: ProfileMetadata = profiles[0] ?? { avatars: [] }
   res.send(returnProfile)
 }
 
-/**
- * Checks the ENSs and mark them that are owned by the user
- */
-async function markOwnedNames(
+export async function getProfilesById(
+  client: SmartContentClient,
   ensOwnership: EnsOwnership,
-  profileId: string,
-  metadata: ProfileMetadata
-): Promise<ProfileMetadata> {
-  const avatarsNames: string[] = metadata.avatars.map((profile) => profile.name).filter((name) => name && name !== '')
-
-  if (avatarsNames.length > 0) {
-    const ownedENS = await ensOwnership.areNamesOwned(profileId, avatarsNames)
-    const avatars = metadata.avatars.map((profile) => ({
-      ...profile,
-      hasClaimedName: ownedENS.get(profile.name) ?? false
-    }))
-    return { avatars }
+  req: Request,
+  res: Response
+) {
+  const profileIds: EthAddress[] | undefined = asArray(req.query.id)
+  if (!profileIds) {
+    return res.status(400).send({ error: 'You must specify at least one profile id' })
   }
 
-  return metadata
+  const profiles = await fetchProfiles(profileIds, client, ensOwnership)
+  res.send(profiles)
+}
+
+async function fetchProfiles(
+  ethAddresses: EthAddress[],
+  client: SmartContentClient,
+  ensOwnership: EnsOwnership
+): Promise<ProfileMetadata[]> {
+  try {
+    const entities: Entity[] = await client.fetchEntitiesByPointers(EntityType.PROFILE, ethAddresses)
+    const profiles: Map<EthAddress, ProfileMetadata> = new Map()
+    const names: Map<EthAddress, string[]> = new Map()
+
+    // Group names and profile metadata by ethAddress
+    entities
+      .filter((entity) => !!entity.metadata)
+      .forEach((entity) => {
+        const ethAddress = entity.pointers[0]
+        const metadata: ProfileMetadata = entity.metadata
+        profiles.set(ethAddress, metadata)
+        const filteredNames = metadata.avatars.map(({ name }) => name).filter((name) => name && name.trim().length > 0)
+        names.set(ethAddress, filteredNames)
+      })
+
+    // Check which names are owned
+    const ownedENS = await ensOwnership.areNamesOwned(names)
+
+    // Add name data and snapshot urls to profiles
+    return Array.from(profiles.entries()).map(([ethAddress, profile]) => {
+      const ensOwnership = ownedENS.get(ethAddress)!
+      const avatars = profile.avatars.map((profileData) => ({
+        ...profileData,
+        hasClaimedName: ensOwnership.get(profileData.name) ?? false,
+        avatar: {
+          ...profileData.avatar,
+          snapshots: addBaseUrlToSnapshots(client.getExternalContentServerUrl(), profileData.avatar)
+        }
+      }))
+      return { avatars }
+    })
+  } catch (error) {
+    LOGGER.warn(error)
+    return []
+  }
 }
 
 /**
  * The content server provides the snapshots' hashes, but clients expect a full url. So in this
  * method, we replace the hashes by urls that would trigger the snapshot download.
  */
-function addBaseUrlToSnapshots(baseUrl: string, metadata: ProfileMetadata): ProfileMetadata {
+function addBaseUrlToSnapshots(baseUrl: string, avatar: Avatar): AvatarSnapshots {
   function addBaseUrl(dst: AvatarSnapshots, src: AvatarSnapshots, key: keyof AvatarSnapshots) {
     if (src[key]) {
       dst[key] = baseUrl + `/contents/${src[key]}`
     }
   }
 
-  const avatars = metadata.avatars.map((profile) => {
-    const original = profile.avatar.snapshots
-    const snapshots: AvatarSnapshots = {}
+  const original = avatar.snapshots
+  const snapshots: AvatarSnapshots = {}
 
-    for (const key in original) {
-      addBaseUrl(snapshots, original, key)
-    }
+  for (const key in original) {
+    addBaseUrl(snapshots, original, key)
+  }
 
-    return {
-      ...profile,
-      name: profile.name,
-      description: profile.description,
-      avatar: {
-        ...profile.avatar,
-        snapshots
-      }
-    }
-  })
+  return snapshots
+}
 
-  return { avatars }
+function asArray<T>(elements: T[]): T[] | undefined {
+  if (!elements) {
+    return undefined
+  }
+  if (elements instanceof Array) {
+    return elements
+  }
+  return [elements]
 }
 
 type ProfileMetadata = {

--- a/lambdas/src/apis/profiles/routes.ts
+++ b/lambdas/src/apis/profiles/routes.ts
@@ -3,7 +3,7 @@ import { SmartContentClient } from '../../utils/SmartContentClient'
 import { getProfileById, getProfilesById } from './controllers/profiles'
 import { EnsOwnership } from './EnsOwnership'
 
-export function initializeProfilesRoutes(
+export function initializeProfileRoutes(
   router: Router,
   client: SmartContentClient,
   ensOwnership: EnsOwnership
@@ -12,12 +12,13 @@ export function initializeProfilesRoutes(
   return router
 }
 
-export function initializeMultipleProfilesRoutes(
+export function initializeProfilesRoutes(
   router: Router,
   client: SmartContentClient,
   ensOwnership: EnsOwnership
 ): Router {
   router.get('/', createHandler(client, ensOwnership, getProfilesById))
+  router.get('/:id', createHandler(client, ensOwnership, getProfileById))
   return router
 }
 

--- a/lambdas/src/apis/profiles/routes.ts
+++ b/lambdas/src/apis/profiles/routes.ts
@@ -1,14 +1,14 @@
 import { Request, Response, Router } from 'express'
 import { SmartContentClient } from '../../utils/SmartContentClient'
-import { getProfileById, getProfilesById } from './controllers/profiles'
+import { getIndividualProfileById, getProfilesById } from './controllers/profiles'
 import { EnsOwnership } from './EnsOwnership'
 
-export function initializeProfileRoutes(
+export function initializeIndividualProfileRoutes(
   router: Router,
   client: SmartContentClient,
   ensOwnership: EnsOwnership
 ): Router {
-  router.get('/:id', createHandler(client, ensOwnership, getProfileById))
+  router.get('/:id', createHandler(client, ensOwnership, getIndividualProfileById))
   return router
 }
 
@@ -18,7 +18,7 @@ export function initializeProfilesRoutes(
   ensOwnership: EnsOwnership
 ): Router {
   router.get('/', createHandler(client, ensOwnership, getProfilesById))
-  router.get('/:id', createHandler(client, ensOwnership, getProfileById))
+  router.get('/:id', createHandler(client, ensOwnership, getIndividualProfileById))
   return router
 }
 

--- a/lambdas/src/apis/profiles/routes.ts
+++ b/lambdas/src/apis/profiles/routes.ts
@@ -1,21 +1,30 @@
 import { Request, Response, Router } from 'express'
-import { SmartContentServerFetcher } from '../../utils/SmartContentServerFetcher'
-import { getProfileById } from './controllers/profiles'
+import { SmartContentClient } from '../../utils/SmartContentClient'
+import { getProfileById, getProfilesById } from './controllers/profiles'
 import { EnsOwnership } from './EnsOwnership'
 
 export function initializeProfilesRoutes(
   router: Router,
-  fetcher: SmartContentServerFetcher,
+  client: SmartContentClient,
   ensOwnership: EnsOwnership
 ): Router {
-  router.get('/:id', createHandler(fetcher, ensOwnership, getProfileById))
+  router.get('/:id', createHandler(client, ensOwnership, getProfileById))
+  return router
+}
+
+export function initializeMultipleProfilesRoutes(
+  router: Router,
+  client: SmartContentClient,
+  ensOwnership: EnsOwnership
+): Router {
+  router.get('/', createHandler(client, ensOwnership, getProfilesById))
   return router
 }
 
 function createHandler(
-  fetcher: SmartContentServerFetcher,
+  client: SmartContentClient,
   ensOwnership: EnsOwnership,
-  originalHandler: (fetcher: SmartContentServerFetcher, ensOwnership: EnsOwnership, req: Request, res: Response) => void
+  originalHandler: (client: SmartContentClient, ensOwnership: EnsOwnership, req: Request, res: Response) => void
 ): (req: Request, res: Response) => void {
-  return (req: Request, res: Response) => originalHandler(fetcher, ensOwnership, req, res)
+  return (req: Request, res: Response) => originalHandler(client, ensOwnership, req, res)
 }

--- a/lambdas/test/apis/profiles/EnsOwnership.spec.ts
+++ b/lambdas/test/apis/profiles/EnsOwnership.spec.ts
@@ -10,14 +10,20 @@ describe('Ensure ENS filtering work as expected', () => {
 
     const originalAddress = '0x079BED9C31CB772c4C156F86E1CFf15bf751ADd0'
 
-    const namesOriginal = await ensOwnership.areNamesOwned(originalAddress, ['marcosnc', 'invalid_name'])
+    const namesOriginal = await ensOwnership.areNamesOwnedByAddress(originalAddress, ['marcosnc', 'invalid_name'])
     assertNamesAreOwned(namesOriginal, 'marcosnc')
     assertNamesAreNotOwned(namesOriginal, 'invalid_name')
 
-    const namesUpper = await ensOwnership.areNamesOwned(originalAddress.toUpperCase(), ['marcosnc', 'invalid_name'])
+    const namesUpper = await ensOwnership.areNamesOwnedByAddress(originalAddress.toUpperCase(), [
+      'marcosnc',
+      'invalid_name'
+    ])
     expect(namesUpper).toEqual(namesOriginal)
 
-    const namesLower = await ensOwnership.areNamesOwned(originalAddress.toLowerCase(), ['marcosnc', 'invalid_name'])
+    const namesLower = await ensOwnership.areNamesOwnedByAddress(originalAddress.toLowerCase(), [
+      'marcosnc',
+      'invalid_name'
+    ])
     expect(namesLower).toEqual(namesOriginal)
   }, 100000)
 
@@ -27,7 +33,7 @@ describe('Ensure ENS filtering work as expected', () => {
     const originalAddress = '0x079BED9C31CB772c4C156F86E1CFf15bf751ADd0'
     const ensOwnership = buildOwnership(fetcher)
 
-    await ensOwnership.areNamesOwned(originalAddress, ['marcosnc', 'invalid_name'])
+    await ensOwnership.areNamesOwnedByAddress(originalAddress, ['marcosnc', 'invalid_name'])
 
     verify(mockedFetcher.queryGraph(anything(), anything(), anything())).once()
   }, 100000)
@@ -38,8 +44,8 @@ describe('Ensure ENS filtering work as expected', () => {
     const originalAddress = '0x079BED9C31CB772c4C156F86E1CFf15bf751ADd0'
     const ensOwnership = buildOwnership(fetcher)
 
-    await ensOwnership.areNamesOwned(originalAddress, ['marcosnc', 'invalid_name'])
-    await ensOwnership.areNamesOwned(originalAddress, ['marcosnc', 'invalid_name', 'another_name'])
+    await ensOwnership.areNamesOwnedByAddress(originalAddress, ['marcosnc', 'invalid_name'])
+    await ensOwnership.areNamesOwnedByAddress(originalAddress, ['marcosnc', 'invalid_name', 'another_name'])
 
     verify(mockedFetcher.queryGraph(anything(), anything(), anything())).times(2)
   }, 100000)
@@ -50,8 +56,8 @@ describe('Ensure ENS filtering work as expected', () => {
     const originalAddress = '0x079BED9C31CB772c4C156F86E1CFf15bf751ADd0'
     const ensOwnership = buildOwnership(fetcher)
 
-    await ensOwnership.areNamesOwned(originalAddress, ['marcosnc', 'invalid_name'])
-    await ensOwnership.areNamesOwned(originalAddress, ['marcosnc', 'invalid_name'])
+    await ensOwnership.areNamesOwnedByAddress(originalAddress, ['marcosnc', 'invalid_name'])
+    await ensOwnership.areNamesOwnedByAddress(originalAddress, ['marcosnc', 'invalid_name'])
 
     verify(mockedFetcher.queryGraph(anything(), anything(), anything())).once()
   }, 100000)
@@ -62,8 +68,8 @@ describe('Ensure ENS filtering work as expected', () => {
     const originalAddress = '0x079BED9C31CB772c4C156F86E1CFf15bf751ADd0'
     const ensOwnership = buildOwnership(fetcher)
 
-    await ensOwnership.areNamesOwned(originalAddress, ['marcosnc', 'invalid_name'])
-    await ensOwnership.areNamesOwned('anotherAddress', ['marcosnc'])
+    await ensOwnership.areNamesOwnedByAddress(originalAddress, ['marcosnc', 'invalid_name'])
+    await ensOwnership.areNamesOwnedByAddress('anotherAddress', ['marcosnc'])
 
     verify(mockedFetcher.queryGraph(anything(), anything(), anything())).times(2)
   }, 100000)

--- a/lambdas/test/apis/profiles/EnsOwnership.spec.ts
+++ b/lambdas/test/apis/profiles/EnsOwnership.spec.ts
@@ -62,7 +62,7 @@ describe('Ensure ENS filtering work as expected', () => {
     verify(mockedFetcher.queryGraph(anything(), anything(), anything())).once()
   }, 100000)
 
-  it(`When getting the owned names for a different entity, then the graph is consulted twice`, async () => {
+  it(`When getting the owned names for a different entity, then the graph is consulted once`, async () => {
     const mockedFetcher: Fetcher = getMockedFetcher()
     const fetcher: Fetcher = instance(mockedFetcher)
     const originalAddress = '0x079BED9C31CB772c4C156F86E1CFf15bf751ADd0'
@@ -71,7 +71,7 @@ describe('Ensure ENS filtering work as expected', () => {
     await ensOwnership.areNamesOwnedByAddress(originalAddress, ['marcosnc', 'invalid_name'])
     await ensOwnership.areNamesOwnedByAddress('anotherAddress', ['marcosnc'])
 
-    verify(mockedFetcher.queryGraph(anything(), anything(), anything())).times(2)
+    verify(mockedFetcher.queryGraph(anything(), anything(), anything())).once()
   }, 100000)
 })
 


### PR DESCRIPTION
Right now, we only have one endpoint `/profile/:ethAddress` that fetches one profile. In order to improve the performance of the client, we want to enabling fetching more than one in one request.

The new endpoint can be used like this `/profiles?id=EthAddress&id=EthAddress...`. We also added a `/profiles/:ethAddress`, so we could deprecate `/profile` in the future

Now, in order to do that, we made two big changes:
**ENSCache**
Previously, the cache was something like `Cache<Pair<EthAddress, Name>, Owned: boolean>`. Now, we changed it to: `Cache<Name, owner: EthAddress | null>`. 

**Queries to the graph**
We want to group as many calls as possible to the graph, so that the API loads faster. To do so, we are now simply fetching by chunks of 1000 names. The result with return a pair `Pair<Name, Owner>`, which we will then use to populate the cache and return whether a given address owns a name or not.
