### PR TITLE
fix: use slice correctly in profiles lambda

### DIFF
--- a/content/src/service/synchronization/ContentCluster.ts
+++ b/content/src/service/synchronization/ContentCluster.ts
@@ -138,6 +138,8 @@ export class ContentCluster implements IdentityProvider {
   /** Detect my own identity */
   async detectMyIdentity(attempts: number = 1): Promise<void> {
     try {
+      ContentCluster.LOGGER.debug('Attempting to determine my identity')
+
       // Fetch server list from the DAO
       if (!this.allServersInDAO) {
         this.allServersInDAO = await this.dao.getAllContentServers()

--- a/lambdas/src/apis/profiles/EnsOwnership.ts
+++ b/lambdas/src/apis/profiles/EnsOwnership.ts
@@ -92,7 +92,7 @@ export class EnsOwnership {
     const result: Map<Name, EthAddress> = new Map()
     let offset = 0
     while (offset < names.length) {
-      const namesSlice = names.slice(offset, EnsOwnership.PAGE_SIZE)
+      const namesSlice = names.slice(offset, offset + EnsOwnership.PAGE_SIZE)
       const owners = await this.fetchOwnedNames(namesSlice)
       for (const { name, owner } of owners) {
         result.set(name, owner)


### PR DESCRIPTION
`slice` uses `(start, end)`, not `(start, count)`

Also, adding some logging to the content server start up process. Otherwise, it looks dead