### PR TITLE
fix: build lighthouse in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,6 +85,9 @@ jobs:
     steps:
       - <<: *attach_root
       - run:
+          name: Build lighthouse
+          command: npx bazel build //comms/lighthouse:server --test_output=all
+      - run:
           name: Run tests
           command: npx bazel test //comms/lighthouse:unit_test --test_output=all
 


### PR DESCRIPTION
We are now building the lighthouse server as part of the CI, to catch any problems with the build process