### PR TITLE
feat: add wearables sanitization in profiles

### DIFF
--- a/lambdas/BUILD.bazel
+++ b/lambdas/BUILD.bazel
@@ -3,42 +3,6 @@ package(default_visibility = ["//visibility:public"])
 load("@npm_bazel_typescript//:index.bzl", "ts_library")
 load("@build_bazel_rules_nodejs//:defs.bzl", "nodejs_binary")
 
-ts_library(
-    name = "lambdas",
-    srcs = glob(["src/**/*.ts"]),
-    module_name = "@katalyst/lambdas",
-    tsconfig = "//:tsconfig.json",
-    deps = [
-        "//contracts",
-        "//commons/utils",
-        "//commons/servers",
-        "@npm//@types",
-        "@npm//@types/node",
-        "@npm//@types/compression",
-        "@npm//@types/log4js",
-        "@npm//cors",
-        "@npm//express",
-        "@npm//sharp",
-        "@npm//compression",
-        "@npm//log4js",
-        "@npm//morgan",
-        "@npm//multer",
-        "@npm//@types/multer",
-        "@npm//@types/lru-cache",
-        "@npm//lru-cache",
-        "@npm//node-fetch",
-        "@npm//@types/node-fetch",
-        "@npm//decentraland-commons",
-        "@npm//web3",
-        "@npm//fp-future",
-        "@npm//@types/web3",
-        "@npm//aws-sdk",
-        "@npm//dcl-crypto",
-        "@npm//dcl-catalyst-commons",
-        "@npm//dcl-catalyst-client",
-    ],
-)
-
 filegroup(
     name = "api_resources",
     srcs = glob(["src/**/*.json"])
@@ -47,12 +11,12 @@ filegroup(
 nodejs_binary(
     name = "server",
     data = [
-        ":lambdas",
+        "//lambdas/src:lambdas",
         ":api_resources",
         "@npm//@bazel/typescript",
         "@npm//typescript",
     ],
-    entry_point = "src/entrypoints/run-server.ts",
+    entry_point = "entrypoints/run-server.ts",
 )
 
 load("//tools/npm:package.bzl", "dataform_npm_package")
@@ -72,13 +36,17 @@ ts_library(
     srcs = glob(["test/**/*.ts"]),
     tsconfig = "//:tsconfig.json",
     deps = [
-        ":lambdas",
+        "//lambdas/src:lambdas",
+        "//commons/utils",
         "@npm//@types/node",
         "@npm//@types/jasmine",
+        "@npm//@types/faker",
         "@npm//node-fetch",
         "@npm//@types/node-fetch",
         "@npm//dcl-catalyst-commons",
         "@npm//ts-mockito",
+        "@npm//dcl-crypto",
+        "@npm//faker",
     ],
 )
 

--- a/lambdas/src/BUILD.bazel
+++ b/lambdas/src/BUILD.bazel
@@ -1,0 +1,39 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@npm_bazel_typescript//:index.bzl", "ts_library")
+
+ts_library(
+    name = "lambdas",
+    srcs = glob(["**/*.ts"]),
+    module_name = "@katalyst/lambdas",
+    tsconfig = "//:tsconfig.json",
+    deps = [
+        "//contracts",
+        "//commons/utils",
+        "//commons/servers",
+        "@npm//@types",
+        "@npm//@types/node",
+        "@npm//@types/compression",
+        "@npm//@types/log4js",
+        "@npm//cors",
+        "@npm//express",
+        "@npm//sharp",
+        "@npm//compression",
+        "@npm//log4js",
+        "@npm//morgan",
+        "@npm//multer",
+        "@npm//@types/multer",
+        "@npm//@types/lru-cache",
+        "@npm//lru-cache",
+        "@npm//node-fetch",
+        "@npm//@types/node-fetch",
+        "@npm//decentraland-commons",
+        "@npm//web3",
+        "@npm//fp-future",
+        "@npm//@types/web3",
+        "@npm//aws-sdk",
+        "@npm//dcl-crypto",
+        "@npm//dcl-catalyst-commons",
+        "@npm//dcl-catalyst-client",
+    ],
+)

--- a/lambdas/src/Environment.ts
+++ b/lambdas/src/Environment.ts
@@ -1,5 +1,6 @@
 import ms from 'ms'
 import { EnsOwnershipFactory } from './apis/profiles/EnsOwnershipFactory'
+import { WearablesOwnershipFactory } from './apis/profiles/WearablesOwnershipFactory'
 import { ControllerFactory } from './controller/ControllerFactory'
 import { DAOCacheFactory } from './service/dao/DAOCacheFactory'
 import { ServiceFactory } from './service/ServiceFactory'
@@ -11,7 +12,10 @@ export const DEFAULT_ETH_NETWORK = 'ropsten'
 export const DEFAULT_ENS_OWNER_PROVIDER_URL_ROPSTEN =
   'https://api.thegraph.com/subgraphs/name/decentraland/marketplace-ropsten'
 const DEFAULT_ENS_OWNER_PROVIDER_URL_MAINNET = 'https://api.thegraph.com/subgraphs/name/decentraland/marketplace'
-
+export const DEFAULT_COLLECTIONS_PROVIDER_URL_ROPSTEN =
+  'https://api.thegraph.com/subgraphs/name/decentraland/collections-ropsten'
+export const DEFAULT_COLLECTIONS_PROVIDER_URL_MAINNET =
+  'https://api.thegraph.com/subgraphs/name/decentraland/collections'
 const DEFAULT_LAMBDAS_STORAGE_LOCATION = 'lambdas-storage'
 
 export class Environment {
@@ -52,7 +56,8 @@ export const enum Bean {
   SMART_CONTENT_SERVER_FETCHER,
   SMART_CONTENT_SERVER_CLIENT,
   DAO,
-  ENS_OWNERSHIP
+  ENS_OWNERSHIP,
+  WEARABLES_OWNERSHIP
 }
 
 export const enum EnvironmentConfig {
@@ -60,13 +65,16 @@ export const enum EnvironmentConfig {
   LOG_REQUESTS,
   CONTENT_SERVER_ADDRESS,
   ENS_OWNER_PROVIDER_URL,
+  COLLECTIONS_PROVIDER_URL,
   COMMIT_HASH,
   USE_COMPRESSION_MIDDLEWARE,
   LOG_LEVEL,
   ETH_NETWORK,
   LAMBDAS_STORAGE_LOCATION,
   PROFILE_NAMES_CACHE_MAX,
-  PROFILE_NAMES_CACHE_TIMEOUT
+  PROFILE_NAMES_CACHE_TIMEOUT,
+  PROFILE_WEARABLES_CACHE_MAX,
+  PROFILE_WEARABLES_CACHE_TIMEOUT
 }
 
 export class EnvironmentBuilder {
@@ -108,6 +116,15 @@ export class EnvironmentBuilder {
           ? DEFAULT_ENS_OWNER_PROVIDER_URL_MAINNET
           : DEFAULT_ENS_OWNER_PROVIDER_URL_ROPSTEN)
     )
+    this.registerConfigIfNotAlreadySet(
+      env,
+      EnvironmentConfig.COLLECTIONS_PROVIDER_URL,
+      () =>
+        process.env.COLLECTIONS_PROVIDER_URL ??
+        (process.env.ETH_NETWORK === 'mainnet'
+          ? DEFAULT_COLLECTIONS_PROVIDER_URL_MAINNET
+          : DEFAULT_COLLECTIONS_PROVIDER_URL_ROPSTEN)
+    )
     this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.COMMIT_HASH, () => process.env.COMMIT_HASH ?? 'Unknown')
     this.registerConfigIfNotAlreadySet(
       env,
@@ -126,10 +143,16 @@ export class EnvironmentBuilder {
       () => process.env.LAMBDAS_STORAGE_LOCATION ?? DEFAULT_LAMBDAS_STORAGE_LOCATION
     )
     this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.PROFILE_NAMES_CACHE_MAX, () =>
-      parseInt(process.env.PROFILE_METADATA_CACHE_MAX ?? '20000')
+      parseInt(process.env.PROFILE_NAMES_CACHE_MAX ?? '20000')
     )
     this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.PROFILE_NAMES_CACHE_TIMEOUT, () =>
-      ms(process.env.PROFILE_METADATA_CACHE_TIMEOUT ?? '3h')
+      ms(process.env.PROFILE_NAMES_CACHE_TIMEOUT ?? '3h')
+    )
+    this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.PROFILE_WEARABLES_CACHE_MAX, () =>
+      parseInt(process.env.PROFILE_WEARABLES_CACHE_MAX ?? '1000')
+    )
+    this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.PROFILE_WEARABLES_CACHE_TIMEOUT, () =>
+      ms(process.env.PROFILE_WEARABLES_CACHE_TIMEOUT ?? '30m')
     )
 
     // Please put special attention on the bean registration order.
@@ -143,6 +166,7 @@ export class EnvironmentBuilder {
     this.registerBeanIfNotAlreadySet(env, Bean.SERVICE, () => ServiceFactory.create(env))
     this.registerBeanIfNotAlreadySet(env, Bean.CONTROLLER, () => ControllerFactory.create(env))
     this.registerBeanIfNotAlreadySet(env, Bean.ENS_OWNERSHIP, () => EnsOwnershipFactory.create(env))
+    this.registerBeanIfNotAlreadySet(env, Bean.WEARABLES_OWNERSHIP, () => WearablesOwnershipFactory.create(env))
 
     return env
   }

--- a/lambdas/src/Server.ts
+++ b/lambdas/src/Server.ts
@@ -12,6 +12,7 @@ import { initializeExploreRoutes } from './apis/explore/routes'
 import { initializeImagesRoutes } from './apis/images/routes'
 import { EnsOwnership } from './apis/profiles/EnsOwnership'
 import { initializeIndividualProfileRoutes, initializeProfilesRoutes } from './apis/profiles/routes'
+import { WearablesOwnership } from './apis/profiles/WearablesOwnership'
 import { Controller } from './controller/Controller'
 import { Bean, Environment, EnvironmentConfig } from './Environment'
 import { SmartContentClient } from './utils/SmartContentClient'
@@ -48,6 +49,7 @@ export class Server {
     this.registerRoute('/status', controller, controller.getStatus)
 
     const ensOwnership: EnsOwnership = env.getBean(Bean.ENS_OWNERSHIP)
+    const wearablesOwnership: WearablesOwnership = env.getBean(Bean.WEARABLES_OWNERSHIP)
     const fetcher: SmartContentServerFetcher = env.getBean(Bean.SMART_CONTENT_SERVER_FETCHER)
     const contentClient: SmartContentClient = env.getBean(Bean.SMART_CONTENT_SERVER_CLIENT)
 
@@ -55,8 +57,14 @@ export class Server {
     this.app.use('/contentv2', initializeContentV2Routes(express.Router(), fetcher))
 
     // Profile API implementation
-    this.app.use('/profile', initializeIndividualProfileRoutes(express.Router(), contentClient, ensOwnership))
-    this.app.use('/profiles', initializeProfilesRoutes(express.Router(), contentClient, ensOwnership))
+    this.app.use(
+      '/profile',
+      initializeIndividualProfileRoutes(express.Router(), contentClient, ensOwnership, wearablesOwnership)
+    )
+    this.app.use(
+      '/profiles',
+      initializeProfilesRoutes(express.Router(), contentClient, ensOwnership, wearablesOwnership)
+    )
 
     // DCL-Crypto API implementation
     this.app.use('/crypto', initializeCryptoRoutes(express.Router(), env.getConfig(EnvironmentConfig.ETH_NETWORK)))

--- a/lambdas/src/apis/collections/Utils.ts
+++ b/lambdas/src/apis/collections/Utils.ts
@@ -1,0 +1,15 @@
+import { WearableId } from './controllers/collections'
+
+/**
+ * We are translating from the old id format into the new one.
+ *
+ * The old wearables format was like this: dcl://collectionName/wearableName
+ * The new format is like this: collectionName-wearableName
+ */
+export function translateWearablesIdFormat(wearableId: WearableId): WearableId {
+  return wearableId.replace('dcl://', '').replace('/', '-')
+}
+
+export function buildWearableId(contract: string, option: string): WearableId {
+  return `${contract}-${option}`
+}

--- a/lambdas/src/apis/collections/controllers/collections.ts
+++ b/lambdas/src/apis/collections/controllers/collections.ts
@@ -110,6 +110,8 @@ function createRelativeContentUrl(
   return undefined
 }
 
+export type WearableId = string // These ids are used as pointers on the content server
+
 const RARITIES_EMISSIONS = {
   common: 100000,
   uncommon: 10000,

--- a/lambdas/src/apis/profiles/WearablesOwnership.ts
+++ b/lambdas/src/apis/profiles/WearablesOwnership.ts
@@ -10,7 +10,7 @@ import { WearableId } from '../collections/controllers/collections'
 export class WearablesOwnership {
   public static readonly REQUESTS_IN_GROUP = 10 // The amount of wearables requests we will group together
   private static readonly PAGE_SIZE = 1000 // The graph has a 1000 limit when return the response
-  private static LOGGER = log4js.getLogger('WearablesOwnership')
+  private static readonly LOGGER = log4js.getLogger('WearablesOwnership')
 
   private internalCache: LRU<EthAddress, { owned: Set<WearableId>; lastUpdated: Timestamp }>
 

--- a/lambdas/src/apis/profiles/WearablesOwnership.ts
+++ b/lambdas/src/apis/profiles/WearablesOwnership.ts
@@ -1,0 +1,130 @@
+import { Fetcher } from 'dcl-catalyst-commons'
+import { EthAddress } from 'dcl-crypto'
+import log4js from 'log4js'
+import LRU from 'lru-cache'
+import { WearableId } from './controllers/profiles'
+
+/**
+ * This is a custom cache for storing the owner of a given name. It can be configured with a max size of elements
+ */
+export class WearablesOwnership {
+  private static readonly PAGE_SIZE = 1000 // The graph has a 1000 limit when return the response
+  private static readonly REQUESTS_IN_GROUP = 10 // The amount of wearables requests we will group together
+  private static LOGGER = log4js.getLogger('WearablesOwnership')
+
+  private internalCache: LRU<EthAddress, { owned: Set<WearableId>; lastUpdated: Timestamp }>
+
+  constructor(
+    private readonly theGraphBaseUrl: string,
+    private readonly fetcher: Fetcher,
+    maxSize: number,
+    maxAge: number
+  ) {
+    this.internalCache = new LRU({ max: maxSize, maxAge })
+  }
+
+  async getWearablesOwnedByAddresses(
+    ethAddresses: EthAddress[]
+  ): Promise<Map<EthAddress, { wearables: Set<WearableId>; updatedMillisAgo: number }>> {
+    // Set up result
+    const result: Map<EthAddress, { wearables: Set<WearableId>; updatedMillisAgo: number }> = new Map()
+
+    // Check what is on the cache
+    const unknown: EthAddress[] = []
+    const now = Date.now()
+    for (const ethAddress of ethAddresses) {
+      const lowerCaseAddress = ethAddress.toLowerCase()
+      const knownWearables = this.internalCache.get(lowerCaseAddress)
+      if (knownWearables !== undefined) {
+        result.set(lowerCaseAddress, {
+          wearables: knownWearables.owned,
+          updatedMillisAgo: now - knownWearables.lastUpdated
+        })
+      } else {
+        unknown.push(lowerCaseAddress)
+      }
+    }
+
+    // Fetch wearables for unknown addresses
+    const graphFetchResult = await this.fetchWearablesForAddresses(unknown)
+
+    // Store fetched data in the cache, and add missing information to the result
+    for (const [lowerCaseAddress, wearables] of graphFetchResult) {
+      this.internalCache.set(lowerCaseAddress, { owned: wearables, lastUpdated: Date.now() })
+      result.set(lowerCaseAddress, { wearables, updatedMillisAgo: 0 })
+    }
+
+    return result
+  }
+
+  private async fetchWearablesForAddresses(addresses: EthAddress[]): Promise<Map<EthAddress, Set<WearableId>>> {
+    const result: Map<EthAddress, Set<WearableId>> = new Map()
+
+    const calls: GraphCall[] = addresses.map((ethAddress) => ({
+      ethAddress,
+      offset: 0,
+      limit: WearablesOwnership.PAGE_SIZE
+    }))
+
+    let index = 0
+    while (index < calls.length) {
+      // Group many requests together, to reduce the amount of calls to the graph
+      const callsToMake = calls.slice(index, index + WearablesOwnership.REQUESTS_IN_GROUP)
+      const wearablesData = await this.fetchWearableData(callsToMake)
+
+      for (const { owner, wearables } of wearablesData) {
+        if (wearables.length === WearablesOwnership.PAGE_SIZE) {
+          // If the amount of wearables is at the limit, then we need to make another call to get the remaining wearables
+          const previousCall = calls.find((call) => call.ethAddress === owner)!
+          calls.push({
+            ethAddress: owner,
+            offset: previousCall.offset + WearablesOwnership.PAGE_SIZE,
+            limit: WearablesOwnership.PAGE_SIZE
+          })
+        }
+
+        // Add finding to the result
+        const wearablesForAddress = result.get(owner)
+        if (wearablesForAddress) {
+          wearables.forEach((wearable) => wearablesForAddress.add(wearable))
+        } else {
+          result.set(owner, new Set(wearables))
+        }
+      }
+      index += WearablesOwnership.REQUESTS_IN_GROUP
+    }
+
+    return result
+  }
+
+  /** This method will take a list of names and return only those that are owned by the given eth address */
+  private async fetchWearableData(callsToMake: GraphCall[]): Promise<{ owner: EthAddress; wearables: WearableId[] }[]> {
+    try {
+      const query = `{` + callsToMake.map((call) => this.getFragment(call)).join('\n') + `}`
+      const response = await this.fetcher.queryGraph<{
+        data: { [addressWithPrefix: string]: { catalystPointer: WearableId }[] }
+      }>(this.theGraphBaseUrl, query, {})
+      return Object.entries(response.data).map(([addressWithPrefix, wearables]) => ({
+        owner: addressWithPrefix.substring(1),
+        wearables: wearables.map(({ catalystPointer }) => catalystPointer)
+      }))
+    } catch (error) {
+      const fetchedEthAddresses = callsToMake.map(({ ethAddress }) => ethAddress).join(',')
+      WearablesOwnership.LOGGER.error(`Could not retrieve for '${fetchedEthAddresses}'.`, error)
+      return []
+    }
+  }
+
+  private getFragment(call: GraphCall) {
+    // We need to add a 'P' prefix, because the graph needs the fragment name to start with a letter
+    // TODO: Add filtering so only wearables are searched
+    return `
+      P${call.ethAddress}: nfts(where: {owner: "${call.ethAddress}"}, first: ${call.limit}, skip: ${call.offset}) {
+        catalystPointer
+      }
+    `
+  }
+}
+
+type GraphCall = { ethAddress: EthAddress; offset: number; limit: number }
+type Timestamp = number

--- a/lambdas/src/apis/profiles/WearablesOwnership.ts
+++ b/lambdas/src/apis/profiles/WearablesOwnership.ts
@@ -95,7 +95,6 @@ export class WearablesOwnership {
     return result
   }
 
-  /** This method will take a list of names and return only those that are owned by the given eth address */
   private async fetchWearableData(queries: GraphQuery[]): Promise<{ owner: EthAddress; wearables: WearableId[] }[]> {
     try {
       const query = `{` + queries.map((query) => this.getFragment(query)).join('\n') + `}`

--- a/lambdas/src/apis/profiles/WearablesOwnershipFactory.ts
+++ b/lambdas/src/apis/profiles/WearablesOwnershipFactory.ts
@@ -1,0 +1,13 @@
+import { Bean, Environment, EnvironmentConfig } from '../../Environment'
+import { WearablesOwnership } from './WearablesOwnership'
+
+export class WearablesOwnershipFactory {
+  static create(env: Environment): WearablesOwnership {
+    return new WearablesOwnership(
+      env.getConfig(EnvironmentConfig.COLLECTIONS_PROVIDER_URL),
+      env.getBean(Bean.SMART_CONTENT_SERVER_FETCHER),
+      env.getConfig(EnvironmentConfig.PROFILE_WEARABLES_CACHE_MAX),
+      env.getConfig(EnvironmentConfig.PROFILE_WEARABLES_CACHE_TIMEOUT)
+    )
+  }
+}

--- a/lambdas/src/apis/profiles/controllers/profiles.ts
+++ b/lambdas/src/apis/profiles/controllers/profiles.ts
@@ -92,7 +92,7 @@ async function fetchProfiles(
  * We are sanitizing the wearables that are being worn. This includes removing any wearables that is not currently owned
  */
 function sanitizeWearables(wearablesInProfile: WearableId[], ownedWearables: Set<WearableId>): WearableId[] {
-  // TODO: Once we deprecate the wearables-api, migrate from the previous id format into the new one. This will allow us to remove the logic on our APIs
+  // TODO: Once we deprecate the wearables-api, migrate from the previous id format into the new one
   return wearablesInProfile.filter(
     (wearable: WearableId) =>
       wearable.includes('base-avatars') ||

--- a/lambdas/src/apis/profiles/controllers/profiles.ts
+++ b/lambdas/src/apis/profiles/controllers/profiles.ts
@@ -41,7 +41,8 @@ export async function getProfilesById(
   res.send(profiles)
 }
 
-async function fetchProfiles(
+// Visible for testing purposes
+export async function fetchProfiles(
   ethAddresses: EthAddress[],
   client: SmartContentClient,
   ensOwnership: EnsOwnership,
@@ -83,6 +84,7 @@ async function fetchProfiles(
       return { avatars }
     })
   } catch (error) {
+    console.log(error)
     LOGGER.warn(error)
     return []
   }
@@ -132,10 +134,11 @@ function asArray<T>(elements: T[]): T[] | undefined {
   return [elements]
 }
 
-type ProfileMetadata = {
+export type ProfileMetadata = {
   avatars: {
     name: string
     description: string
+    hasClaimedName?: boolean
     avatar: Avatar
   }[]
 }

--- a/lambdas/src/apis/profiles/controllers/profiles.ts
+++ b/lambdas/src/apis/profiles/controllers/profiles.ts
@@ -20,7 +20,7 @@ export async function getIndividualProfileById(
   // Method: GET
   // Path: /:id
   const profileId: string = req.params.id
-  const profiles = await fetchProfiles([profileId], client, ensOwnership, wearables)
+  const profiles = await fetchProfiles([profileId], client, ensOwnership, wearables, false)
   const returnProfile: ProfileMetadata = profiles[0] ?? { avatars: [] }
   res.send(returnProfile)
 }
@@ -46,7 +46,8 @@ export async function fetchProfiles(
   ethAddresses: EthAddress[],
   client: SmartContentClient,
   ensOwnership: EnsOwnership,
-  wearablesOwnership: WearablesOwnership
+  wearablesOwnership: WearablesOwnership,
+  performWearableSanitization: boolean = true
 ): Promise<ProfileMetadata[]> {
   try {
     const entities: Entity[] = await client.fetchEntitiesByPointers(EntityType.PROFILE, ethAddresses)
@@ -78,7 +79,9 @@ export async function fetchProfiles(
         avatar: {
           ...profileData.avatar,
           snapshots: addBaseUrlToSnapshots(client.getExternalContentServerUrl(), profileData.avatar),
-          wearables: sanitizeWearables(profileData.avatar.wearables, ownedWearables)
+          wearables: performWearableSanitization
+            ? sanitizeWearables(profileData.avatar.wearables, ownedWearables)
+            : profileData.avatar.wearables
         }
       }))
       return { avatars }

--- a/lambdas/src/apis/profiles/routes.ts
+++ b/lambdas/src/apis/profiles/routes.ts
@@ -2,30 +2,40 @@ import { Request, Response, Router } from 'express'
 import { SmartContentClient } from '../../utils/SmartContentClient'
 import { getIndividualProfileById, getProfilesById } from './controllers/profiles'
 import { EnsOwnership } from './EnsOwnership'
+import { WearablesOwnership } from './WearablesOwnership'
 
 export function initializeIndividualProfileRoutes(
   router: Router,
   client: SmartContentClient,
-  ensOwnership: EnsOwnership
+  ensOwnership: EnsOwnership,
+  wearablesOwnership: WearablesOwnership
 ): Router {
-  router.get('/:id', createHandler(client, ensOwnership, getIndividualProfileById))
+  router.get('/:id', createHandler(client, ensOwnership, wearablesOwnership, getIndividualProfileById))
   return router
 }
 
 export function initializeProfilesRoutes(
   router: Router,
   client: SmartContentClient,
-  ensOwnership: EnsOwnership
+  ensOwnership: EnsOwnership,
+  wearablesOwnership: WearablesOwnership
 ): Router {
-  router.get('/', createHandler(client, ensOwnership, getProfilesById))
-  router.get('/:id', createHandler(client, ensOwnership, getIndividualProfileById))
+  router.get('/', createHandler(client, ensOwnership, wearablesOwnership, getProfilesById))
+  router.get('/:id', createHandler(client, ensOwnership, wearablesOwnership, getIndividualProfileById))
   return router
 }
 
 function createHandler(
   client: SmartContentClient,
   ensOwnership: EnsOwnership,
-  originalHandler: (client: SmartContentClient, ensOwnership: EnsOwnership, req: Request, res: Response) => void
+  wearablesOwnership: WearablesOwnership,
+  originalHandler: (
+    client: SmartContentClient,
+    ensOwnership: EnsOwnership,
+    wearablesOwnership: WearablesOwnership,
+    req: Request,
+    res: Response
+  ) => void
 ): (req: Request, res: Response) => void {
-  return (req: Request, res: Response) => originalHandler(client, ensOwnership, req, res)
+  return (req: Request, res: Response) => originalHandler(client, ensOwnership, wearablesOwnership, req, res)
 }

--- a/lambdas/test/apis/profiles/EnsOwnership.spec.ts
+++ b/lambdas/test/apis/profiles/EnsOwnership.spec.ts
@@ -1,6 +1,6 @@
 import { Fetcher } from 'dcl-catalyst-commons'
 import { anything, instance, mock, verify, when } from 'ts-mockito'
-import { EnsOwnership } from '../../../src/apis/profiles/EnsOwnership'
+import { EnsOwnership } from '@katalyst/lambdas/apis/profiles/EnsOwnership'
 import { DEFAULT_ENS_OWNER_PROVIDER_URL_ROPSTEN } from '../../../src/Environment'
 
 describe('Ensure ENS filtering work as expected', () => {

--- a/lambdas/test/apis/profiles/WearablesOwnership.spec.ts
+++ b/lambdas/test/apis/profiles/WearablesOwnership.spec.ts
@@ -38,7 +38,7 @@ describe('Wearables Ownership', () => {
     verify(mock.queryGraph(anything(), anything(), anything())).once()
   })
 
-  it(`When multiple addresses are consulted, then they are grouped is one the graph query`, async () => {
+  it(`When multiple addresses are consulted, then they are grouped in one query to the graph`, async () => {
     const addresses = buildArrayWithAddresses({ amount: 5 })
     const { mock, instance } = getMockedFetcher()
     const wearablesOwnership = buildOwnership(instance)

--- a/lambdas/test/apis/profiles/WearablesOwnership.spec.ts
+++ b/lambdas/test/apis/profiles/WearablesOwnership.spec.ts
@@ -39,7 +39,7 @@ describe('Wearables Ownership', () => {
   })
 
   it(`When multiple addresses are consulted, then they are grouped is one the graph query`, async () => {
-    const addresses = createArrayWithAddresses({ amount: 5 })
+    const addresses = buildArrayWithAddresses({ amount: 5 })
     const { mock, instance } = getMockedFetcher()
     const wearablesOwnership = buildOwnership(instance)
 
@@ -49,7 +49,7 @@ describe('Wearables Ownership', () => {
   })
 
   it(`When more than WearablesOwnership#REQUESTS_IN_GROUP addresses are consulted, then more than one request is needed`, async () => {
-    const addresses = createArrayWithAddresses({ amount: WearablesOwnership.REQUESTS_IN_GROUP + 1 })
+    const addresses = buildArrayWithAddresses({ amount: WearablesOwnership.REQUESTS_IN_GROUP + 1 })
     const { mock, instance } = getMockedFetcher()
     const wearablesOwnership = buildOwnership(instance)
 
@@ -72,20 +72,20 @@ describe('Wearables Ownership', () => {
 
     verify(mock.queryGraph(anything(), anything(), anything())).once()
   })
-
-  function createArrayWithAddresses(options: { amount: number }): EthAddress[] {
-    return Array.from({ length: options.amount }, () => random.alphaNumeric(10))
-  }
-
-  function assertOwnedWearablesAreAsExpected(returned: OwnedWearables, expected: Map<EthAddress, WearableId[]>) {
-    expect(returned.size).toEqual(expected.size)
-
-    for (const [ethAddress, expectedWearables] of expected) {
-      const returnedWearables = returned.get(ethAddress.toLowerCase())!.wearables // Returned addresses are always lowercase
-      expect(returnedWearables).toEqual(new Set(expectedWearables))
-    }
-  }
 })
+
+function buildArrayWithAddresses(options: { amount: number }): EthAddress[] {
+  return Array.from({ length: options.amount }, () => random.alphaNumeric(10))
+}
+
+function assertOwnedWearablesAreAsExpected(returned: OwnedWearables, expected: Map<EthAddress, WearableId[]>) {
+  expect(returned.size).toEqual(expected.size)
+
+  for (const [ethAddress, expectedWearables] of expected) {
+    const returnedWearables = returned.get(ethAddress.toLowerCase())!.wearables // Returned addresses are always lowercase
+    expect(returnedWearables).toEqual(new Set(expectedWearables))
+  }
+}
 
 function buildOwnership(fetcher: Fetcher) {
   return new WearablesOwnership(DEFAULT_ENS_OWNER_PROVIDER_URL_ROPSTEN, fetcher, 500, 1000)

--- a/lambdas/test/apis/profiles/WearablesOwnership.spec.ts
+++ b/lambdas/test/apis/profiles/WearablesOwnership.spec.ts
@@ -1,0 +1,102 @@
+import { WearableId } from '@katalyst/lambdas/apis/collections/controllers/collections'
+import { OwnedWearables, WearablesOwnership } from '@katalyst/lambdas/apis/profiles/WearablesOwnership'
+import { DEFAULT_ENS_OWNER_PROVIDER_URL_ROPSTEN } from '@katalyst/lambdas/Environment'
+import { Fetcher } from 'dcl-catalyst-commons'
+import { EthAddress } from 'dcl-crypto'
+import { delay } from 'decentraland-katalyst-utils/util'
+import { random } from 'faker'
+import { anything, instance, mock, verify, when } from 'ts-mockito'
+
+describe('Wearables Ownership', () => {
+  const SOME_ADDRESS = '0x079bed9c31cb772c4c156f86e1cff15bf751add0'
+  const WEARABLE_ID_1 = 'someCollection-someWearable'
+
+  it(`When the same address is used, casing is ignored`, async () => {
+    const address = '0x079BED9C31CB772c4C156F86E1CFf15bf751ADd0'
+    const returnedValue = new Map([[address, [WEARABLE_ID_1]]])
+    const { instance } = getMockedFetcher(returnedValue)
+    const wearablesOwnership = buildOwnership(instance)
+
+    const resultOriginal = await wearablesOwnership.getWearablesOwnedByAddresses([address])
+    const resultUpper = await wearablesOwnership.getWearablesOwnedByAddresses([address.toUpperCase()])
+    const resultLower = await wearablesOwnership.getWearablesOwnedByAddresses([address.toUpperCase()])
+
+    assertOwnedWearablesAreAsExpected(resultOriginal, returnedValue)
+    assertOwnedWearablesAreAsExpected(resultUpper, returnedValue)
+    assertOwnedWearablesAreAsExpected(resultLower, returnedValue)
+  })
+
+  it(`When fetching wearables for the first time, then the graph is consulted and updatedAgo is 0`, async () => {
+    const returnedValue = new Map([[SOME_ADDRESS, [WEARABLE_ID_1]]])
+    const { mock, instance } = getMockedFetcher(returnedValue)
+    const wearablesOwnership = buildOwnership(instance)
+
+    const result = await wearablesOwnership.getWearablesOwnedByAddresses([SOME_ADDRESS])
+
+    expect(result.size).toEqual(1)
+    expect(result.get(SOME_ADDRESS)?.updatedMillisAgo).toEqual(0)
+    verify(mock.queryGraph(anything(), anything(), anything())).once()
+  })
+
+  it(`When multiple addresses are consulted, then they are grouped is one the graph query`, async () => {
+    const addresses = createArrayWithAddresses({ amount: 5 })
+    const { mock, instance } = getMockedFetcher()
+    const wearablesOwnership = buildOwnership(instance)
+
+    await wearablesOwnership.getWearablesOwnedByAddresses(addresses)
+
+    verify(mock.queryGraph(anything(), anything(), anything())).once()
+  })
+
+  it(`When more than WearablesOwnership#REQUESTS_IN_GROUP addresses are consulted, then more than one request is needed`, async () => {
+    const addresses = createArrayWithAddresses({ amount: WearablesOwnership.REQUESTS_IN_GROUP + 1 })
+    const { mock, instance } = getMockedFetcher()
+    const wearablesOwnership = buildOwnership(instance)
+
+    await wearablesOwnership.getWearablesOwnedByAddresses(addresses)
+
+    verify(mock.queryGraph(anything(), anything(), anything())).twice()
+  })
+
+  it(`When the same address is consulted, then the cache is used, the graph is fetched only once and updatedAgo is more than 0`, async () => {
+    const returnedValue = new Map([[SOME_ADDRESS, [WEARABLE_ID_1]]])
+    const { mock, instance } = getMockedFetcher(returnedValue)
+    const wearablesOwnership = buildOwnership(instance)
+
+    await wearablesOwnership.getWearablesOwnedByAddresses([SOME_ADDRESS])
+    await delay(1) // We wait 1 ms, so that we can make sure that 'updateAgo' is modified
+    const secondCallResult = await wearablesOwnership.getWearablesOwnedByAddresses([SOME_ADDRESS])
+
+    expect(secondCallResult.size).toEqual(1)
+    expect(secondCallResult.get(SOME_ADDRESS)?.updatedMillisAgo).toBeGreaterThan(0)
+
+    verify(mock.queryGraph(anything(), anything(), anything())).once()
+  })
+
+  function createArrayWithAddresses(options: { amount: number }): EthAddress[] {
+    return Array.from({ length: options.amount }, () => random.alphaNumeric(10))
+  }
+
+  function assertOwnedWearablesAreAsExpected(returned: OwnedWearables, expected: Map<EthAddress, WearableId[]>) {
+    expect(returned.size).toEqual(expected.size)
+
+    for (const [ethAddress, expectedWearables] of expected) {
+      const returnedWearables = returned.get(ethAddress.toLowerCase())!.wearables // Returned addresses are always lowercase
+      expect(returnedWearables).toEqual(new Set(expectedWearables))
+    }
+  }
+})
+
+function buildOwnership(fetcher: Fetcher) {
+  return new WearablesOwnership(DEFAULT_ENS_OWNER_PROVIDER_URL_ROPSTEN, fetcher, 500, 1000)
+}
+
+function getMockedFetcher(returnedValues: Map<EthAddress, WearableId[]> = new Map()) {
+  const returnValue = {}
+  Array.from(returnedValues.entries()).forEach(([ethAddress, wearables]) => {
+    returnValue[`P${ethAddress.toLowerCase()}`] = wearables.map((wearableId) => ({ catalystPointer: wearableId }))
+  })
+  const mockedFetcher: Fetcher = mock(Fetcher)
+  when(mockedFetcher.queryGraph(anything(), anything(), anything())).thenResolve(returnValue)
+  return { mock: mockedFetcher, instance: instance(mockedFetcher) }
+}

--- a/lambdas/test/apis/profiles/controller/profiles.spec.ts
+++ b/lambdas/test/apis/profiles/controller/profiles.spec.ts
@@ -1,0 +1,154 @@
+import { WearableId } from '@katalyst/lambdas/apis/collections/controllers/collections'
+import { fetchProfiles, ProfileMetadata } from '@katalyst/lambdas/apis/profiles/controllers/profiles'
+import { EnsOwnership } from '@katalyst/lambdas/apis/profiles/EnsOwnership'
+import { WearablesOwnership } from '@katalyst/lambdas/apis/profiles/WearablesOwnership'
+import { SmartContentClient } from '@katalyst/lambdas/utils/SmartContentClient'
+import { Entity, EntityType } from 'dcl-catalyst-commons'
+import { EthAddress } from 'dcl-crypto'
+import { anything, instance, mock, when } from 'ts-mockito'
+
+const EXTERNAL_URL = 'https://content-url.com'
+
+describe('profiles', () => {
+  const SOME_ADDRESS = '0x079bed9c31cb772c4c156f86e1cff15bf751add0'
+  const SOME_NAME = 'NFTName'
+  const WEARABLE_ID_1 = 'someCollection-someWearable'
+
+  it(`When profiles are fetched and NFTs are owned, then the returned profile is the same as the content server`, async () => {
+    const { entity, metadata } = profileWith(SOME_ADDRESS, { name: SOME_NAME, wearables: [WEARABLE_ID_1] })
+    const client = contentServer(entity)
+    const ensOwnership = ownedNames(SOME_ADDRESS, SOME_NAME)
+    const wearablesOwnership = ownedWearables(SOME_ADDRESS, WEARABLE_ID_1)
+
+    const profiles = await fetchProfiles([SOME_ADDRESS], client, ensOwnership, wearablesOwnership)
+
+    expect(profiles.length).toEqual(1)
+    expect(profiles[0]).toEqual(metadata)
+  })
+
+  it(`When the current name is not owned, then it says so in the profile`, async () => {
+    const { entity } = profileWith(SOME_ADDRESS, { name: SOME_NAME })
+    const client = contentServer(entity)
+    const ensOwnership = ownedNames(SOME_ADDRESS, 'SomeOtherName')
+    const wearablesOwnership = noWearables()
+
+    const profiles = await fetchProfiles([SOME_ADDRESS], client, ensOwnership, wearablesOwnership)
+
+    expect(profiles.length).toEqual(1)
+    expect(profiles[0].avatars[0].hasClaimedName).toEqual(false)
+  })
+
+  it(`When some of the worn wearables are not owned, then they are filtered out`, async () => {
+    const { entity } = profileWith(SOME_ADDRESS, { wearables: [WEARABLE_ID_1] })
+    const client = contentServer(entity)
+    const ensOwnership = noNames()
+    const wearablesOwnership = ownedWearables(SOME_ADDRESS, 'Some other id')
+
+    const profiles = await fetchProfiles([SOME_ADDRESS], client, ensOwnership, wearablesOwnership)
+
+    expect(profiles.length).toEqual(1)
+    expect(profiles[0].avatars[0].avatar.wearables.length).toEqual(0)
+  })
+
+  it(`When the is no profile with that address, then an empty list is returned`, async () => {
+    const client = contentServer()
+    const ensOwnership = noNames()
+    const wearablesOwnership = noWearables()
+
+    const profiles = await fetchProfiles([SOME_ADDRESS], client, ensOwnership, wearablesOwnership)
+
+    expect(profiles.length).toEqual(0)
+  })
+
+  it(`When profiles are returned, external urls are added to snapshots`, async () => {
+    const { entity } = profileWith(SOME_ADDRESS, { snapshots: { aKey: 'aHash' } })
+    const client = contentServer(entity)
+    const ensOwnership = noNames()
+    const wearablesOwnership = noWearables()
+
+    const profiles = await fetchProfiles([SOME_ADDRESS], client, ensOwnership, wearablesOwnership)
+
+    expect(profiles.length).toEqual(1)
+    expect(profiles[0].avatars[0].avatar.snapshots.aKey).toEqual(`${EXTERNAL_URL}/contents/aHash`)
+  })
+})
+
+function profileWith(
+  ethAddress: EthAddress,
+  options: { name?: string; wearables?: string[]; snapshots?: Record<string, string> }
+): { entity: Entity; metadata: ProfileMetadata } {
+  const metadata = {
+    avatars: [
+      {
+        name: options.name ?? '',
+        description: 'description',
+        hasClaimedName: true,
+        avatar: {
+          bodyShape: {},
+          eyes: {},
+          hair: {},
+          skin: {},
+          version: 10,
+          snapshots: options.snapshots ?? {},
+          wearables: options.wearables ?? []
+        }
+      }
+    ]
+  }
+
+  const entity = {
+    id: '',
+    type: EntityType.PROFILE,
+    pointers: [ethAddress],
+    timestamp: 10,
+    metadata: metadata
+  }
+
+  return { entity, metadata }
+}
+
+function contentServer(profile?: Entity): SmartContentClient {
+  const mockedClient = mock(SmartContentClient)
+  when(mockedClient.fetchEntitiesByPointers(anything(), anything())).thenResolve(profile ? [profile] : [])
+  when(mockedClient.getExternalContentServerUrl()).thenReturn(EXTERNAL_URL)
+  return instance(mockedClient)
+}
+
+function noNames(): EnsOwnership {
+  const mockedEnsOwnership = mock(EnsOwnership)
+  when(mockedEnsOwnership.areNamesOwned(anything())).thenCall((names: Map<EthAddress, string[]>) => {
+    const entries = Array.from(names.entries()).map<[EthAddress, Map<string, boolean>]>(([address, names]) => [
+      address,
+      new Map(names.map((name) => [name, false]))
+    ])
+    return Promise.resolve(new Map(entries))
+  })
+  return instance(mockedEnsOwnership)
+}
+
+function ownedNames(ethAddress: EthAddress, ...owned: string[]): EnsOwnership {
+  const mockedEnsOwnership = mock(EnsOwnership)
+  when(mockedEnsOwnership.areNamesOwned(anything())).thenCall((names: Map<EthAddress, string[]>) => {
+    const entries = Array.from(names.entries()).map<[EthAddress, Map<string, boolean>]>(([address, names]) => [
+      address,
+      new Map(names.map((name) => [name, address === ethAddress && owned.includes(name)]))
+    ])
+    return Promise.resolve(new Map(entries))
+  })
+  return instance(mockedEnsOwnership)
+}
+
+function ownedWearables(ethAddress: EthAddress, ...wearables: WearableId[]): WearablesOwnership {
+  const mockedWearablesOwnership = mock(WearablesOwnership)
+  const result = new Map([[ethAddress, { wearables: new Set(wearables), updatedMillisAgo: 0 }]])
+  when(mockedWearablesOwnership.getWearablesOwnedByAddresses(anything())).thenResolve(result)
+  return instance(mockedWearablesOwnership)
+}
+
+function noWearables(): WearablesOwnership {
+  const mockedWearablesOwnership = mock(WearablesOwnership)
+  when(mockedWearablesOwnership.getWearablesOwnedByAddresses(anything())).thenCall((addresses) =>
+    Promise.resolve(new Map(addresses.map((address) => [address, { ownedWearables: new Set() }])))
+  )
+  return instance(mockedWearablesOwnership)
+}

--- a/lambdas/test/apis/profiles/controller/profiles.spec.ts
+++ b/lambdas/test/apis/profiles/controller/profiles.spec.ts
@@ -50,6 +50,18 @@ describe('profiles', () => {
     expect(profiles[0].avatars[0].avatar.wearables.length).toEqual(0)
   })
 
+  it(`When some of the worn wearables are not owned but sanitization is off, then they are not filtered out`, async () => {
+    const { entity } = profileWith(SOME_ADDRESS, { wearables: [WEARABLE_ID_1] })
+    const client = contentServer(entity)
+    const ensOwnership = noNames()
+    const wearablesOwnership = ownedWearables(SOME_ADDRESS, 'Some other id')
+
+    const profiles = await fetchProfiles([SOME_ADDRESS], client, ensOwnership, wearablesOwnership, false)
+
+    expect(profiles.length).toEqual(1)
+    expect(profiles[0].avatars[0].avatar.wearables).toEqual([WEARABLE_ID_1])
+  })
+
   it(`When the is no profile with that address, then an empty list is returned`, async () => {
     const client = contentServer()
     const ensOwnership = noNames()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,6 +27,7 @@
     "lib": ["es2017", "dom", "esnext.asynciterable", "esnext"],
     "paths": {
       "@katalyst/content/*": ["content/src/*"],
+      "@katalyst/lambdas/*": ["lambdas/src/*"],
       "@katalyst/test-helpers/*": ["content/test/helpers/*"],
       "decentraland-katalyst-contracts/*": ["contracts/*"],
       "decentraland-katalyst-commons/*": ["commons/servers/*"],


### PR DESCRIPTION
We are now adding wearable sanitization to profiles. This means that we are filtering out wearables that are no longer owned by the user.

To do so, we added a cache that looks like this: `Cache<EthAddress, { wearable: Set<WearabledId>, lastFetched: Date }>`

We are storing the lastFetched data, so that we can return it later on another endpoint, where we will be able to request all wearables owned by the user.