### PR TITLE
feat: adding wearables by owner endpoint

### DIFF
--- a/lambdas/src/Environment.ts
+++ b/lambdas/src/Environment.ts
@@ -6,6 +6,7 @@ import { DAOCacheFactory } from './service/dao/DAOCacheFactory'
 import { ServiceFactory } from './service/ServiceFactory'
 import { SmartContentClientFactory } from './utils/SmartContentClientFactory'
 import { SmartContentServerFetcherFactory } from './utils/SmartContentServerFetcherFactory'
+import { TheGraphClientFactory } from './utils/TheGraphClientFactory'
 
 const DEFAULT_SERVER_PORT = 7070
 export const DEFAULT_ETH_NETWORK = 'ropsten'
@@ -57,7 +58,8 @@ export const enum Bean {
   SMART_CONTENT_SERVER_CLIENT,
   DAO,
   ENS_OWNERSHIP,
-  WEARABLES_OWNERSHIP
+  WEARABLES_OWNERSHIP,
+  THE_GRAPH_CLIENT
 }
 
 export const enum EnvironmentConfig {
@@ -164,6 +166,7 @@ export class EnvironmentBuilder {
       SmartContentServerFetcherFactory.create(env)
     )
     this.registerBeanIfNotAlreadySet(env, Bean.SMART_CONTENT_SERVER_CLIENT, () => SmartContentClientFactory.create(env))
+    this.registerBeanIfNotAlreadySet(env, Bean.THE_GRAPH_CLIENT, () => TheGraphClientFactory.create(env))
     this.registerBeanIfNotAlreadySet(env, Bean.DAO, () => DAOCacheFactory.create(env))
     this.registerBeanIfNotAlreadySet(env, Bean.SERVICE, () => ServiceFactory.create(env))
     this.registerBeanIfNotAlreadySet(env, Bean.CONTROLLER, () => ControllerFactory.create(env))

--- a/lambdas/src/Server.ts
+++ b/lambdas/src/Server.ts
@@ -18,6 +18,7 @@ import { Controller } from './controller/Controller'
 import { Bean, Environment, EnvironmentConfig } from './Environment'
 import { SmartContentClient } from './utils/SmartContentClient'
 import { SmartContentServerFetcher } from './utils/SmartContentServerFetcher'
+import { TheGraphClient } from './utils/TheGraphClient'
 
 export class Server {
   private port: number
@@ -57,6 +58,7 @@ export class Server {
     const wearablesOwnership: WearablesOwnership = env.getBean(Bean.WEARABLES_OWNERSHIP)
     const fetcher: SmartContentServerFetcher = env.getBean(Bean.SMART_CONTENT_SERVER_FETCHER)
     const contentClient: SmartContentClient = env.getBean(Bean.SMART_CONTENT_SERVER_CLIENT)
+    const theGraphClient: TheGraphClient = env.getBean(Bean.THE_GRAPH_CLIENT)
 
     // Backwards compatibility for older Content API
     this.app.use('/contentv2', initializeContentV2Routes(express.Router(), fetcher))
@@ -84,7 +86,7 @@ export class Server {
     this.app.use('/contracts', initializeContractRoutes(express.Router(), env.getBean(Bean.DAO)))
 
     // DAO Collections access API
-    this.app.use('/collections', initializeCollectionsRoutes(express.Router(), contentClient))
+    this.app.use('/collections', initializeCollectionsRoutes(express.Router(), contentClient, theGraphClient))
 
     // Functionality for Explore use case
     this.app.use('/explore', initializeExploreRoutes(express.Router(), env.getBean(Bean.DAO), contentClient))

--- a/lambdas/src/apis/collections/controllers/collections.ts
+++ b/lambdas/src/apis/collections/controllers/collections.ts
@@ -1,6 +1,7 @@
 import { SmartContentClient } from '@katalyst/lambdas/utils/SmartContentClient'
 import { Entity, EntityType } from 'dcl-catalyst-commons'
 import { Request, Response } from 'express'
+import { WearableMetadata } from '../types'
 
 export async function getStandardErc721(client: SmartContentClient, req: Request, res: Response) {
   // Method: GET
@@ -139,11 +140,4 @@ const RARITIES_EMISSIONS = {
   legendary: 100,
   mythic: 10,
   unique: 1
-}
-
-type WearableMetadata = {
-  name: string
-  rarity: string
-  image?: string
-  thumbnail?: string
 }

--- a/lambdas/src/apis/collections/controllers/wearables.ts
+++ b/lambdas/src/apis/collections/controllers/wearables.ts
@@ -1,0 +1,77 @@
+import { SmartContentClient } from '@katalyst/lambdas/utils/SmartContentClient'
+import { TheGraphClient } from '@katalyst/lambdas/utils/TheGraphClient'
+import { EntityType } from 'dcl-catalyst-commons'
+import { EthAddress } from 'dcl-crypto'
+import { Request, Response } from 'express'
+import { WearableMetadata } from '../types'
+import { WearableId } from './collections'
+
+// Different versions of the same query param
+const INCLUDE_DEFINITION_VERSIONS = [
+  'includeDefinition',
+  'includedefinition',
+  'includeDefinitions',
+  'includedefinitions'
+]
+
+export async function getWearablesByOwnerEndpoint(
+  client: SmartContentClient,
+  theGraphClient: TheGraphClient,
+  req: Request,
+  res: Response
+) {
+  // Method: GET
+  // Path: /wearables-by-owner/:owner
+
+  const { owner } = req.params
+  const includeDefinition = INCLUDE_DEFINITION_VERSIONS.some((version) => version in req.query)
+
+  const result = await getWearablesByOwner(owner, includeDefinition, client, theGraphClient)
+  res.send(result)
+}
+
+export async function getWearablesByOwner(
+  owner: EthAddress,
+  includeDefinition: boolean,
+  client: SmartContentClient,
+  theGraphClient: TheGraphClient
+): Promise<{ urn: WearableId; amount: number; definition?: WearableMetadata | undefined }[]> {
+  // Fetch wearables & definitions (if needed)
+  const wearablesByOwner = await theGraphClient.findWearablesByOwner(owner)
+  const definitions: Map<WearableId, Wearable> = includeDefinition
+    ? await fetchDefinitions(wearablesByOwner, client)
+    : new Map()
+
+  // Count wearables by user
+  const count: Map<WearableId, number> = new Map()
+  for (const wearableId of wearablesByOwner) {
+    const amount = count.get(wearableId) ?? 0
+    count.set(wearableId, amount + 1)
+  }
+
+  // Return result
+  return Array.from(count.entries()).map(([id, amount]) => ({
+    urn: id,
+    amount,
+    definition: definitions.get(id)
+  }))
+}
+
+async function fetchDefinitions(
+  wearableIds: WearableId[],
+  client: SmartContentClient
+): Promise<Map<string, WearableMetadata>> {
+  const entities = await client.fetchEntitiesByPointers(EntityType.WEARABLE, wearableIds)
+  return new Map(
+    entities
+      .filter((entity) => !!entity.metadata)
+      .map((entity) => [entity.pointers[0], mapMetadataIntoWearable(entity.metadata)])
+  )
+}
+
+function mapMetadataIntoWearable(metadata: WearableMetadata): Wearable {
+  return metadata
+}
+
+// TODO: Update once we know what the metadata will look like
+type Wearable = WearableMetadata

--- a/lambdas/src/apis/collections/routes.ts
+++ b/lambdas/src/apis/collections/routes.ts
@@ -1,11 +1,18 @@
 import { SmartContentClient } from '@katalyst/lambdas/utils/SmartContentClient'
+import { TheGraphClient } from '@katalyst/lambdas/utils/TheGraphClient'
 import { Request, Response, Router } from 'express'
 import { contentsImage, contentsThumbnail, getStandardErc721 } from './controllers/collections'
+import { getWearablesByOwnerEndpoint as getWearablesByOwnerHandler } from './controllers/wearables'
 
-export function initializeCollectionsRoutes(router: Router, client: SmartContentClient): Router {
+export function initializeCollectionsRoutes(
+  router: Router,
+  client: SmartContentClient,
+  theGraphClient: TheGraphClient
+): Router {
   router.get('/standard/erc721/:chainId/:contract/:option/:emission?', createHandler(client, getStandardErc721))
   router.get('/contents/:urn/image', createHandler(client, contentsImage))
   router.get('/contents/:urn/thumbnail', createHandler(client, contentsThumbnail))
+  router.get('/wearables-by-owner/:owner', (req, res) => getWearablesByOwnerHandler(client, theGraphClient, req, res))
   return router
 }
 

--- a/lambdas/src/apis/collections/types.ts
+++ b/lambdas/src/apis/collections/types.ts
@@ -1,0 +1,7 @@
+// TODO: Talk with DApps team and update
+export type WearableMetadata = {
+  name: string
+  rarity: string
+  image?: string
+  thumbnail?: string
+}

--- a/lambdas/src/apis/profiles/EnsOwnership.ts
+++ b/lambdas/src/apis/profiles/EnsOwnership.ts
@@ -1,49 +1,15 @@
-import { Fetcher } from 'dcl-catalyst-commons'
-import { EthAddress } from 'dcl-crypto'
-import log4js from 'log4js'
+import { TheGraphClient } from '@katalyst/lambdas/utils/TheGraphClient'
 import { NFTOwnership } from './NFTOwnership'
 
 export class EnsOwnership extends NFTOwnership {
-  private static readonly LOGGER = log4js.getLogger('EnsOwnership')
-  private static readonly QUERY: string = `
-    query FetchOwnersByName($names: [String]) {
-        nfts(
-            where: {
-                name_in: $names,
-                category: ens
-            })
-        {
-            name
-            owner {
-              address
-            }
-        }
-    }`
-
-  constructor(
-    private readonly theGraphBaseUrl: string,
-    private readonly fetcher: Fetcher,
-    maxSize: number,
-    maxAge: number
-  ) {
+  constructor(private readonly theGraphClient: TheGraphClient, maxSize: number, maxAge: number) {
     super(maxSize, maxAge)
   }
 
   /** This method will take a list of names and return only those that are owned by the given eth address */
   protected async querySubgraph(names: Name[]) {
-    try {
-      const response = await this.fetcher.queryGraph<{ nfts: { name: Name; owner: { address: EthAddress } }[] }>(
-        this.theGraphBaseUrl,
-        EnsOwnership.QUERY,
-        {
-          names
-        }
-      )
-      return response.nfts.map(({ name, owner }) => ({ nft: name, owner: owner.address }))
-    } catch (error) {
-      EnsOwnership.LOGGER.error(`Could not retrieve ENSs.`, error)
-      return []
-    }
+    const result = await this.theGraphClient.findOwnersByName(names)
+    return result.map(({ name, owner }) => ({ nft: name, owner }))
   }
 }
 

--- a/lambdas/src/apis/profiles/EnsOwnershipFactory.ts
+++ b/lambdas/src/apis/profiles/EnsOwnershipFactory.ts
@@ -4,8 +4,7 @@ import { EnsOwnership } from './EnsOwnership'
 export class EnsOwnershipFactory {
   static create(env: Environment): EnsOwnership {
     return new EnsOwnership(
-      env.getConfig(EnvironmentConfig.ENS_OWNER_PROVIDER_URL),
-      env.getBean(Bean.SMART_CONTENT_SERVER_FETCHER),
+      env.getBean(Bean.THE_GRAPH_CLIENT),
       env.getConfig(EnvironmentConfig.PROFILE_NAMES_CACHE_MAX),
       env.getConfig(EnvironmentConfig.PROFILE_NAMES_CACHE_TIMEOUT)
     )

--- a/lambdas/src/apis/profiles/WearablesOwnership.ts
+++ b/lambdas/src/apis/profiles/WearablesOwnership.ts
@@ -1,50 +1,16 @@
-import { Fetcher } from 'dcl-catalyst-commons'
-import { EthAddress } from 'dcl-crypto'
-import log4js from 'log4js'
+import { TheGraphClient } from '@katalyst/lambdas/utils/TheGraphClient'
 import { NFTOwnership } from './NFTOwnership'
 
 /**
  * This is a custom cache that stores wearables owned by a given user. It can be configured with a max size of elements
  */
 export class WearablesOwnership extends NFTOwnership {
-  private static readonly LOGGER = log4js.getLogger('WearablesOwnership')
-  private static readonly QUERY: string = `
-    query FetchOwnersByURN($urns: [String]) {
-      nfts(
-          where: {
-              urn_in: $urns,
-              searchItemType_in: ["wearable_v1", "wearable_v2"]
-          })
-      {
-          urn
-          owner {
-            address
-          }
-      }
-  }`
-
-  constructor(
-    private readonly theGraphBaseUrl: string,
-    private readonly fetcher: Fetcher,
-    maxSize: number,
-    maxAge: number
-  ) {
+  constructor(private readonly theGraphClient: TheGraphClient, maxSize: number, maxAge: number) {
     super(maxSize, maxAge)
   }
 
   protected async querySubgraph(urns: string[]) {
-    try {
-      const response = await this.fetcher.queryGraph<{ nfts: { urn: string; owner: { address: EthAddress } }[] }>(
-        this.theGraphBaseUrl,
-        WearablesOwnership.QUERY,
-        {
-          urns
-        }
-      )
-      return response.nfts.map(({ urn, owner }) => ({ nft: urn, owner: owner.address }))
-    } catch (error) {
-      WearablesOwnership.LOGGER.error(`Could not retrieve Wearables.`, error)
-      return []
-    }
+    const result = await this.theGraphClient.findOwnersByWearable(urns)
+    return result.map(({ urn, owner }) => ({ nft: urn, owner }))
   }
 }

--- a/lambdas/src/apis/profiles/WearablesOwnershipFactory.ts
+++ b/lambdas/src/apis/profiles/WearablesOwnershipFactory.ts
@@ -4,8 +4,7 @@ import { WearablesOwnership } from './WearablesOwnership'
 export class WearablesOwnershipFactory {
   static create(env: Environment): WearablesOwnership {
     return new WearablesOwnership(
-      env.getConfig(EnvironmentConfig.COLLECTIONS_PROVIDER_URL),
-      env.getBean(Bean.SMART_CONTENT_SERVER_FETCHER),
+      env.getBean(Bean.THE_GRAPH_CLIENT),
       env.getConfig(EnvironmentConfig.PROFILE_WEARABLES_CACHE_MAX),
       env.getConfig(EnvironmentConfig.PROFILE_WEARABLES_CACHE_TIMEOUT)
     )

--- a/lambdas/src/utils/TheGraphClient.ts
+++ b/lambdas/src/utils/TheGraphClient.ts
@@ -1,0 +1,161 @@
+import { Fetcher } from 'dcl-catalyst-commons'
+import { EthAddress } from 'dcl-crypto'
+import log4js from 'log4js'
+import { WearableId } from '../apis/collections/controllers/collections'
+
+export class TheGraphClient {
+  public static readonly MAX_PAGE_SIZE = 1000
+  private static readonly LOGGER = log4js.getLogger('TheGraphClient')
+
+  constructor(private readonly urls: URLs, private readonly fetcher: Fetcher) {}
+
+  public async findOwnersByName(names: string[]): Promise<{ name: string; owner: EthAddress }[]> {
+    const query: Query<
+      { nfts: { name: string; owner: { address: EthAddress } }[] },
+      { name: string; owner: EthAddress }[]
+    > = {
+      description: 'fetch owners by name',
+      subgraph: 'ensSubgraph',
+      query: QUERY_OWNER_BY_NAME,
+      mapper: (response) => response.nfts.map(({ name, owner }) => ({ name, owner: owner.address })),
+      default: []
+    }
+    return this.splitQueryVariablesIntoSlices(query, names, (slicedNames) => ({ names: slicedNames }))
+  }
+
+  public async findOwnersByWearable(wearables: WearableId[]): Promise<{ urn: string; owner: EthAddress }[]> {
+    const query: Query<
+      { nfts: { urn: string; owner: { address: EthAddress } }[] },
+      { urn: string; owner: EthAddress }[]
+    > = {
+      description: 'fetch owners by wearable',
+      subgraph: 'collectionsSubgraph',
+      query: QUERY_OWNER_BY_WEARABLES,
+      mapper: (response) => response.nfts.map(({ urn, owner }) => ({ urn, owner: owner.address })),
+      default: []
+    }
+    return this.splitQueryVariablesIntoSlices(query, wearables, (slicedWearables) => ({ urns: slicedWearables }))
+  }
+
+  public findWearablesByOwner(owner: EthAddress): Promise<WearableId[]> {
+    const query: Query<{ nfts: { urn: string }[] }, WearableId[]> = {
+      description: 'fetch wearables by owner',
+      subgraph: 'collectionsSubgraph',
+      query: QUERY_WEARABLES_BY_OWNER,
+      mapper: (response) => response.nfts.map(({ urn }) => urn),
+      default: []
+    }
+    return this.paginatableQuery(query, { owner: owner.toLowerCase() })
+  }
+
+  /** This method takes a query that could be paginated and performs the pagination internally */
+  private async paginatableQuery<QueryResult, ReturnType extends Array<any>>(
+    query: Query<QueryResult, ReturnType>,
+    variables: Record<string, any>
+  ): Promise<ReturnType> {
+    let result: ReturnType | undefined = undefined
+    let shouldContinue = true
+    let offset = 0
+    while (shouldContinue) {
+      const queried = await this.runQuery(query, { ...variables, first: TheGraphClient.MAX_PAGE_SIZE, skip: offset })
+      if (!result) {
+        result = queried
+      } else {
+        result.push(...queried)
+      }
+      shouldContinue = queried.length === TheGraphClient.MAX_PAGE_SIZE
+      offset += TheGraphClient.MAX_PAGE_SIZE
+    }
+    return result!
+  }
+
+  /**
+   * This method takes a query that has an array input variable, and makes multiple queries if necessary.
+   * This is so that the input doesn't exceed the maximum limit
+   */
+  private async splitQueryVariablesIntoSlices<QueryResult, ReturnType extends Array<any>>(
+    query: Query<QueryResult, ReturnType>,
+    input: string[],
+    inputToVariables: (input: string[]) => Record<string, any>
+  ): Promise<ReturnType | []> {
+    let result: ReturnType | undefined = undefined
+    let offset = 0
+    while (offset < input.length) {
+      const slice = input.slice(offset, offset + TheGraphClient.MAX_PAGE_SIZE)
+      const queried = await this.runQuery(query, inputToVariables(slice))
+      if (!result) {
+        result = queried
+      } else {
+        result.push(...queried)
+      }
+      offset += TheGraphClient.MAX_PAGE_SIZE
+    }
+    return result ?? []
+  }
+
+  private async runQuery<QueryResult, ReturnType>(
+    query: Query<QueryResult, ReturnType>,
+    variables: Record<string, any>
+  ): Promise<ReturnType> {
+    try {
+      const response = await this.fetcher.queryGraph<QueryResult>(this.urls[query.subgraph], query.query, variables)
+      return query.mapper(response)
+    } catch (error) {
+      TheGraphClient.LOGGER.error(
+        `Failed to execute the following query to the subgraph '${query.description}'.`,
+        error
+      )
+      return query.default
+    }
+  }
+}
+
+const QUERY_WEARABLES_BY_OWNER: string = `
+  query WearablesByOwner($owner: String, $first: Int, $skip: Int) {
+    nfts(where: {owner: $owner}, first: $first, skip: $skip) {
+      urn
+    }
+  }`
+
+const QUERY_OWNER_BY_WEARABLES = `
+  query FetchOwnersByURN($urns: [String]) {
+    nfts(
+        where: {
+            urn_in: $urns,
+            searchItemType_in: ["wearable_v1", "wearable_v2"]
+        })
+    {
+        urn
+        owner {
+          address
+        }
+    }
+  }`
+
+const QUERY_OWNER_BY_NAME = `
+  query FetchOwnersByName($names: [String]) {
+    nfts(
+      where: {
+        name_in: $names,
+        category: ens
+      })
+    {
+      name
+      owner {
+        address
+      }
+    }
+  }`
+
+type Query<QueryResult, ReturnType> = {
+  description: string
+  subgraph: keyof URLs
+  query: string
+  mapper: (queryResult: QueryResult) => ReturnType
+  default: ReturnType
+}
+
+type URLs = {
+  ensSubgraph: string
+  collectionsSubgraph: string
+}

--- a/lambdas/src/utils/TheGraphClientFactory.ts
+++ b/lambdas/src/utils/TheGraphClientFactory.ts
@@ -1,0 +1,10 @@
+import { Bean, Environment, EnvironmentConfig } from '../Environment'
+import { TheGraphClient } from './TheGraphClient'
+
+export class TheGraphClientFactory {
+  static create(env: Environment): TheGraphClient {
+    const collectionsSubgraph: string = env.getConfig(EnvironmentConfig.COLLECTIONS_PROVIDER_URL)
+    const ensSubgraph: string = env.getConfig(EnvironmentConfig.ENS_OWNER_PROVIDER_URL)
+    return new TheGraphClient({ collectionsSubgraph, ensSubgraph }, env.getBean(Bean.SMART_CONTENT_SERVER_FETCHER))
+  }
+}


### PR DESCRIPTION
We are now adding a new lambda: `/collections/wearables-by-owner/:ethAddress`

Based on the ethAddress, this lambda will return the ids of the owned wearables, with their respective amount. The payload will look like this:
```
type Response = { 
  urn: WearableId,
  amount: number,
  definition?: Wearable
}[]
```
There is an optional property called `definition`. If the query param `includeDefinitions` is set on the request, then the wearable's definition will be included in the response.

**Note**
There was some refactoring done, in order to create `TheGraphClient`. This client will be in charge of handling all interactions with the graph. I noted that we were having the graph logic in lots of places, sometimes repeated, so I grouped everything under one class.