### PR TITLE
fix: prevent flooding metrics and enable lambdas metrics endpoint

### DIFF
--- a/commons/servers/metrics.ts
+++ b/commons/servers/metrics.ts
@@ -33,12 +33,12 @@ export class Metrics {
 
   static requestCounters = function (req, res, next) {
     numRequests.inc({ method: req.method })
-    pathsTaken.inc({ path: req.path })
+    pathsTaken.inc({ path: req.route.path })
     next()
   }
 
   static responseCounters = ResponseTime(function (req, res, time) {
-    responses.labels(req.method, req.url, res.statusCode).observe(time)
+    responses.labels(req.method, req.route.path, res.statusCode).observe(time)
   })
 
   static injectMetricsRoute(app: express.Express) {

--- a/lambdas/src/Environment.ts
+++ b/lambdas/src/Environment.ts
@@ -74,7 +74,8 @@ export const enum EnvironmentConfig {
   PROFILE_NAMES_CACHE_MAX,
   PROFILE_NAMES_CACHE_TIMEOUT,
   PROFILE_WEARABLES_CACHE_MAX,
-  PROFILE_WEARABLES_CACHE_TIMEOUT
+  PROFILE_WEARABLES_CACHE_TIMEOUT,
+  METRICS
 }
 
 export class EnvironmentBuilder {
@@ -154,6 +155,7 @@ export class EnvironmentBuilder {
     this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.PROFILE_WEARABLES_CACHE_TIMEOUT, () =>
       ms(process.env.PROFILE_WEARABLES_CACHE_TIMEOUT ?? '30m')
     )
+    this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.METRICS, () => process.env.METRICS === 'true')
 
     // Please put special attention on the bean registration order.
     // Some beans depend on other beans, so the required beans should be registered before

--- a/lambdas/src/Server.ts
+++ b/lambdas/src/Server.ts
@@ -1,5 +1,6 @@
 import compression from 'compression'
 import cors from 'cors'
+import { Metrics } from 'decentraland-katalyst-commons/metrics'
 import express, { RequestHandler } from 'express'
 import http from 'http'
 import log4js from 'log4js'
@@ -43,6 +44,10 @@ export class Server {
     this.app.use(express.json())
     if (env.getConfig(EnvironmentConfig.LOG_REQUESTS)) {
       this.app.use(morgan('combined'))
+    }
+
+    if (env.getConfig(EnvironmentConfig.METRICS)) {
+      Metrics.initialize(this.app)
     }
 
     // Base endpoints


### PR DESCRIPTION
The common practice is to register the route instead of the final url paths to normalize analysis.

![Screen Shot 2021-02-03 at 21 40 52](https://user-images.githubusercontent.com/260114/106828205-7e81cd80-6668-11eb-89e4-81ceea5c6acb.png)

This PR uses express' router to register the route instead of the final paths, `req.route.path`.

---

From express docs:

### req.route

Contains the currently-matched route, a string. For example:

```
app.get('/user/:id?', function userIdHandler (req, res) {
  console.log(req.route)
  res.send('GET')
})
```

Example output from the previous snippet:

```
{ path: '/user/:id?',
  stack:
   [ { handle: [Function: userIdHandler],
       name: 'userIdHandler',
       params: undefined,
       path: undefined,
       keys: [],
       regexp: /^\/?$/i,
       method: 'get' } ],
  methods: { get: true } }
```