### PR TITLE
fix: Changing rollup config of monitor to fix lighthouse build

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
  # We need to skip that file as it makes eslint to hang
 comms/peer/src/Peer.ts
 status/**/*
+comms/lighthouse/rollup.config.js

--- a/comms/lighthouse/rollup.config.js
+++ b/comms/lighthouse/rollup.config.js
@@ -1,6 +1,5 @@
 import commonjs from '@rollup/plugin-commonjs'
 import npm from '@rollup/plugin-node-resolve'
-import ts from '@wessberg/rollup-plugin-ts'
 import react from 'react'
 import reactDom from 'react-dom'
 import globals from 'rollup-plugin-node-globals'
@@ -15,6 +14,7 @@ export default {
   output: {
     name: 'bundle'
   },
+  context: 'this',
   plugins: [
     json(),
     npm({ preferBuiltins: true, browser: true }),
@@ -25,8 +25,6 @@ export default {
         'react-dom': Object.keys(reactDom)
       }
     }),
-    globals(),
-    ,
-    ts({})
+    globals()
   ]
 }


### PR DESCRIPTION
It seems with the update to a new version of typescript, it started to include some code in the build of the lighthouse monitor that failed when rollup would try to bundle it all together.

In order to fix this:
* Added 'this' as context to rollup (the code that typescript started to include used this in global scope, but checking if it is undefined or not).
* Removed 'ts' as plugin for the build, since the input of rollup is already transpiled