### PR TITLE
feat: add origin information to the client

### DIFF
--- a/content/src/Environment.ts
+++ b/content/src/Environment.ts
@@ -151,7 +151,8 @@ export enum EnvironmentConfig {
   SNAPSHOT_FREQUENCY,
   CUSTOM_DAO,
   DISABLE_SYNCHRONIZATION,
-  DISABLE_DENYLIST
+  DISABLE_DENYLIST,
+  CONTENT_SERVER_ADDRESS
 }
 
 export class EnvironmentBuilder {
@@ -318,6 +319,12 @@ export class EnvironmentBuilder {
       env,
       EnvironmentConfig.DISABLE_DENYLIST,
       () => process.env.DISABLE_DENYLIST !== 'false'
+    )
+
+    this.registerConfigIfNotAlreadySet(
+      env,
+      EnvironmentConfig.CONTENT_SERVER_ADDRESS,
+      () => process.env.CONTENT_SERVER_ADDRESS
     )
 
     // Please put special attention on the bean registration order.

--- a/content/src/helpers/FetcherFactory.ts
+++ b/content/src/helpers/FetcherFactory.ts
@@ -4,9 +4,13 @@ import { CURRENT_COMMIT_HASH, Environment, EnvironmentConfig } from '../Environm
 export class FetcherFactory {
   static create(env: Environment): Fetcher {
     const fetchRequestTimeout = env.getConfig<string>(EnvironmentConfig.FETCH_REQUEST_TIMEOUT)
+    const contentServerAddress = env.getConfig<string>(EnvironmentConfig.CONTENT_SERVER_ADDRESS)
     return new Fetcher({
       timeout: fetchRequestTimeout,
-      headers: { 'User-Agent': `content-server/${CURRENT_COMMIT_HASH} (+https://github.com/decentraland/catalyst)` }
+      headers: {
+        'User-Agent': `content-server/${CURRENT_COMMIT_HASH} (+https://github.com/decentraland/catalyst)`,
+        Origin: contentServerAddress
+      }
     })
   }
 }


### PR DESCRIPTION
We are setting the origin in all requests made between content servers

The content server will know its own address based on the changes in https://github.com/decentraland/catalyst-owner/pull/44