### PR TITLE
chore: make config consistent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM node:12.18.1-slim
 
 RUN apt-get update && \
-    apt-get upgrade -yq && \
-    apt-get install -yq yarn git zlib1g zlib1g-dev
+  apt-get upgrade -yq && \
+  apt-get install -yq yarn git zlib1g zlib1g-dev
 
 WORKDIR /app
 
@@ -14,20 +14,20 @@ COPY . .
 
 # The following are all collapsed to reduce image size
 RUN yarn install &&\
- yarn bazel clean &&\
- yarn bazel build //comms/lighthouse:server &&\
- yarn bazel build //content:server &&\
- yarn bazel build //lambdas:server &&\
- cp -L -R dist/bin/ ../bin &&\
- yarn bazel clean --expunge && yarn cache clean &&\
- cd .. &&\
- rm -rf build &&\
- rm -rf /root/.cache/bazel
+  yarn bazel clean &&\
+  yarn bazel build //comms/lighthouse:server &&\
+  yarn bazel build //content:server &&\
+  yarn bazel build //lambdas:server &&\
+  cp -L -R dist/bin/ ../bin &&\
+  yarn bazel clean --expunge && yarn cache clean &&\
+  cd .. &&\
+  rm -rf build &&\
+  rm -rf /root/.cache/bazel
 
 WORKDIR /app
 
 ENV COMMIT_HASH=bc34832282cfa746cfb1f27184cf3b53f321a164
-ENV CATALYST_VERSION=1.0.0-beta.0
+ENV CATALYST_VERSION=1.0.0
 
 EXPOSE 6969
 EXPOSE 7070

--- a/content/src/Environment.ts
+++ b/content/src/Environment.ts
@@ -30,12 +30,12 @@ export const CURRENT_CONTENT_VERSION: EntityVersion = EntityVersion.V3
 const DEFAULT_STORAGE_ROOT_FOLDER = 'storage'
 const DEFAULT_SERVER_PORT = 6969
 export const DEFAULT_ETH_NETWORK = 'ropsten'
-export const DEFAULT_DCL_PARCEL_ACCESS_URL_ROPSTEN =
+export const DEFAULT_LAND_MANAGER_SUBGRAPH_ROPSTEN =
   'https://api.thegraph.com/subgraphs/name/decentraland/land-manager-ropsten'
-export const DEFAULT_DCL_PARCEL_ACCESS_URL_MAINNET = 'https://api.thegraph.com/subgraphs/name/decentraland/land-manager'
-export const DEFAULT_DCL_COLLECTIONS_ACCESS_URL_ROPSTEN =
+export const DEFAULT_LAND_MANAGER_SUBGRAPH_MAINNET = 'https://api.thegraph.com/subgraphs/name/decentraland/land-manager'
+export const DEFAULT_COLLECTIONS_SUBGRAPH_ROPSTEN =
   'https://api.thegraph.com/subgraphs/name/decentraland/collections-ethereum-ropsten'
-export const DEFAULT_DCL_COLLECTIONS_ACCESS_URL_MAINNET =
+export const DEFAULT_COLLECTIONS_SUBGRAPH_MAINNET =
   'https://api.thegraph.com/subgraphs/name/decentraland/collections-ethereum-mainnet'
 export const CURRENT_COMMIT_HASH = process.env.COMMIT_HASH ?? 'Unknown'
 export const CURRENT_CATALYST_VERSION = process.env.CATALYST_VERSION ?? 'Unknown'
@@ -135,8 +135,8 @@ export enum EnvironmentConfig {
   USE_COMPRESSION_MIDDLEWARE,
   BOOTSTRAP_FROM_SCRATCH,
   REQUEST_TTL_BACKWARDS,
-  DCL_PARCEL_ACCESS_URL,
-  DCL_COLLECTIONS_ACCESS_URL,
+  LAND_MANAGER_SUBGRAPH_URL,
+  COLLECTIONS_L1_SUBGRAPH_URL,
   SQS_QUEUE_URL_REPORTING,
   SQS_ACCESS_KEY_ID,
   SQS_SECRET_ACCESS_KEY,
@@ -235,21 +235,21 @@ export class EnvironmentBuilder {
     this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.REQUEST_TTL_BACKWARDS, () => ms('20m'))
     this.registerConfigIfNotAlreadySet(
       env,
-      EnvironmentConfig.DCL_PARCEL_ACCESS_URL,
+      EnvironmentConfig.LAND_MANAGER_SUBGRAPH_URL,
       () =>
-        process.env.DCL_PARCEL_ACCESS_URL ??
+        process.env.LAND_MANAGER_SUBGRAPH_URL ??
         (env.getConfig(EnvironmentConfig.ETH_NETWORK) === 'mainnet'
-          ? DEFAULT_DCL_PARCEL_ACCESS_URL_MAINNET
-          : DEFAULT_DCL_PARCEL_ACCESS_URL_ROPSTEN)
+          ? DEFAULT_LAND_MANAGER_SUBGRAPH_MAINNET
+          : DEFAULT_LAND_MANAGER_SUBGRAPH_ROPSTEN)
     )
     this.registerConfigIfNotAlreadySet(
       env,
-      EnvironmentConfig.DCL_COLLECTIONS_ACCESS_URL,
+      EnvironmentConfig.COLLECTIONS_L1_SUBGRAPH_URL,
       () =>
-        process.env.DCL_COLLECTIONS_ACCESS_URL ??
+        process.env.COLLECTIONS_L1_SUBGRAPH_URL ??
         (env.getConfig(EnvironmentConfig.ETH_NETWORK) === 'mainnet'
-          ? DEFAULT_DCL_COLLECTIONS_ACCESS_URL_MAINNET
-          : DEFAULT_DCL_COLLECTIONS_ACCESS_URL_ROPSTEN)
+          ? DEFAULT_COLLECTIONS_SUBGRAPH_MAINNET
+          : DEFAULT_COLLECTIONS_SUBGRAPH_ROPSTEN)
     )
     this.registerConfigIfNotAlreadySet(
       env,

--- a/content/src/service/access/AccessCheckerImplFactory.ts
+++ b/content/src/service/access/AccessCheckerImplFactory.ts
@@ -7,7 +7,7 @@ export class AccessCheckerImplFactory {
       env.getBean(Bean.AUTHENTICATOR),
       env.getBean(Bean.FETCHER),
       env.getConfig(EnvironmentConfig.LAND_MANAGER_SUBGRAPH_URL),
-      env.getConfig(EnvironmentConfig.DCL_COLLECTIONS_ACCESS_URL)
+      env.getConfig(EnvironmentConfig.COLLECTIONS_L1_SUBGRAPH_URL)
     )
   }
 }

--- a/content/src/service/access/AccessCheckerImplFactory.ts
+++ b/content/src/service/access/AccessCheckerImplFactory.ts
@@ -6,7 +6,7 @@ export class AccessCheckerImplFactory {
     return new AccessCheckerImpl(
       env.getBean(Bean.AUTHENTICATOR),
       env.getBean(Bean.FETCHER),
-      env.getConfig(EnvironmentConfig.DCL_PARCEL_ACCESS_URL),
+      env.getConfig(EnvironmentConfig.LAND_MANAGER_SUBGRAPH_URL),
       env.getConfig(EnvironmentConfig.DCL_COLLECTIONS_ACCESS_URL)
     )
   }

--- a/content/test/integration/service/access/AccessCheckerImpl.spec.ts
+++ b/content/test/integration/service/access/AccessCheckerImpl.spec.ts
@@ -1,6 +1,6 @@
 import {
-  DEFAULT_DCL_COLLECTIONS_ACCESS_URL_ROPSTEN,
-  DEFAULT_DCL_PARCEL_ACCESS_URL_ROPSTEN
+  DEFAULT_COLLECTIONS_SUBGRAPH_ROPSTEN,
+  DEFAULT_LAND_MANAGER_SUBGRAPH_ROPSTEN
 } from '@katalyst/content/Environment'
 import { AccessCheckerImpl } from '@katalyst/content/service/access/AccessCheckerImpl'
 import { ContentAuthenticator } from '@katalyst/content/service/auth/Authenticator'
@@ -25,7 +25,7 @@ describe('Integration - AccessCheckerImpl', function () {
     const accessChecker = new AccessCheckerImpl(
       new ContentAuthenticator(),
       new Fetcher(),
-      DEFAULT_DCL_PARCEL_ACCESS_URL_ROPSTEN,
+      DEFAULT_LAND_MANAGER_SUBGRAPH_ROPSTEN,
       'Unused URL'
     )
 
@@ -59,7 +59,7 @@ describe('Integration - AccessCheckerImpl', function () {
       new ContentAuthenticator(),
       new Fetcher(),
       'Unused URL',
-      DEFAULT_DCL_COLLECTIONS_ACCESS_URL_ROPSTEN
+      DEFAULT_COLLECTIONS_SUBGRAPH_ROPSTEN
     )
     const pointer = 'urn:decentraland:ethereum:collections-v2:0x1b8ba74cc34c2927aac0a8af9c3b1ba2e61352f2:0'
 

--- a/content/test/manual/check-failed-deployments.spec.ts
+++ b/content/test/manual/check-failed-deployments.spec.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_DCL_PARCEL_ACCESS_URL_MAINNET } from '@katalyst/content/Environment'
+import { DEFAULT_LAND_MANAGER_SUBGRAPH_MAINNET } from '@katalyst/content/Environment'
 import { AccessCheckerImpl } from '@katalyst/content/service/access/AccessCheckerImpl'
 import { AuditInfo } from '@katalyst/content/service/Audit'
 import { ContentAuthenticator } from '@katalyst/content/service/auth/Authenticator'
@@ -52,7 +52,7 @@ describe('Failed Deployments validations.', () => {
       const accessChecker = new AccessCheckerImpl(
         new ContentAuthenticator(),
         new Fetcher(),
-        DEFAULT_DCL_PARCEL_ACCESS_URL_MAINNET
+        DEFAULT_LAND_MANAGER_SUBGRAPH_MAINNET
       )
 
       if (reviewSceneErrors) {

--- a/lambdas/src/Environment.ts
+++ b/lambdas/src/Environment.ts
@@ -14,13 +14,13 @@ export const DEFAULT_ETH_NETWORK = 'ropsten'
 export const DEFAULT_ENS_OWNER_PROVIDER_URL_ROPSTEN =
   'https://api.thegraph.com/subgraphs/name/decentraland/marketplace-ropsten'
 const DEFAULT_ENS_OWNER_PROVIDER_URL_MAINNET = 'https://api.thegraph.com/subgraphs/name/decentraland/marketplace'
-export const DEFAULT_COLLECTIONS_PROVIDER_URL_ROPSTEN =
+export const DEFAULT_COLLECTIONS_SUBGRAPH_ROPSTEN =
   'https://api.thegraph.com/subgraphs/name/decentraland/collections-ethereum-ropsten'
-export const DEFAULT_COLLECTIONS_PROVIDER_URL_MAINNET =
+export const DEFAULT_COLLECTIONS_SUBGRAPH_MAINNET =
   'https://api.thegraph.com/subgraphs/name/decentraland/collections-ethereum-mainnet'
-export const DEFAULT_COLLECTIONS_PROVIDER_URL_MATIC_MUMBAI =
+export const DEFAULT_COLLECTIONS_SUBGRAPH_MATIC_MUMBAI =
   'https://api.thegraph.com/subgraphs/name/decentraland/collections-matic-mumbai'
-export const DEFAULT_COLLECTIONS_PROVIDER_URL_MATIC_MAINNET =
+export const DEFAULT_COLLECTIONS_SUBGRAPH_MATIC_MAINNET =
   'https://api.thegraph.com/subgraphs/name/decentraland/collections-matic-mainnet'
 
 const DEFAULT_LAMBDAS_STORAGE_LOCATION = 'lambdas-storage'
@@ -74,8 +74,8 @@ export const enum EnvironmentConfig {
   LOG_REQUESTS,
   CONTENT_SERVER_ADDRESS,
   ENS_OWNER_PROVIDER_URL,
-  COLLECTIONS_PROVIDER_URL,
-  COLLECTIONS_PROVIDER_MATIC_URL,
+  COLLECTIONS_L1_SUBGRAPH_URL,
+  COLLECTIONS_L2_SUBGRAPH_URL,
   COMMIT_HASH,
   CATALYST_VERSION,
   USE_COMPRESSION_MIDDLEWARE,
@@ -130,22 +130,22 @@ export class EnvironmentBuilder {
     )
     this.registerConfigIfNotAlreadySet(
       env,
-      EnvironmentConfig.COLLECTIONS_PROVIDER_URL,
+      EnvironmentConfig.COLLECTIONS_L1_SUBGRAPH_URL,
       () =>
-        process.env.COLLECTIONS_PROVIDER_URL ??
+        process.env.COLLECTIONS_L1_SUBGRAPH_URL ??
         (process.env.ETH_NETWORK === 'mainnet'
-          ? DEFAULT_COLLECTIONS_PROVIDER_URL_MAINNET
-          : DEFAULT_COLLECTIONS_PROVIDER_URL_ROPSTEN)
+          ? DEFAULT_COLLECTIONS_SUBGRAPH_MAINNET
+          : DEFAULT_COLLECTIONS_SUBGRAPH_ROPSTEN)
     )
 
     this.registerConfigIfNotAlreadySet(
       env,
-      EnvironmentConfig.COLLECTIONS_PROVIDER_MATIC_URL,
+      EnvironmentConfig.COLLECTIONS_L2_SUBGRAPH_URL,
       () =>
-        process.env.COLLECTIONS_PROVIDER_MATIC_URL ??
+        process.env.COLLECTIONS_L2_SUBGRAPH_URL ??
         (process.env.ETH_NETWORK === 'mainnet'
-          ? DEFAULT_COLLECTIONS_PROVIDER_URL_MATIC_MAINNET
-          : DEFAULT_COLLECTIONS_PROVIDER_URL_MATIC_MUMBAI)
+          ? DEFAULT_COLLECTIONS_SUBGRAPH_MATIC_MAINNET
+          : DEFAULT_COLLECTIONS_SUBGRAPH_MATIC_MUMBAI)
     )
 
     this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.COMMIT_HASH, () => process.env.COMMIT_HASH ?? 'Unknown')

--- a/lambdas/src/utils/TheGraphClientFactory.ts
+++ b/lambdas/src/utils/TheGraphClientFactory.ts
@@ -3,8 +3,8 @@ import { TheGraphClient } from './TheGraphClient'
 
 export class TheGraphClientFactory {
   static create(env: Environment): TheGraphClient {
-    const collectionsSubgraph: string = env.getConfig(EnvironmentConfig.COLLECTIONS_PROVIDER_URL)
-    const maticCollectionsSubgraph: string = env.getConfig(EnvironmentConfig.COLLECTIONS_PROVIDER_MATIC_URL)
+    const collectionsSubgraph: string = env.getConfig(EnvironmentConfig.COLLECTIONS_L1_SUBGRAPH_URL)
+    const maticCollectionsSubgraph: string = env.getConfig(EnvironmentConfig.COLLECTIONS_L2_SUBGRAPH_URL)
     const ensSubgraph: string = env.getConfig(EnvironmentConfig.ENS_OWNER_PROVIDER_URL)
     return new TheGraphClient(
       { collectionsSubgraph, maticCollectionsSubgraph, ensSubgraph },


### PR DESCRIPTION
We are making two changes here:
1. We are setting the version as 1.0.0, since we will be releasing a new version soon
2. We are making config consistent between lambdas & the content server. 
Now, by setting `COLLECTIONS_L1_SUBGRAPH_URL` or `COLLECTIONS_L2_SUBGRAPH_URL` as environment variables, both services will read the same config. Previously, each service's config had a different name