### PR TITLE
fix: set timeout for sync fetch

### DIFF
--- a/content/src/service/synchronization/clients/ContentServerClient.ts
+++ b/content/src/service/synchronization/clients/ContentServerClient.ts
@@ -34,16 +34,19 @@ export class ContentServerClient {
     let error = false
 
     // Fetch the deployments
-    const stream = this.client.streamAllDeployments({
-      filters: { fromLocalTimestamp: this.lastLocalDeploymentTimestamp + 1 },
-      fields: DeploymentFields.AUDIT_INFO,
-      errorListener: (errorMessage) => {
-        error = true
-        ContentServerClient.LOGGER.error(
-          `Failed to get new entities from content server '${this.getAddress()}'\n${errorMessage}`
-        )
-      }
-    })
+    const stream = this.client.streamAllDeployments(
+      {
+        filters: { fromLocalTimestamp: this.lastLocalDeploymentTimestamp + 1 },
+        fields: DeploymentFields.AUDIT_INFO,
+        errorListener: (errorMessage) => {
+          error = true
+          ContentServerClient.LOGGER.error(
+            `Failed to get new entities from content server '${this.getAddress()}'\n${errorMessage}`
+          )
+        }
+      },
+      { timeout: '20s' }
+    )
 
     // Listen to all deployments passing through, and store the newest one's timestamps
     const passTrough = passThrough(


### PR DESCRIPTION
The fetch used for syncing was set to 2m by default. Now, we are making sure that the timeout is much smaller.

This is necessary because some servers might be really slow, and we want to make sure that the sync doesn't hang, waiting to fetch everything from them. Take into account that this call is a simple json fetch, should not take more than 20s