### PR TITLE
feat: add new collections endpoint

### DIFF
--- a/lambdas/src/apis/collections/controllers/collections.ts
+++ b/lambdas/src/apis/collections/controllers/collections.ts
@@ -70,7 +70,6 @@ export async function getCollectionsHandler(
 
   try {
     const onChainCollections = await theGraphClient.getAllCollections()
-    onChainCollections.unshift()
     const collections: Collection[] = [
       {
         id: BASE_AVATARS_COLLECTION_ID,

--- a/lambdas/src/apis/collections/controllers/collections.ts
+++ b/lambdas/src/apis/collections/controllers/collections.ts
@@ -69,18 +69,22 @@ export async function getCollectionsHandler(
   // Path: /
 
   try {
-    const onChainCollections = await theGraphClient.getAllCollections()
-    const collections: Collection[] = [
-      {
-        id: BASE_AVATARS_COLLECTION_ID,
-        name: 'Base Wearables'
-      },
-      ...onChainCollections.map(({ urn, name }) => ({ id: urn, name }))
-    ]
+    const collections: Collection[] = await getCollections(theGraphClient)
     res.send({ collections })
   } catch (error) {
     res.status(500).send(error.message)
   }
+}
+
+export async function getCollections(theGraphClient: TheGraphClient): Promise<Collection[]> {
+  const onChainCollections = await theGraphClient.getAllCollections()
+  return [
+    {
+      id: BASE_AVATARS_COLLECTION_ID,
+      name: 'Base Wearables'
+    },
+    ...onChainCollections.map(({ urn, name }) => ({ id: urn, name }))
+  ]
 }
 
 function getProtocol(chainId: string): string | undefined {

--- a/lambdas/src/apis/collections/routes.ts
+++ b/lambdas/src/apis/collections/routes.ts
@@ -1,7 +1,7 @@
 import { SmartContentClient } from '@katalyst/lambdas/utils/SmartContentClient'
 import { TheGraphClient } from '@katalyst/lambdas/utils/TheGraphClient'
 import { Request, Response, Router } from 'express'
-import { contentsImage, contentsThumbnail, getStandardErc721 } from './controllers/collections'
+import { contentsImage, contentsThumbnail, getCollectionsHandler, getStandardErc721 } from './controllers/collections'
 import {
   getWearablesByOwnerEndpoint as getWearablesByOwnerHandler,
   getWearablesEndpoint
@@ -17,6 +17,7 @@ export function initializeCollectionsRoutes(
   router.get('/standard/erc721/:chainId/:contract/:option/:emission?', createHandler(client, getStandardErc721))
   router.get('/contents/:urn/image', createHandler(client, contentsImage))
   router.get('/contents/:urn/thumbnail', createHandler(client, contentsThumbnail))
+  router.get('/', (req, res) => getCollectionsHandler(theGraphClient, req, res))
   router.get('/wearables-by-owner/:owner', (req, res) => getWearablesByOwnerHandler(client, theGraphClient, req, res))
   router.get('/wearables', (req, res) => getWearablesEndpoint(client, theGraphClient, offChainManager, req, res))
   return router

--- a/lambdas/src/apis/collections/types.ts
+++ b/lambdas/src/apis/collections/types.ts
@@ -1,5 +1,10 @@
 import { EthAddress } from 'dcl-crypto'
 
+export type Collection = {
+  id: string
+  name: string
+}
+
 export type WearableMetadata = {
   id: WearableId
   description: string

--- a/lambdas/test/apis/collections/controller/collections.spec.ts
+++ b/lambdas/test/apis/collections/controller/collections.spec.ts
@@ -1,0 +1,28 @@
+import { getCollections } from '@katalyst/lambdas/apis/collections/controllers/collections'
+import { BASE_AVATARS_COLLECTION_ID } from '@katalyst/lambdas/apis/collections/off-chain/OffChainWearablesManager'
+import { TheGraphClient } from '@katalyst/lambdas/utils/TheGraphClient'
+import { instance, mock, when } from 'ts-mockito'
+
+const COLLECTION_1 = {
+  urn: 'some-urn',
+  name: 'some-name'
+}
+
+describe('collections', () => {
+  it(`When collections are requested, then the base wearables collections is added to on-chain collections`, async () => {
+    const { instance: graphClient } = withCollections(COLLECTION_1)
+
+    const response = await getCollections(graphClient)
+
+    expect(response).toEqual([
+      { id: BASE_AVATARS_COLLECTION_ID, name: 'Base Wearables' },
+      { id: 'some-urn', name: 'some-name' }
+    ])
+  })
+})
+
+function withCollections(...collections: { urn: string; name: string }[]) {
+  const mockedClient = mock(TheGraphClient)
+  when(mockedClient.getAllCollections()).thenResolve(collections)
+  return { instance: instance(mockedClient), mock: mockedClient }
+}


### PR DESCRIPTION
We are now adding a new `/collections` endpoint that will return all available collections.

The payload will look like this:
```
{
    "collections": [
        {
            "id": "urn:decentraland:off-chain:base-avatars",
            "name": "Base Wearables"
        },
        ...
    ]
}
```
The idea was to make it like this, in order to easily add pagination/filters in the future consistently with other endpoints