### PR TITLE
fix: use client version with sync fix

### DIFF
--- a/content/src/storage/Repository.ts
+++ b/content/src/storage/Repository.ts
@@ -101,9 +101,7 @@ async function connectTo(connection: DBConnection, credentials: DBCredentials) {
   // Build the database
   const db: Repository = pgp(dbConfig)
 
-  setInterval(() => {
-    LOGGER.debug('Total waiting queries to the database: ', db.$pool.waitingCount)
-  }, ms('1m'))
+  setInterval(() => LOGGER.debug('Amount of queries waiting: ', db.$pool.waitingCount), ms('1m'))
 
   // Make sure we can connect to it
   await retry(

--- a/content/src/storage/Repository.ts
+++ b/content/src/storage/Repository.ts
@@ -1,4 +1,5 @@
 import log4js from 'log4js'
+import ms from 'ms'
 import pgPromise, { IDatabase, IInitOptions, IMain, ITask } from 'pg-promise'
 import { retry } from '../helpers/RetryHelper'
 import { ContentFilesRepository } from './repositories/ContentFilesRepository'
@@ -102,7 +103,7 @@ async function connectTo(connection: DBConnection, credentials: DBCredentials) {
 
   setInterval(() => {
     LOGGER.debug('Total waiting queries to the database: ', db.$pool.waitingCount)
-  }, 10000)
+  }, ms('1m'))
 
   // Make sure we can connect to it
   await retry(

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "aws-sdk": "^2.854.0",
     "compression": "^1.7.4",
     "cors": "^2.8.5",
-    "dcl-catalyst-client": "4.0.3",
+    "dcl-catalyst-client": "4.0.4",
     "dcl-catalyst-commons": "^3.0.1",
     "dcl-crypto": "^2.3.0",
     "decentraland-commons": "^5.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3148,10 +3148,10 @@ date-format@^3.0.0:
   resolved "https://registry.yarnpkg.com/date-format/-/date-format-3.0.0.tgz#eb8780365c7d2b1511078fb491e6479780f3ad95"
   integrity sha512-eyTcpKOcamdhWJXj56DpQMo1ylSQpcGtGKXcU0Tb97+K56/CF5amAqqqNj0+KvA0iw2ynxtHWFsPDSClCxe48w==
 
-dcl-catalyst-client@4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/dcl-catalyst-client/-/dcl-catalyst-client-4.0.3.tgz#961966afab0ec0337d3a838a0879983818a8c465"
-  integrity sha512-7jc38CJtoGKqxaSDyfaZuWCA8O8KecUHu8hm2anUpWnUCai+daQpGkoIicMfoUSPaJ4LWanvszivM8f+xYddNA==
+dcl-catalyst-client@4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/dcl-catalyst-client/-/dcl-catalyst-client-4.0.4.tgz#25c6fe7f29d396b08807736bf10dbfa101ae1e6a"
+  integrity sha512-vIiBh70DoAjGGQJanQNxNB7utEURZg0hJ4InVtBoTCwA7TPv09aLCNYO44MUO3vNTGObSHnVJzdQA3x9U46n0Q==
   dependencies:
     async-iterator-to-array "0.0.1"
     dcl-catalyst-commons "^3.0.1"


### PR DESCRIPTION
We are doing the following changes:
* Using the client version with [this fix](https://github.com/decentraland/catalyst-client/pull/77)
* Increasing the db-client pool size to 20
* Logging the amount of pending queries every 1 minute 