### PR TITLE
fix: Added status handler for when id is taken, and properly connected it

### DIFF
--- a/comms/peer/rollup.config.js
+++ b/comms/peer/rollup.config.js
@@ -1,5 +1,3 @@
-import ts from '@wessberg/rollup-plugin-ts'
-
 /* eslint-disable @typescript-eslint/no-var-requires */
 const json = require('rollup-plugin-json')
 
@@ -10,5 +8,5 @@ export default {
   output: {
     name: 'bundle'
   },
-  plugins: [json(), ts({})]
+  plugins: [json()]
 }

--- a/comms/peer/src/Peer.ts
+++ b/comms/peer/src/Peer.ts
@@ -10,7 +10,7 @@ import { randomUint32 } from '../../../commons/utils/util'
 import { ConnectionRejectReasons, PEER_CONSTANTS } from './constants'
 import { PeerMessageType, PingMessageType, PongMessageType, SuspendRelayType } from './messageTypes'
 import { PeerHttpClient } from './PeerHttpClient'
-import { ServerMessageType } from './peerjs-server-connector/enums'
+import { PeerErrorType, ServerMessageType } from './peerjs-server-connector/enums'
 import { HandshakeData } from './peerjs-server-connector/peerjsserverconnection'
 import { ServerMessage } from './peerjs-server-connector/servermessage'
 import { delay, pickBy, pickRandom } from './peerjs-server-connector/util'
@@ -145,7 +145,11 @@ export class Peer implements IPeer {
     this.wrtcHandler.on(PeerWebRTCEvent.PeerConnectionLost, this.handlePeerConnectionLost.bind(this))
 
     this.wrtcHandler.on(PeerWebRTCEvent.ServerConnectionError, async (err) => {
-      if (!this.retryingConnection) await this.retryConnection()
+      if (err.type === PeerErrorType.UnavailableID) {
+        this.config.statusHandler!('id-taken')
+      } else {
+        if (!this.retryingConnection) await this.retryConnection()
+      }
     })
 
     this.setUpTimeToRequestOptimumNetwork()

--- a/comms/peer/src/types.ts
+++ b/comms/peer/src/types.ts
@@ -86,7 +86,7 @@ export type PeerConfig = {
   optimizeNetworkInterval?: number
   authHandler?: (msg: string) => Promise<string>
   positionConfig?: PositionConfig
-  statusHandler?: (status: string) => void
+  statusHandler?: (status: PeerStatus) => void
   statsUpdateInterval?: number
   /**
    * If not set, the peer won't execute pings regularly.
@@ -169,3 +169,5 @@ export type PeerRelayData = {
    */
   pendingSuspensionRequests: string[]
 }
+
+export type PeerStatus = 'reconnection-error' | 'id-taken'

--- a/comms/peer/test/Peer.integration.spec.ts
+++ b/comms/peer/test/Peer.integration.spec.ts
@@ -970,6 +970,24 @@ describe('Peer Integration Test', function () {
 
   it('handles authentication', () => {})
 
+  it('raises an specific error when the requested id is taken', async () => {
+    let idTakenErrorReceived = false
+    extraPeersConfig = {
+      statusHandler: (status) => {
+        if (status === 'id-taken') {
+          idTakenErrorReceived = true
+        }
+      }
+    }
+    const [socket] = await createPeer('peer')
+
+    socket.onmessage({
+      data: JSON.stringify({ type: ServerMessageType.IdTaken, payload: { msg: 'ETH Address is taken' } })
+    })
+
+    expect(idTakenErrorReceived).toEqual(true)
+  })
+
   function getConnectedPeers(peer: Peer) {
     //@ts-ignore
     return peer.wrtcHandler.connectedPeers

--- a/version.bzl
+++ b/version.bzl
@@ -1,3 +1,3 @@
 # NOTE: If you change the format of this line, you must change the bash command
 # in /scripts/publish to extract the version string correctly.
-LH_VERSION = "0.2.19"
+LH_VERSION = "0.2.20"


### PR DESCRIPTION
We are not handling the status of peer connections when the server rejects because an id is taken. This should fix that. After this, we will need to update the peer library in Explorer.