### PR TITLE
chore: stop creating db in content server

### DIFF
--- a/content/src/entrypoints/run-local-database.ts
+++ b/content/src/entrypoints/run-local-database.ts
@@ -1,20 +1,38 @@
 import { exec } from 'child_process'
+import { promisify } from 'util'
 import { DEFAULT_DATABASE_CONFIG } from '../Environment'
 
-exec(
-  `
-    docker rm -f postgres ; \
-    docker run \
+const execute = promisify(exec)
+
+async function main() {
+  await deletePreviousPsql()
+  await runNewPsql()
+}
+
+main()
+  .then(() => console.log('Done!'))
+  .catch((error) => console.error(error))
+
+async function runNewPsql() {
+  const { stderr } = await execute(`docker run \
     --name postgres \
     -e POSTGRES_PASSWORD=${DEFAULT_DATABASE_CONFIG.password} \
     -e POSTGRES_USER=${DEFAULT_DATABASE_CONFIG.user} \
     -e POSTGRES_DB=${DEFAULT_DATABASE_CONFIG.database} \
     -p ${DEFAULT_DATABASE_CONFIG.port}:5432 \
     -v psql-vol:/var/lib/postgresql/data \
-    -d postgres:12`,
-  (error, stdout, stderr) => {
-    console.log('ERROR', error)
-    console.log('STDOUT', stdout)
-    console.log('STDERR', stderr)
+    -d postgres:12`)
+
+  if (stderr) {
+    throw new Error(stderr)
   }
-)
+}
+
+async function deletePreviousPsql() {
+  const { stderr, stdout } = await execute('docker rm -f postgres')
+  if (stderr && !stderr.includes('Error: No such container: postgres')) {
+    throw new Error('Failed to delete the existing postgres container')
+  } else if (stdout) {
+    console.log('Deleted the previous container')
+  }
+}

--- a/content/src/storage/Database.ts
+++ b/content/src/storage/Database.ts
@@ -39,29 +39,8 @@ export type DBCredentials = {
 /**
  * Builds the database client by connecting to the content database. If it isn't present, then it tries to connect with the root user and creates the content database and user.
  */
-export async function build(
-  connection: DBConnection,
-  contentCredentials: DBCredentials,
-  rootCredentials?: DBCredentials
-): Promise<FullDatabase> {
-  try {
-    return await connectTo(connection, contentCredentials)
-  } catch (error) {
-    if (rootCredentials) {
-      console.log('Trying to create database...')
-      // Probably the content database doesn't exist. So we try to create it
-      const rootRepo = await connectTo(connection, rootCredentials)
-      await rootRepo.query(`CREATE USER ${contentCredentials.user} WITH PASSWORD $1`, [contentCredentials.password])
-      await rootRepo.query(`CREATE DATABASE ${contentCredentials.database}`)
-      await rootRepo.query(
-        `GRANT ALL PRIVILEGES ON DATABASE ${contentCredentials.database} TO ${contentCredentials.user}`
-      )
-
-      return connectTo(connection, contentCredentials)
-    } else {
-      throw error
-    }
-  }
+export async function build(connection: DBConnection, contentCredentials: DBCredentials): Promise<FullDatabase> {
+  return connectTo(connection, contentCredentials)
 }
 
 async function connectTo(connection: DBConnection, credentials: DBCredentials) {

--- a/content/src/storage/Database.ts
+++ b/content/src/storage/Database.ts
@@ -25,12 +25,12 @@ export interface IExtensions {
   systemProperties: SystemPropertiesRepository
 }
 
-export type DBConnection = {
+type DBConnection = {
   host: string
   port: number
 }
 
-export type DBCredentials = {
+type DBCredentials = {
   database: string
   user: string
   password: string
@@ -39,7 +39,7 @@ export type DBCredentials = {
 /**
  * Builds the database client by connecting to the content database. If it isn't present, then it tries to connect with the root user and creates the content database and user.
  */
-export async function build(connection: DBConnection, contentCredentials: DBCredentials): Promise<FullDatabase> {
+export function build(connection: DBConnection, contentCredentials: DBCredentials): Promise<FullDatabase> {
   return connectTo(connection, contentCredentials)
 }
 

--- a/content/src/storage/Database.ts
+++ b/content/src/storage/Database.ts
@@ -37,7 +37,7 @@ type DBCredentials = {
 }
 
 /**
- * Builds the database client by connecting to the content database. If it isn't present, then it tries to connect with the root user and creates the content database and user.
+ * Builds the database client by connecting to the content database
  */
 export function build(connection: DBConnection, contentCredentials: DBCredentials): Promise<FullDatabase> {
   return connectTo(connection, contentCredentials)

--- a/content/src/storage/RepositoryFactory.ts
+++ b/content/src/storage/RepositoryFactory.ts
@@ -1,5 +1,5 @@
 import { Environment, EnvironmentConfig } from '../Environment'
-import { build, DBCredentials } from './Database'
+import { build } from './Database'
 import { Repository } from './Repository'
 import { RepositoryQueue } from './RepositoryQueue'
 
@@ -15,17 +15,7 @@ export class RepositoryFactory {
       password: env.getConfig<string>(EnvironmentConfig.PSQL_PASSWORD)
     }
 
-    let rootCredentials: DBCredentials | undefined
-
-    if (process.env.POSTGRES_PASSWORD && process.env.POSTGRES_USER && process.env.POSTGRES_DB) {
-      rootCredentials = {
-        database: process.env.POSTGRES_DB,
-        user: process.env.POSTGRES_USER,
-        password: process.env.POSTGRES_PASSWORD
-      }
-    }
-
-    const database = await build(connection, contentCredentials, rootCredentials)
+    const database = await build(connection, contentCredentials)
     return new Repository(
       database,
       new RepositoryQueue({


### PR DESCRIPTION
Before this change, the content server tried to connect to the database during startup. If it failed, it would connect as the root user, and create the database for itself. This was clearly an anti-pattern.

Thanks to https://github.com/decentraland/catalyst-owner/pull/53, we now have the ability to run psql scripts. We added a script that creates the database there, and stop giving that responsibility to the content server. That is done in https://github.com/decentraland/catalyst-owner/pull/55