### PR TITLE
chore: add logs on fallback to old content

### DIFF
--- a/lambdas/src/apis/content-v2/controllers/translator.ts
+++ b/lambdas/src/apis/content-v2/controllers/translator.ts
@@ -181,6 +181,7 @@ export async function getContents(fetcher: SmartContentServerFetcher, req: Reque
       // Let's try on the old content server
       const legacyContentServerResponse = await fetch(`https://content.decentraland.org/contents/${cid}`)
       if (legacyContentServerResponse.ok) {
+        LOGGER.info(`Failed to find '${cid}' on the content server, but found it on the legacy one.`)
         copySuccessResponse(legacyContentServerResponse, res)
       } else {
         res.status(404).send()


### PR DESCRIPTION
We currently have a fallback in place where lambdas go to the old content server if they don't find something. 

We are not sure if this fallback is still being used, so we are adding some logs to it.