### PR TITLE
fix: don't fail when address owns no wearables

### DIFF
--- a/lambdas/src/apis/collections/controllers/wearables.ts
+++ b/lambdas/src/apis/collections/controllers/wearables.ts
@@ -173,6 +173,9 @@ function sanitizePagination(offset: number | undefined, limit: number | undefine
 }
 
 async function fetchDefinitions(wearableIds: WearableId[], client: SmartContentClient): Promise<Map<string, Wearable>> {
+  if (wearableIds.length === 0) {
+    return new Map()
+  }
   const entities = await client.fetchEntitiesByPointers(EntityType.WEARABLE, wearableIds)
   return new Map(
     entities


### PR DESCRIPTION
Previously, if the user owned no wearables, then the request would fail