### PR TITLE
feat: expose all lambdas metrics

### DIFF
--- a/commons/servers/metrics.ts
+++ b/commons/servers/metrics.ts
@@ -37,12 +37,12 @@ export class Metrics {
 
   private static requestCounters = function (req, _res, next) {
     numRequests.inc({ method: req.method })
-    pathsTaken.inc({ path: req.route.path })
+    pathsTaken.inc({ path: req.baseUrl + req.route.path })
     next()
   }
 
   private static responseCounters = ResponseTime(function (req, res, time) {
-    responses.labels(req.method, req.route.path, res.statusCode).observe(time)
+    responses.labels(req.method, req.baseUrl + req.route.path, res.statusCode).observe(time)
   })
 
   private static injectMetricsRoute(app: express.Express) {


### PR DESCRIPTION
We are now exposing metrics for all lambda endpoints. The main problem was that lambdas use routers, so we couldn't calculate the `req.route.path` correctly. 

The solution was to create a `Router` proxy (an ES6 Proxy) that would inject the metrics handler when each route is defined. 
How it looks now:
![Screen Shot 2021-04-06 at 16 10 29](https://user-images.githubusercontent.com/15222168/113765444-a76b2100-96f2-11eb-99b9-e597d3499f3a.png)
