### PR TITLE
feat: add support for file references inside profiles

### DIFF
--- a/lambdas/BUILD.bazel
+++ b/lambdas/BUILD.bazel
@@ -16,7 +16,7 @@ nodejs_binary(
         "@npm//@bazel/typescript",
         "@npm//typescript",
     ],
-    entry_point = "entrypoints/run-server.ts",
+    entry_point = "//lambdas/src:entrypoints/run-server.ts",
 )
 
 load("//tools/npm:package.bzl", "dataform_npm_package")

--- a/lambdas/src/apis/profiles/controllers/profiles.ts
+++ b/lambdas/src/apis/profiles/controllers/profiles.ts
@@ -123,11 +123,11 @@ function addBaseUrlToSnapshots(
   for (const key in original) {
     const originalValue = original[key]
     if (content.has(originalValue)) {
-      // Key references a content file
+      // Snapshot references a content file
       const hash = content.get(originalValue)!
       snapshots[key] = baseUrl + `/contents/${hash}`
     } else {
-      // Key is directly a hash
+      // Snapshot is directly a hash
       snapshots[key] = baseUrl + `/contents/${originalValue}`
     }
   }

--- a/lambdas/test/apis/profiles/controller/profiles.spec.ts
+++ b/lambdas/test/apis/profiles/controller/profiles.spec.ts
@@ -9,7 +9,7 @@ import { anything, instance, mock, when } from 'ts-mockito'
 
 const EXTERNAL_URL = 'https://content-url.com'
 
-fdescribe('profiles', () => {
+describe('profiles', () => {
   const SOME_ADDRESS = '0x079bed9c31cb772c4c156f86e1cff15bf751add0'
   const SOME_NAME = 'NFTName'
   const WEARABLE_ID_1 = 'someCollection-someWearable'


### PR DESCRIPTION
Right now, profiles metadata looks like this on the content server:
```
{
    "avatars": [
        {
            "userId": "0xe100cf9c1d7a96a7790cb54b86658572c755ab2f",
            "name": "Chamo",
            "avatar": {
            "bodyShape": "dcl://base-avatars/BaseMale",
            "snapshots": {
                "face": "QmQUEPgRA2kR5A8YsXngguA9g7zu5TurtNvABpYtyWQ8tJ",
                "face128": "QmaYUWCBoVVWCGvGu6qgZiLvyNNYM9NseSspAzq2X74gEY",
                "face256": "QmRW7cAP8UMuNH1xUF5giDvxU2wVVnNe3Jjz2CUii93v19",
                "body": "QmNmLGQmsNMnbJ9mmPDoGEHBKufqtDjDLdTuNa9DREtegY"
            },
            ....
        },
    ]
}
```

If you look at the snapshots, those property values are file hashes. This means that clients that want to create/update profiles need to know exactly how the content server calculates hashes, so that they match the uploaded files. This isn't the best way to do it, since that hashing mechanism could change in the future.

The plan is to support snapshots that, instead of having a hash, reference the content file by name. For example:
```
"snapshots": {
    "face": "./face.png",
    "face128": "./face128.png",
    "face256": "./face256.png",
    "body": "./body.png"
},
```
The lambda will see that reference, and replace it with a hash in a transparent way. 