### PR TITLE
fix: make correct call to collections subgraph

### DIFF
--- a/lambdas/src/apis/profiles/EnsOwnership.ts
+++ b/lambdas/src/apis/profiles/EnsOwnership.ts
@@ -9,7 +9,7 @@ export class EnsOwnership extends NFTOwnership {
 
   protected async querySubgraph(nftsToCheck: [EthAddress, Name[]][]) {
     const result = await this.theGraphClient.checkForNamesOwnership(nftsToCheck)
-    return result.map(({ names, owner }) => ({ ownedNfts: names, owner }))
+    return result.map(({ names, owner }) => ({ ownedNFTs: names, owner }))
   }
 }
 

--- a/lambdas/src/apis/profiles/EnsOwnership.ts
+++ b/lambdas/src/apis/profiles/EnsOwnership.ts
@@ -1,4 +1,5 @@
 import { TheGraphClient } from '@katalyst/lambdas/utils/TheGraphClient'
+import { EthAddress } from 'dcl-crypto'
 import { NFTOwnership } from './NFTOwnership'
 
 export class EnsOwnership extends NFTOwnership {
@@ -6,10 +7,9 @@ export class EnsOwnership extends NFTOwnership {
     super(maxSize, maxAge)
   }
 
-  /** This method will take a list of names and return only those that are owned by the given eth address */
-  protected async querySubgraph(names: Name[]) {
-    const result = await this.theGraphClient.findOwnersByName(names)
-    return result.map(({ name, owner }) => ({ nft: name, owner }))
+  protected async querySubgraph(nftsToCheck: [EthAddress, Name[]][]) {
+    const result = await this.theGraphClient.checkForNamesOwnership(nftsToCheck)
+    return result.map(({ names, owner }) => ({ ownedNfts: names, owner }))
   }
 }
 

--- a/lambdas/src/apis/profiles/NFTOwnership.ts
+++ b/lambdas/src/apis/profiles/NFTOwnership.ts
@@ -71,7 +71,7 @@ export abstract class NFTOwnership {
 
   protected abstract querySubgraph(
     nftsToCheck: [EthAddress, NFTId[]][]
-  ): Promise<{ owner: EthAddress; ownedNfts: NFTId[] }[]>
+  ): Promise<{ owner: EthAddress; ownedNFTs: NFTId[] }[]>
 
   /** Return a set of the NFTs that are actually owned by the user */
   private async checkForOwnership(nftsToCheck: Map<EthAddress, NFTId[]>): Promise<Map<EthAddress, Set<NFTId>>> {
@@ -80,9 +80,9 @@ export abstract class NFTOwnership {
     let offset = 0
     while (offset < entries.length) {
       const slice = entries.slice(offset, offset + NFTOwnership.NFT_FRAGMENTS_PER_QUERY)
-      const ownedNFTs = await this.querySubgraph(slice)
-      for (const { ownedNfts, owner } of ownedNFTs) {
-        result.set(owner, new Set(ownedNfts))
+      const queryResult = await this.querySubgraph(slice)
+      for (const { ownedNFTs, owner } of queryResult) {
+        result.set(owner, new Set(ownedNFTs))
       }
       offset += NFTOwnership.NFT_FRAGMENTS_PER_QUERY
     }

--- a/lambdas/src/apis/profiles/NFTOwnership.ts
+++ b/lambdas/src/apis/profiles/NFTOwnership.ts
@@ -5,10 +5,10 @@ import LRU from 'lru-cache'
  * This is a custom cache for storing the owner of a given NFT. It can be configured with a max size of elements
  */
 export abstract class NFTOwnership {
-  private static readonly PAGE_SIZE = 1000 // The graph has a 1000 limit when return the response
+  private static readonly NFT_FRAGMENTS_PER_QUERY = 10
 
-  // The cache lib returns undefined when no value was calculated at all. We will set a 'null' value when we checked the blockchain, and there was no owner
-  private internalCache: LRU<NFTId, EthAddress | null>
+  // The cache lib returns undefined when no value was calculated at all
+  private internalCache: LRU<NFTIdOwnerPair, Owned>
 
   constructor(maxSize: number, maxAge: number) {
     this.internalCache = new LRU({ max: maxSize, maxAge })
@@ -26,8 +26,7 @@ export abstract class NFTOwnership {
       Array.from(check.keys()).map((ethAddress) => [ethAddress.toLowerCase(), new Map()])
     )
 
-    // We will keep the unknown nfts in 2 different structures, so that it is easier to use them later
-    const unknown: NFTId[] = []
+    // Place to store unknown NFTs
     const unknownMap: Map<EthAddress, NFTId[]> = new Map()
 
     // Check what is on the cache
@@ -35,9 +34,10 @@ export abstract class NFTOwnership {
       const lowerCaseAddress = ethAddress.toLowerCase()
       const ethAddressResult = result.get(lowerCaseAddress)!
       for (const nft of nfts) {
-        const owner = this.internalCache.get(nft)
-        if (owner === undefined) {
-          unknown.push(nft)
+        const pair = this.buildOwnerIdPair(lowerCaseAddress, nft)
+        const owned = this.internalCache.get(pair)
+        if (owned === undefined) {
+          // Unknown NFTS
           const unknownNFTsPerAddress = unknownMap.get(lowerCaseAddress)
           if (!unknownNFTsPerAddress) {
             unknownMap.set(lowerCaseAddress, [nft])
@@ -45,44 +45,56 @@ export abstract class NFTOwnership {
             unknownNFTsPerAddress.push(nft)
           }
         } else {
-          ethAddressResult.set(nft, lowerCaseAddress === owner)
+          // NFT ownership already in cache
+          ethAddressResult.set(nft, owned)
         }
       }
     }
 
-    // Fetch owners for unknown nfts
-    const graphFetchResult = await this.fetchActualOwners(unknown)
+    // Check ownership for unknown nfts
+    const graphFetchResult = await this.checkForOwnership(unknownMap)
 
     // Store fetched data in the cache, and add missing information to the result
     for (const [ethAddress, nfts] of unknownMap) {
       const ethAddressResult = result.get(ethAddress)!
-      for (const nfs of nfts) {
-        const owner = graphFetchResult.get(nfs)
-        this.internalCache.set(nfs, owner ?? null) // We are setting undefined values to null. This is so that we know we queried the data, and there is no owner
-        ethAddressResult.set(nfs, owner === ethAddress)
+      const ownedNfts = graphFetchResult.get(ethAddress)!
+      for (const nft of nfts) {
+        const pair = this.buildOwnerIdPair(ethAddress, nft)
+        const owned = ownedNfts.has(nft)
+        this.internalCache.set(pair, owned)
+        ethAddressResult.set(nft, owned)
       }
     }
 
     return result
   }
 
-  protected abstract querySubgraph(ids: NFTId[]): Promise<{ nft: NFTId; owner: EthAddress }[]>
+  protected abstract querySubgraph(
+    nftsToCheck: [EthAddress, NFTId[]][]
+  ): Promise<{ owner: EthAddress; ownedNfts: NFTId[] }[]>
 
-  private async fetchActualOwners(ids: NFTId[]): Promise<Map<NFTId, EthAddress>> {
-    const result: Map<NFTId, EthAddress> = new Map()
+  /** Return a set of the NFTs that are actually owned by the user */
+  private async checkForOwnership(nftsToCheck: Map<EthAddress, NFTId[]>): Promise<Map<EthAddress, Set<NFTId>>> {
+    const entries = Array.from(nftsToCheck.entries())
+    const result: Map<EthAddress, Set<NFTId>> = new Map()
     let offset = 0
-    while (offset < ids.length) {
-      const slice = ids.slice(offset, offset + NFTOwnership.PAGE_SIZE)
-      const owners = await this.querySubgraph(slice)
-      for (const { nft, owner } of owners) {
-        result.set(nft, owner)
+    while (offset < entries.length) {
+      const slice = entries.slice(offset, offset + NFTOwnership.NFT_FRAGMENTS_PER_QUERY)
+      const ownedNFTs = await this.querySubgraph(slice)
+      for (const { ownedNfts, owner } of ownedNFTs) {
+        result.set(owner, new Set(ownedNfts))
       }
-      offset += NFTOwnership.PAGE_SIZE
+      offset += NFTOwnership.NFT_FRAGMENTS_PER_QUERY
     }
 
     return result
+  }
+
+  private buildOwnerIdPair(owner: EthAddress, nftId: NFTId): NFTIdOwnerPair {
+    return `${owner}-${nftId}`
   }
 }
 
+type NFTIdOwnerPair = string
 type Owned = boolean
 type NFTId = string

--- a/lambdas/src/apis/profiles/WearablesOwnership.ts
+++ b/lambdas/src/apis/profiles/WearablesOwnership.ts
@@ -1,4 +1,5 @@
 import { TheGraphClient } from '@katalyst/lambdas/utils/TheGraphClient'
+import { EthAddress } from 'dcl-crypto'
 import { NFTOwnership } from './NFTOwnership'
 
 /**
@@ -9,8 +10,8 @@ export class WearablesOwnership extends NFTOwnership {
     super(maxSize, maxAge)
   }
 
-  protected async querySubgraph(urns: string[]) {
-    const result = await this.theGraphClient.findOwnersByWearable(urns)
-    return result.map(({ urn, owner }) => ({ nft: urn, owner }))
+  protected async querySubgraph(nftsToCheck: [EthAddress, string[]][]) {
+    const result = await this.theGraphClient.checkForWearablesOwnership(nftsToCheck)
+    return result.map(({ urns, owner }) => ({ ownedNfts: urns, owner }))
   }
 }

--- a/lambdas/src/apis/profiles/WearablesOwnership.ts
+++ b/lambdas/src/apis/profiles/WearablesOwnership.ts
@@ -12,6 +12,6 @@ export class WearablesOwnership extends NFTOwnership {
 
   protected async querySubgraph(nftsToCheck: [EthAddress, string[]][]) {
     const result = await this.theGraphClient.checkForWearablesOwnership(nftsToCheck)
-    return result.map(({ urns, owner }) => ({ ownedNfts: urns, owner }))
+    return result.map(({ urns, owner }) => ({ ownedNFTs: urns, owner }))
   }
 }

--- a/lambdas/src/utils/TheGraphClient.ts
+++ b/lambdas/src/utils/TheGraphClient.ts
@@ -46,7 +46,7 @@ export class TheGraphClient {
     const nameList = names.map((name) => `"${name}"`).join(',')
     // We need to add a 'P' prefix, because the graph needs the fragment name to start with a letter
     return `
-      P${ethAddress}: nfts(where: { owner: "${ethAddress}", category: ens, name_in: [${nameList}] }) {
+      P${ethAddress}: nfts(where: { owner: "${ethAddress}", category: ens, name_in: [${nameList}] }, first: 1000) {
         name
       }
     `
@@ -75,7 +75,7 @@ export class TheGraphClient {
     const urnList = wearableIds.map((wearableId) => `"${wearableId}"`).join(',')
     // We need to add a 'P' prefix, because the graph needs the fragment name to start with a letter
     return `
-      P${ethAddress}: nfts(where: { owner: "${ethAddress}", searchItemType_in: ["wearable_v1", "wearable_v2"], urn_in: [${urnList}] }) {
+      P${ethAddress}: nfts(where: { owner: "${ethAddress}", searchItemType_in: ["wearable_v1", "wearable_v2"], urn_in: [${urnList}] }, first: 1000) {
         urn
       }
     `

--- a/lambdas/test/apis/profiles/NFTOwnership.spec.ts
+++ b/lambdas/test/apis/profiles/NFTOwnership.spec.ts
@@ -43,13 +43,13 @@ describe('NFTOwnership', () => {
     expect(nftOwnership.timesQueried()).toEqual(1)
   })
 
-  it(`When getting the same owned nfts for a different address, then the graph is consulted once`, async () => {
+  it(`When getting the same owned nfts for a different address, then the graph is consulted twice`, async () => {
     const nftOwnership = buildOwnership()
 
     await nftOwnership.areNFTsOwnedByAddress(address, ['marcosnc', 'invalid_name'])
     await nftOwnership.areNFTsOwnedByAddress('anotherAddress', ['marcosnc'])
 
-    expect(nftOwnership.timesQueried()).toEqual(1)
+    expect(nftOwnership.timesQueried()).toEqual(2)
   })
 })
 
@@ -71,9 +71,12 @@ function buildOwnership() {
 class TestOwnership extends NFTOwnership {
   private queried = 0
 
-  protected querySubgraph(ids: string[]): Promise<{ nft: string; owner: string }[]> {
+  protected querySubgraph(nftsToCheck: [string, string[]][]): Promise<{ ownedNFTs: string[]; owner: string }[]> {
     this.queried++
-    return Promise.resolve([{ nft: 'marcosnc', owner: address.toLowerCase() }])
+    return Promise.resolve([
+      { ownedNFTs: ['marcosnc'], owner: address.toLowerCase() },
+      { ownedNFTs: [], owner: 'anotheraddress' }
+    ])
   }
 
   public timesQueried(): number {


### PR DESCRIPTION
When we tried to generalize how NFT ownership was checked against the subgraph, we did it incorrectly. We had a cache that looked like this: `Cache<NFTId, Owner | null>`. This worked for names, because names are 1/1 NFTs, but this wouldn't work for wearables. This is because there can be hundreds of instances of the same wearable, each with a different owner.

To fix this, we are changing the cache to `Cache<{ethAddress, NftId}, owned: boolean>`