### PR TITLE
refactor: use sync source for downloading files

### DIFF
--- a/content/src/service/synchronization/SynchronizationManager.ts
+++ b/content/src/service/synchronization/SynchronizationManager.ts
@@ -1,3 +1,4 @@
+import { streamMap } from '@katalyst/content/service/synchronization/streaming/StreamHelper'
 import { ServerAddress, Timestamp } from 'dcl-catalyst-commons'
 import { delay } from 'decentraland-katalyst-utils/util'
 import log4js from 'log4js'
@@ -82,7 +83,11 @@ export class ClusterSynchronizationManager implements SynchronizationManager {
       const contentServers: ContentServerClient[] = this.cluster.getAllServersInCluster()
 
       // Fetch all new deployments
-      const streams = contentServers.map((contentServer) => contentServer.getNewDeployments())
+      const streams = contentServers.map((contentServer) => {
+        const deploymentStream = contentServer.getNewDeployments()
+        const sourceData = streamMap((deployment) => ({ deployment, contentServer }))
+        return deploymentStream.pipe(sourceData)
+      })
 
       // Process them together
       await this.deployer.processAllDeployments(streams)

--- a/content/src/service/synchronization/SynchronizationManager.ts
+++ b/content/src/service/synchronization/SynchronizationManager.ts
@@ -1,5 +1,5 @@
 import { streamMap } from '@katalyst/content/service/synchronization/streaming/StreamHelper'
-import { ServerAddress, Timestamp } from 'dcl-catalyst-commons'
+import { DeploymentWithAuditInfo, ServerAddress, Timestamp } from 'dcl-catalyst-commons'
 import { delay } from 'decentraland-katalyst-utils/util'
 import log4js from 'log4js'
 import ms from 'ms'
@@ -8,6 +8,7 @@ import { SystemPropertiesManager, SystemProperty } from '../system-properties/Sy
 import { ContentServerClient } from './clients/ContentServerClient'
 import { ContentCluster } from './ContentCluster'
 import { EventDeployer } from './EventDeployer'
+import { DeploymentWithSource } from './streaming/EventStreamProcessor'
 
 export interface SynchronizationManager {
   start(): Promise<void>
@@ -85,7 +86,10 @@ export class ClusterSynchronizationManager implements SynchronizationManager {
       // Fetch all new deployments
       const streams = contentServers.map((contentServer) => {
         const deploymentStream = contentServer.getNewDeployments()
-        const sourceData = streamMap((deployment) => ({ deployment, contentServer }))
+        const sourceData = streamMap<DeploymentWithAuditInfo, DeploymentWithSource>((deployment) => ({
+          deployment,
+          source: contentServer
+        }))
         return deploymentStream.pipe(sourceData)
       })
 


### PR DESCRIPTION
Before this change, when a catalyst server performed synced with others, it would:
1. Learn new updates from other servers
1. Check and discard known deployments
1. Fetch all necessary files for each deployment
1. Perform the deployment internally (store it on the database)

The problem is that between step (1) and (3), the catalyst would lose the source of the deployment itself (the server where the update was learnt from). This forced the server to check against other random servers to see who might have those files.

We are now keeping the actual source from (1) to (3), so we can just query that server instead of trying to find one