### PR TITLE
fix: use X-Forwarded-Host header to create next url

### DIFF
--- a/lambdas/src/apis/collections/controllers/wearables.ts
+++ b/lambdas/src/apis/collections/controllers/wearables.ts
@@ -118,14 +118,17 @@ export async function getWearablesEndpoint(
       },
       { arrayFormat: 'repeat' }
     )
-    const next = nextLastId
-      ? req.protocol + '://' + req.get('host') + req.baseUrl + req.path + '?' + queryParams
-      : undefined
+    const next = nextLastId ? calculateNextUrl(req, queryParams) : undefined
 
     res.send({ wearables, filters: requestFilters, pagination: { limit: sanitizedLimit, next } })
   } catch (error) {
     res.status(500).send(error.message)
   }
+}
+
+function calculateNextUrl(req: Request, queryParams: string) {
+  const host = req.get('X-Forwarded-Host') ?? req.get('Host')
+  return req.protocol + '://' + host + req.baseUrl + req.path + '?' + queryParams
 }
 
 /**

--- a/lambdas/src/apis/collections/controllers/wearables.ts
+++ b/lambdas/src/apis/collections/controllers/wearables.ts
@@ -127,7 +127,7 @@ export async function getWearablesEndpoint(
 }
 
 function calculateNextUrl(req: Request, queryParams: string) {
-  const host = req.get('X-Forwarded-Host') ?? req.get('Host')
+  const host = req.get('X-Forwarded-Host') //?? req.get('Host')
   return req.protocol + '://' + host + req.baseUrl + req.path + '?' + queryParams
 }
 

--- a/lambdas/src/apis/collections/controllers/wearables.ts
+++ b/lambdas/src/apis/collections/controllers/wearables.ts
@@ -127,7 +127,8 @@ export async function getWearablesEndpoint(
 }
 
 function calculateNextUrl(req: Request, queryParams: string) {
-  const host = req.get('X-Forwarded-Host') //?? req.get('Host')
+  // When running local the X-Forwarded-Host is absent, as it is set by nginx
+  const host = req.get('X-Forwarded-Host') ?? req.get('Host')
   return req.protocol + '://' + host + req.baseUrl + req.path + '?' + queryParams
 }
 

--- a/lambdas/src/utils/SmartContentClient.ts
+++ b/lambdas/src/utils/SmartContentClient.ts
@@ -119,7 +119,7 @@ export class SmartContentClient implements ContentAPI {
       try {
         const fetcher = new Fetcher()
         await fetcher.fetchJson(`${SmartContentClient.INTERNAL_CONTENT_SERVER_URL}/status`, {
-          attempts: 1,
+          attempts: 6,
           waitTime: '10s'
         })
         SmartContentClient.LOGGER.info('Will use the internal content server url')

--- a/lambdas/src/utils/SmartContentClient.ts
+++ b/lambdas/src/utils/SmartContentClient.ts
@@ -119,7 +119,7 @@ export class SmartContentClient implements ContentAPI {
       try {
         const fetcher = new Fetcher()
         await fetcher.fetchJson(`${SmartContentClient.INTERNAL_CONTENT_SERVER_URL}/status`, {
-          attempts: 6,
+          attempts: 1,
           waitTime: '10s'
         })
         SmartContentClient.LOGGER.info('Will use the internal content server url')


### PR DESCRIPTION
Uses[ 'X-Forwarded-Host' header ](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host)to build the url of the next page in the colection, instead of using host. As host is the local host from the nginx, but the forwarded host is the host that the original request was made to.


This change has been tested in peer-testing with the following configuration: https://github.com/decentraland/catalyst-owner/pull/46