### PR TITLE
Downgrade typescript version to fix comms build

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "ts-mockito": "^2.6.1",
     "ts-proto": "^1.8.0",
     "ts-protoc-gen": "^0.14.0",
-    "typescript": "^3.9.9",
+    "typescript": "^3.7.7",
     "web3x-codegen": "^4.0.6",
     "yargs": "^16.2.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8742,7 +8742,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.2.2, typescript@^3.9.9:
+typescript@^3.2.2, typescript@^3.7.7:
   version "3.9.9"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.9.tgz#e69905c54bc0681d0518bd4d587cc6f2d0b1a674"
   integrity sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==


### PR DESCRIPTION
After bumping typescript from 3.7.4 to 3.9.8  in https://github.com/decentraland/catalyst/commit/d099fbad29df3aaa522f0d5c9b7a78d1d557a031 the build for comms failed.

So, to fix the build in the master branch, we downgraded the dependency and created another issue to investigate if we can bump the library.