### PR TITLE
feat: use correct subgraph when validating wearables

### DIFF
--- a/content/src/Environment.ts
+++ b/content/src/Environment.ts
@@ -37,6 +37,10 @@ export const DEFAULT_COLLECTIONS_SUBGRAPH_ROPSTEN =
   'https://api.thegraph.com/subgraphs/name/decentraland/collections-ethereum-ropsten'
 export const DEFAULT_COLLECTIONS_SUBGRAPH_MAINNET =
   'https://api.thegraph.com/subgraphs/name/decentraland/collections-ethereum-mainnet'
+export const DEFAULT_COLLECTIONS_SUBGRAPH_MATIC_MUMBAI =
+  'https://api.thegraph.com/subgraphs/name/decentraland/collections-matic-mumbai'
+export const DEFAULT_COLLECTIONS_SUBGRAPH_MATIC_MAINNET =
+  'https://api.thegraph.com/subgraphs/name/decentraland/collections-matic-mainnet'
 export const CURRENT_COMMIT_HASH = process.env.COMMIT_HASH ?? 'Unknown'
 export const CURRENT_CATALYST_VERSION = process.env.CATALYST_VERSION ?? 'Unknown'
 export const DEFAULT_DATABASE_CONFIG = {
@@ -137,6 +141,7 @@ export enum EnvironmentConfig {
   REQUEST_TTL_BACKWARDS,
   LAND_MANAGER_SUBGRAPH_URL,
   COLLECTIONS_L1_SUBGRAPH_URL,
+  COLLECTIONS_L2_SUBGRAPH_URL,
   SQS_QUEUE_URL_REPORTING,
   SQS_ACCESS_KEY_ID,
   SQS_SECRET_ACCESS_KEY,
@@ -251,6 +256,17 @@ export class EnvironmentBuilder {
           ? DEFAULT_COLLECTIONS_SUBGRAPH_MAINNET
           : DEFAULT_COLLECTIONS_SUBGRAPH_ROPSTEN)
     )
+
+    this.registerConfigIfNotAlreadySet(
+      env,
+      EnvironmentConfig.COLLECTIONS_L2_SUBGRAPH_URL,
+      () =>
+        process.env.COLLECTIONS_L2_SUBGRAPH_URL ??
+        (process.env.ETH_NETWORK === 'mainnet'
+          ? DEFAULT_COLLECTIONS_SUBGRAPH_MATIC_MAINNET
+          : DEFAULT_COLLECTIONS_SUBGRAPH_MATIC_MUMBAI)
+    )
+
     this.registerConfigIfNotAlreadySet(
       env,
       EnvironmentConfig.SQS_QUEUE_URL_REPORTING,

--- a/content/src/service/access/AccessCheckerForScenes.ts
+++ b/content/src/service/access/AccessCheckerForScenes.ts
@@ -11,7 +11,7 @@ export class AccessCheckerForScenes {
   constructor(
     private readonly authenticator: ContentAuthenticator,
     private readonly fetcher: Fetcher,
-    private readonly dclParcelAccessUrl: string,
+    private readonly landManagerSubgraphUrl: string,
     private readonly LOGGER: log4js.Logger
   ) {}
 
@@ -206,7 +206,7 @@ export class AccessCheckerForScenes {
     }
 
     try {
-      return (await this.fetcher.queryGraph<{ parcels: Parcel[] }>(this.dclParcelAccessUrl, query, variables))
+      return (await this.fetcher.queryGraph<{ parcels: Parcel[] }>(this.landManagerSubgraphUrl, query, variables))
         .parcels[0]
     } catch (error) {
       this.LOGGER.error(`Error fetching parcel (${x}, ${y})`, error)
@@ -258,7 +258,7 @@ export class AccessCheckerForScenes {
     }
 
     try {
-      return (await this.fetcher.queryGraph<{ estates: Estate[] }>(this.dclParcelAccessUrl, query, variables))
+      return (await this.fetcher.queryGraph<{ estates: Estate[] }>(this.landManagerSubgraphUrl, query, variables))
         .estates[0]
     } catch (error) {
       this.LOGGER.error(`Error fetching estate (${estateId})`, error)
@@ -295,7 +295,11 @@ export class AccessCheckerForScenes {
 
     try {
       return (
-        await this.fetcher.queryGraph<{ authorizations: Authorization[] }>(this.dclParcelAccessUrl, query, variables)
+        await this.fetcher.queryGraph<{ authorizations: Authorization[] }>(
+          this.landManagerSubgraphUrl,
+          query,
+          variables
+        )
       ).authorizations
     } catch (error) {
       this.LOGGER.error(`Error fetching authorizations for ${owner}`, error)

--- a/content/src/service/access/AccessCheckerImpl.ts
+++ b/content/src/service/access/AccessCheckerImpl.ts
@@ -14,22 +14,24 @@ export class AccessCheckerImpl implements AccessChecker {
   private readonly accessCheckerForProfiles: AccessCheckerForProfiles
   private readonly accessCheckerForWearables: AccessCheckerForWearables
 
-  constructor(
-    authenticator: ContentAuthenticator,
-    fetcher: Fetcher,
-    dclParcelAccessUrl: string,
-    dclCollectionsAccessUrl: string
-  ) {
+  constructor({
+    authenticator,
+    fetcher,
+    landManagerSubgraphUrl,
+    collectionsL1SubgraphUrl,
+    collectionsL2SubgraphUrl
+  }: AccessCheckerImplParams) {
     this.accessCheckerForScenes = new AccessCheckerForScenes(
       authenticator,
       fetcher,
-      dclParcelAccessUrl,
+      landManagerSubgraphUrl,
       AccessCheckerImpl.LOGGER
     )
     this.accessCheckerForProfiles = new AccessCheckerForProfiles(authenticator)
     this.accessCheckerForWearables = new AccessCheckerForWearables(
       fetcher,
-      dclCollectionsAccessUrl,
+      collectionsL1SubgraphUrl,
+      collectionsL2SubgraphUrl,
       AccessCheckerImpl.LOGGER
     )
   }
@@ -51,4 +53,12 @@ export class AccessCheckerImpl implements AccessChecker {
         return ['Unknown type provided']
     }
   }
+}
+
+export type AccessCheckerImplParams = {
+  authenticator: ContentAuthenticator
+  fetcher: Fetcher
+  landManagerSubgraphUrl: string
+  collectionsL1SubgraphUrl: string
+  collectionsL2SubgraphUrl: string
 }

--- a/content/src/service/access/AccessCheckerImplFactory.ts
+++ b/content/src/service/access/AccessCheckerImplFactory.ts
@@ -3,11 +3,12 @@ import { AccessCheckerImpl } from './AccessCheckerImpl'
 
 export class AccessCheckerImplFactory {
   static create(env: Environment): AccessCheckerImpl {
-    return new AccessCheckerImpl(
-      env.getBean(Bean.AUTHENTICATOR),
-      env.getBean(Bean.FETCHER),
-      env.getConfig(EnvironmentConfig.LAND_MANAGER_SUBGRAPH_URL),
-      env.getConfig(EnvironmentConfig.COLLECTIONS_L1_SUBGRAPH_URL)
-    )
+    return new AccessCheckerImpl({
+      authenticator: env.getBean(Bean.AUTHENTICATOR),
+      fetcher: env.getBean(Bean.FETCHER),
+      landManagerSubgraphUrl: env.getConfig(EnvironmentConfig.LAND_MANAGER_SUBGRAPH_URL),
+      collectionsL1SubgraphUrl: env.getConfig(EnvironmentConfig.COLLECTIONS_L1_SUBGRAPH_URL),
+      collectionsL2SubgraphUrl: env.getConfig(EnvironmentConfig.COLLECTIONS_L2_SUBGRAPH_URL)
+    })
   }
 }

--- a/content/test/integration/service/access/AccessCheckerImpl.spec.ts
+++ b/content/test/integration/service/access/AccessCheckerImpl.spec.ts
@@ -2,13 +2,13 @@ import {
   DEFAULT_COLLECTIONS_SUBGRAPH_ROPSTEN,
   DEFAULT_LAND_MANAGER_SUBGRAPH_ROPSTEN
 } from '@katalyst/content/Environment'
-import { AccessCheckerImpl } from '@katalyst/content/service/access/AccessCheckerImpl'
+import { AccessCheckerImpl, AccessCheckerImplParams } from '@katalyst/content/service/access/AccessCheckerImpl'
 import { ContentAuthenticator } from '@katalyst/content/service/auth/Authenticator'
 import { EntityType, Fetcher } from 'dcl-catalyst-commons'
 
 describe('Integration - AccessCheckerImpl', function () {
   it(`When access URL is wrong while checking scene access it reports an error`, async () => {
-    const accessChecker = new AccessCheckerImpl(new ContentAuthenticator(), new Fetcher(), 'Wrong URL', 'Unused URL')
+    const accessChecker = buildAccessCheckerImpl({ landManagerSubgraphUrl: 'Wrong URL' })
 
     const errors = await accessChecker.hasAccess(
       EntityType.SCENE,
@@ -22,12 +22,7 @@ describe('Integration - AccessCheckerImpl', function () {
   })
 
   it(`When an address without permissions tries to deploy a scene it fails`, async () => {
-    const accessChecker = new AccessCheckerImpl(
-      new ContentAuthenticator(),
-      new Fetcher(),
-      DEFAULT_LAND_MANAGER_SUBGRAPH_ROPSTEN,
-      'Unused URL'
-    )
+    const accessChecker = buildAccessCheckerImpl({ landManagerSubgraphUrl: DEFAULT_LAND_MANAGER_SUBGRAPH_ROPSTEN })
 
     const errors = await accessChecker.hasAccess(
       EntityType.SCENE,
@@ -41,7 +36,7 @@ describe('Integration - AccessCheckerImpl', function () {
   })
 
   it(`When access URL is wrong while checking wearable access it reports an error`, async () => {
-    const accessChecker = new AccessCheckerImpl(new ContentAuthenticator(), new Fetcher(), 'Unused URL', 'Wrong URL')
+    const accessChecker = buildAccessCheckerImpl({ collectionsL1SubgraphUrl: 'Wrong URL' })
     const pointer = 'urn:decentraland:ethereum:collections-v2:0x1b8ba74cc34c2927aac0a8af9c3b1ba2e61352f2:0'
     const errors = await accessChecker.hasAccess(
       EntityType.WEARABLE,
@@ -55,12 +50,7 @@ describe('Integration - AccessCheckerImpl', function () {
   })
 
   it(`When an address without permissions tries to deploy a wearable it fails`, async () => {
-    const accessChecker = new AccessCheckerImpl(
-      new ContentAuthenticator(),
-      new Fetcher(),
-      'Unused URL',
-      DEFAULT_COLLECTIONS_SUBGRAPH_ROPSTEN
-    )
+    const accessChecker = buildAccessCheckerImpl({ collectionsL1SubgraphUrl: DEFAULT_COLLECTIONS_SUBGRAPH_ROPSTEN })
     const pointer = 'urn:decentraland:ethereum:collections-v2:0x1b8ba74cc34c2927aac0a8af9c3b1ba2e61352f2:0'
 
     const errors = await accessChecker.hasAccess(
@@ -73,4 +63,16 @@ describe('Integration - AccessCheckerImpl', function () {
     expect(errors.length).toBe(1)
     expect(errors[0]).toEqual(`The provided Eth Address does not have access to the following wearable: (${pointer})`)
   })
+
+  function buildAccessCheckerImpl(params: Partial<AccessCheckerImplParams>) {
+    const finalParams = {
+      authenticator: new ContentAuthenticator(),
+      fetcher: new Fetcher(),
+      landManagerSubgraphUrl: 'Unused URL',
+      collectionsL1SubgraphUrl: 'Unused URL',
+      collectionsL2SubgraphUrl: 'Unused URL',
+      ...params
+    }
+    return new AccessCheckerImpl(finalParams)
+  }
 })

--- a/content/test/unit/service/validations/Validations.spec.ts
+++ b/content/test/unit/service/validations/Validations.spec.ts
@@ -470,7 +470,13 @@ function buildEntity(options?: { timestamp?: Timestamp; content?: Map<string, st
 function getValidatorWithRealAccess() {
   const authenticator = new ContentAuthenticator()
   return new Validations(
-    new AccessCheckerImpl(authenticator, new Fetcher(), 'unused_url', 'unused_url'),
+    new AccessCheckerImpl({
+      authenticator,
+      fetcher: new Fetcher(),
+      landManagerSubgraphUrl: 'unused_url',
+      collectionsL1SubgraphUrl: 'unused_url',
+      collectionsL2SubgraphUrl: 'unused_url'
+    }),
     authenticator,
     'ropsten',
     ms('10m')

--- a/lambdas/src/utils/TheGraphClient.ts
+++ b/lambdas/src/utils/TheGraphClient.ts
@@ -224,7 +224,7 @@ export class TheGraphClient {
     pagination: { limit: number; lastId: string | undefined }
   ): Promise<WearableId[]> {
     // Order will be L1 > L2
-    const L1_NETWORKS = ['ethereum', 'ropsten', 'kovan', 'rinkeby', 'goerli']
+    const L1_NETWORKS = ['mainnet', 'ropsten', 'kovan', 'rinkeby', 'goerli']
     const L2_NETWORKS = ['matic', 'mumbai']
 
     let limit = pagination.limit


### PR DESCRIPTION
We are now supporting both L1 and L2 to validate wearable ownership. But, we are checking one or the other, depending on the network in the urn