### PR TITLE
fix: adding correct index for local timestamp in deployments table

### DIFF
--- a/content/src/migrations/scripts/1615568102704_fix_local_timestamp_index.ts
+++ b/content/src/migrations/scripts/1615568102704_fix_local_timestamp_index.ts
@@ -1,0 +1,18 @@
+/* eslint-disable @typescript-eslint/camelcase */
+import { MigrationBuilder } from 'node-pg-migrate'
+
+/*
+  In this migration, we are replacing the current index 'deployments_local_timestamp_idx' with one that used both 'local_timestamp' and 'entity_id' columns
+ */
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.sql(`DROP INDEX IF EXISTS deployments_local_timestamp_idx`)
+  pgm.sql(
+    `CREATE INDEX IF NOT EXISTS deployments_local_timestamp_entity_id_idx ON deployments USING btree ( local_timestamp DESC, entity_id DESC )`
+  )
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.sql(`DROP INDEX IF EXISTS deployments_local_timestamp_entity_id_idx`)
+  pgm.sql(`CREATE INDEX IF NOT EXISTS deployments_local_timestamp_idx ON deployments ( origin_timestamp DESC )`)
+}

--- a/content/src/migrations/scripts/1615568102704_fix_local_timestamp_index.ts
+++ b/content/src/migrations/scripts/1615568102704_fix_local_timestamp_index.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/camelcase */
 import { MigrationBuilder } from 'node-pg-migrate'
 
 /*


### PR DESCRIPTION
Fixes https://github.com/decentraland/catalyst/issues/274

Went from
```
                                                                             QUERY PLAN
--------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=239325.40..239383.85 rows=501 width=1660) (actual time=1459.488..1483.128 rows=501 loops=1)
   ->  Gather Merge  (cost=238683.68..283627.76 rows=385208 width=1660) (actual time=1425.201..1461.070 rows=6001 loops=1)
         Workers Planned: 2
         Workers Launched: 2
         ->  Sort  (cost=237683.66..238165.17 rows=192604 width=1660) (actual time=1395.499..1397.691 rows=2026 loops=3)
               Sort Key: dep1.local_timestamp DESC, dep1.entity_id DESC
               Sort Method: top-N heapsort  Memory: 22717kB
               Worker 0:  Sort Method: top-N heapsort  Memory: 22590kB
               Worker 1:  Sort Method: top-N heapsort  Memory: 22595kB
               ->  Parallel Hash Left Join  (cost=111582.59..224633.79 rows=192604 width=1660) (actual time=438.527..1101.151 rows=152845 loops=3)
                     Hash Cond: (dep1.deleter_deployment = dep2.id)
                     ->  Parallel Seq Scan on deployments dep1  (cost=0.00..109656.55 rows=192604 width=1609) (actual time=0.020..263.680 rows=152845 loops=3)
                           Filter: (local_timestamp >= '1970-01-01 00:00:00.001+00'::timestamp with time zone)
                     ->  Parallel Hash  (cost=109175.04..109175.04 rows=192604 width=51) (actual time=436.926..436.929 rows=152845 loops=3)
                           Buckets: 524288  Batches: 1  Memory Usage: 43552kB
                           ->  Parallel Seq Scan on deployments dep2  (cost=0.00..109175.04 rows=192604 width=51) (actual time=10.695..255.679 rows=152845 loops=3)
 Planning Time: 1.160 ms
 JIT:
   Functions: 41
   Options: Inlining false, Optimization false, Expressions true, Deforming true
   Timing: Generation 5.673 ms, Inlining 0.000 ms, Optimization 2.614 ms, Emission 45.314 ms, Total 53.601 ms
 Execution Time: 1523.218 ms
(22 rows)
```
To:
```
                                                                                              QUERY PLAN
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=8759.46..9466.19 rows=501 width=1660) (actual time=93.244..102.117 rows=501 loops=1)
   ->  Gather Merge  (cost=1000.87..647918.84 rows=458595 width=1660) (actual time=39.420..94.685 rows=6001 loops=1)
         Workers Planned: 2
         Workers Launched: 2
         ->  Nested Loop Left Join  (cost=0.84..593985.58 rows=191081 width=1660) (actual time=0.103..17.212 rows=2013 loops=3)
               ->  Parallel Index Scan using deployments_local_timestamp_entity_id_idx on deployments dep1  (cost=0.42..326128.96 rows=191081 width=1609) (actual time=0.061..4.689 rows=2013 loops=3)
                     Index Cond: (local_timestamp >= '1970-01-01 00:00:00.001+00'::timestamp with time zone)
               ->  Index Scan using deployments_pkey on deployments dep2  (cost=0.42..1.39 rows=1 width=51) (actual time=0.002..0.002 rows=1 loops=6040)
                     Index Cond: (id = dep1.deleter_deployment)
 Planning Time: 0.477 ms
 Execution Time: 102.610 ms
```