### PR TITLE
fix: consider collection ids as urns

### DIFF
--- a/lambdas/src/apis/collections/controllers/wearables.ts
+++ b/lambdas/src/apis/collections/controllers/wearables.ts
@@ -88,6 +88,8 @@ export async function getWearablesEndpoint(
     return res.status(400).send(`The text search must be at least 3 characters long`)
   } else if (wearableIds && wearableIds.length > MAX_LIMIT) {
     return res.status(400).send(`You can't ask for more than ${MAX_LIMIT} wearables`)
+  } else if (collectionIds && collectionIds.length > MAX_LIMIT) {
+    return res.status(400).send(`You can't filter for more than ${MAX_LIMIT} collection ids`)
   }
 
   const requestFilters = {

--- a/lambdas/src/apis/collections/off-chain/OffChainWearablesManager.ts
+++ b/lambdas/src/apis/collections/off-chain/OffChainWearablesManager.ts
@@ -71,7 +71,7 @@ export class OffChainWearablesManager {
   }
 }
 
-export const BASE_AVATARS_COLLECTION_ID = 'base-avatars'
+export const BASE_AVATARS_COLLECTION_ID = 'urn:decentraland:off-chain:base-avatars'
 
 const DEFAULT_COLLECTIONS: OffChainCollections = {
   [BASE_AVATARS_COLLECTION_ID]: baseAvatars


### PR DESCRIPTION
Previously, we expected collection ids to be the contract address of the collection. Now, we expect them to be the urn. For example:
`urn:decentraland:off-chain:base-avatars` or
`urn:decentraland:ethereum:collections-v1:xmash_up_2020`