### PR TITLE
feat: adding cache for entities

### DIFF
--- a/content/src/controller/Controller.ts
+++ b/content/src/controller/Controller.ts
@@ -5,7 +5,6 @@ import {
   EntityType,
   EntityVersion,
   LegacyAuditInfo,
-  PartialDeploymentHistory,
   Pointer,
   SortingField,
   SortingOrder,
@@ -28,6 +27,7 @@ import {
   DeploymentPointerChanges,
   PointerChangesFilters
 } from '../service/deployments/DeploymentManager'
+import { Entity } from '../service/Entity'
 import {
   DeploymentResult,
   isSuccessfulDeployment,
@@ -81,16 +81,14 @@ export class Controller {
     }
 
     // Calculate and mask entities
-    let history: PartialDeploymentHistory<Deployment>
+    let entities: Entity[]
     if (ids.length > 0) {
-      history = await this.service.getDeployments({ filters: { entityTypes: [type], entityIds: ids } })
+      entities = await this.service.getEntitiesByIds(ids)
     } else {
-      history = await this.service.getDeployments({
-        filters: { entityTypes: [type], pointers, onlyCurrentlyPointed: true }
-      })
+      entities = await this.service.getEntitiesByPointers(type, pointers)
     }
-    const maskedEntities: ControllerEntity[] = history.deployments.map((fullDeployment) =>
-      ControllerEntityFactory.maskDeployment(fullDeployment, enumFields)
+    const maskedEntities: ControllerEntity[] = entities.map((entity) =>
+      ControllerEntityFactory.maskEntity(entity, enumFields)
     )
     res.send(maskedEntities)
   }

--- a/content/src/service/Service.ts
+++ b/content/src/service/Service.ts
@@ -4,6 +4,7 @@ import {
   EntityId,
   EntityType,
   PartialDeploymentHistory,
+  Pointer,
   ServerAddress,
   ServerStatus,
   Timestamp
@@ -60,6 +61,8 @@ export interface MetaverseContentService {
     lastId?: string,
     task?: Database
   ): Promise<PartialDeploymentPointerChanges>
+  getEntitiesByIds(ids: EntityId[], task?: Database): Promise<Entity[]>
+  getEntitiesByPointers(type: EntityType, pointers: Pointer[], task?: Database): Promise<Entity[]>
   listenToDeployments(listener: DeploymentListener): void
 }
 

--- a/content/src/service/ServiceFactory.ts
+++ b/content/src/service/ServiceFactory.ts
@@ -1,4 +1,7 @@
+import { Pointer } from 'dcl-catalyst-commons'
 import { Bean, Environment } from '../Environment'
+import { CacheManager, ENTITIES_BY_POINTERS_CACHE_CONFIG } from './caching/CacheManager'
+import { Entity } from './Entity'
 import { ClusterDeploymentsService, MetaverseContentService } from './Service'
 import { ServiceImpl } from './ServiceImpl'
 import { ServiceStorage } from './ServiceStorage'
@@ -6,6 +9,8 @@ import { ServiceStorage } from './ServiceStorage'
 export class ServiceFactory {
   static create(env: Environment): MetaverseContentService & ClusterDeploymentsService {
     const serviceStorage = new ServiceStorage(env.getBean(Bean.STORAGE))
+    const cacheManager: CacheManager = env.getBean(Bean.CACHE_MANAGER)
+    const cache = cacheManager.buildEntityTypedCache<Pointer, Entity>(ENTITIES_BY_POINTERS_CACHE_CONFIG)
     return new ServiceImpl(
       serviceStorage,
       env.getBean(Bean.POINTER_MANAGER),
@@ -13,7 +18,8 @@ export class ServiceFactory {
       env.getBean(Bean.FAILED_DEPLOYMENTS_MANAGER),
       env.getBean(Bean.DEPLOYMENT_MANAGER),
       env.getBean(Bean.VALIDATIONS),
-      env.getBean(Bean.REPOSITORY)
+      env.getBean(Bean.REPOSITORY),
+      cache
     )
   }
 }

--- a/content/src/service/caching/Cache.ts
+++ b/content/src/service/caching/Cache.ts
@@ -28,9 +28,9 @@ export class Cache<Key, Value> {
     const calculated: Map<Key, Value | undefined> = missing.length > 0 ? await orCalculate(missing) : new Map()
 
     // Save the calculated values. When a key doesn't have a value, set it as null
-    Array.from(calculated.entries())
-      .map<[Key, Value | null]>(([key, value]) => [key, value ?? null])
-      .forEach(([key, value]) => this.internalCache.set(key, value))
+    for (const [key, value] of calculated) {
+      this.internalCache.set(key, value ?? null)
+    }
 
     // Concatenate the results and return them
     return [

--- a/content/src/service/caching/Cache.ts
+++ b/content/src/service/caching/Cache.ts
@@ -1,0 +1,77 @@
+import { EntityType } from 'dcl-catalyst-commons'
+import LRU from 'lru-cache'
+
+/** This is a regular cache, that can be configured with a max size of elements */
+export class Cache<Key, Value> {
+  // Null implies that there is no value set for the key even though one was calculated for it.
+  // The cache lib returns undefined when no value was calculated at all.
+  private internalCache: LRU<Key, Value | null>
+
+  constructor(size: number) {
+    this.internalCache = new LRU({ max: size })
+  }
+
+  /**
+   * Get the values for the given keys, or calculated them if they are nor present.
+   * If no value can be calculated for a given key, then the key shouldn't be present, or it should be, with an `undefined` value.
+   */
+  async get(keys: Key[], orCalculate: (keys: Key[]) => Promise<Map<Key, Value | undefined>>): Promise<Value[]> {
+    // Check what is on the cache
+    const onCache: Map<Key, Value | null | undefined> = new Map(keys.map((key) => [key, this.internalCache.get(key)]))
+
+    // Get all the keys without values calculated
+    const missing: Key[] = Array.from(onCache.entries())
+      .filter(([, value]) => value === undefined)
+      .map(([key]) => key)
+
+    // Calculate values for those keys
+    const calculated: Map<Key, Value | undefined> = missing.length > 0 ? await orCalculate(missing) : new Map()
+
+    // Save the calculated values. When a key doesn't have a value, set it as null
+    Array.from(calculated.entries())
+      .map<[Key, Value | null]>(([key, value]) => [key, value ?? null])
+      .forEach(([key, value]) => this.internalCache.set(key, value))
+
+    // Concatenate the results and return them
+    return [
+      ...Array.from(onCache.values()).filter((value): value is Value => !!value),
+      ...Array.from(calculated.values()).filter((value): value is Value => !!value)
+    ]
+  }
+
+  invalidate(key: Key) {
+    this.internalCache.del(key)
+  }
+}
+
+/** This is a cache that can be configured per entity type */
+export class CacheByType<Key, Value> {
+  private constructor(private readonly cachesByType: Map<EntityType, Cache<Key, Value>>) {}
+
+  get(
+    type: EntityType,
+    keys: Key[],
+    orCalculate: (type: EntityType, keys: Key[]) => Promise<Map<Key, Value | undefined>>
+  ): Promise<Value[]> {
+    return this.cachesByType.get(type)!.get(keys, (pointers) => orCalculate(type, pointers))
+  }
+
+  invalidate(type: EntityType, key: Key) {
+    this.cachesByType.get(type)!.invalidate(key)
+  }
+
+  static withSizes<K, V>(sizes: Map<EntityType, number>): CacheByType<K, V> {
+    const cachesByType: Map<EntityType, Cache<K, V>> = new Map()
+
+    Object.values(EntityType).forEach((entityType: EntityType) => {
+      const cacheSize = sizes.get(entityType)
+      if (!cacheSize) {
+        throw new Error(`Can't build a cache by type since it is missing the type '${entityType}'.`)
+      }
+      const cache: Cache<K, V> = new Cache(cacheSize)
+      cachesByType.set(entityType, cache)
+    })
+
+    return new CacheByType(cachesByType)
+  }
+}

--- a/content/src/service/caching/CacheManager.ts
+++ b/content/src/service/caching/CacheManager.ts
@@ -1,0 +1,71 @@
+import { EntityType } from 'dcl-catalyst-commons'
+import { CacheByType } from './Cache'
+
+/** This manger is used to create cache instances, based on some pre-configured defaults */
+export class CacheManager {
+  private readonly cacheSizes: Map<string, number>
+
+  constructor(cacheSizes: Map<string, number> = new Map()) {
+    this.cacheSizes = new Map(Array.from(cacheSizes.entries()).map(([name, size]) => [name.toUpperCase(), size]))
+  }
+
+  buildEntityTypedCache<K, V>(cacheConfig: CacheConfig): CacheByType<K, V> {
+    const cacheSizes: Map<EntityType, number> = new Map()
+
+    Object.values(EntityType).forEach((entityType: EntityType) => {
+      const cacheName = this.getTypedCacheConfigName(cacheConfig, entityType)
+      const cacheSize = this.cacheSizes.get(cacheName) ?? cacheConfig.getDefaultSize(entityType)
+      cacheSizes.set(entityType, cacheSize)
+    })
+
+    return CacheByType.withSizes(cacheSizes)
+  }
+
+  private getTypedCacheConfigName(cacheConfig: CacheConfig, type: EntityType) {
+    return `CACHE_${cacheConfig.getName()}_${type}`.toUpperCase()
+  }
+}
+
+export class CacheConfig {
+  private readonly name: string
+  private readonly defaultSizes: Map<EntityType, number> = new Map()
+
+  constructor(builder: CacheConfigBuilder) {
+    this.name = builder.name
+    this.defaultSizes = builder.defaultSizes
+  }
+
+  getDefaultSize(entityType: EntityType): number {
+    return this.defaultSizes.get(entityType)!
+  }
+
+  getName(): string {
+    return this.name
+  }
+}
+
+class CacheConfigBuilder {
+  readonly defaultSizes: Map<EntityType, number> = new Map()
+
+  constructor(readonly name: string) {}
+
+  withDefaultSize(entityType: EntityType, size: number): CacheConfigBuilder {
+    this.defaultSizes.set(entityType, size)
+    return this
+  }
+
+  build(): CacheConfig {
+    Object.values(EntityType).forEach((entityType: EntityType) => {
+      if (!this.defaultSizes.has(entityType)) {
+        throw new Error(`Can't build a cache config since it is missing the type '${entityType}'.`)
+      }
+    })
+    return new CacheConfig(this)
+  }
+}
+
+export const ENTITIES_BY_POINTERS_CACHE_CONFIG = new CacheConfigBuilder('ENTITIES_BY_POINTERS')
+  .withDefaultSize(EntityType.PROFILE, 2000)
+  .withDefaultSize(EntityType.SCENE, 2000)
+  .withDefaultSize(EntityType.WEARABLE, 500)
+  .build()

--- a/content/src/service/caching/CacheManagerFactory.ts
+++ b/content/src/service/caching/CacheManagerFactory.ts
@@ -1,0 +1,8 @@
+import { Environment, EnvironmentConfig } from '@katalyst/content/Environment'
+import { CacheManager } from './CacheManager'
+
+export class CacheManagerFactory {
+  static create(env: Environment): CacheManager {
+    return new CacheManager(env.getConfig(EnvironmentConfig.CACHE_SIZES))
+  }
+}

--- a/content/test/helpers/service/MockedMetaverseContentService.ts
+++ b/content/test/helpers/service/MockedMetaverseContentService.ts
@@ -157,6 +157,18 @@ export class MockedMetaverseContentService implements MetaverseContentService {
     throw new Error('Method not implemented.')
   }
 
+  getEntitiesByIds(ids: string[]): Promise<Entity[]> {
+    return Promise.resolve(this.entities.filter(({ id }) => ids.includes(id)))
+  }
+
+  getEntitiesByPointers(type: EntityType, pointers: string[]): Promise<Entity[]> {
+    return Promise.resolve(
+      this.entities.filter(
+        (entity) => entity.type === type && entity.pointers.some((pointer) => pointers.includes(pointer))
+      )
+    )
+  }
+
   private entityToDeployment(entity: Entity): Deployment {
     return {
       ...entity,

--- a/content/test/integration/E2EAssertions.ts
+++ b/content/test/integration/E2EAssertions.ts
@@ -57,7 +57,7 @@ export async function assertEntityWasNotDeployed(server: TestServer, entity: Con
 }
 
 export async function assertEntitiesAreActiveOnServer(server: TestServer, ...entities: ControllerEntity[]) {
-  // Legacy check
+  // Entities check
   for (const entity of entities) {
     const entitiesByPointer = await server.getEntitiesByPointers(entity.type, entity.pointers)
     assert.deepStrictEqual(entitiesByPointer, [entity])

--- a/content/test/unit/denylist/DenylistServiceDecorator.spec.ts
+++ b/content/test/unit/denylist/DenylistServiceDecorator.spec.ts
@@ -78,6 +78,68 @@ describe('DenylistServiceDecorator', () => {
     expect(deployment1.auditInfo).toEqual(MockedMetaverseContentService.AUDIT_INFO)
   })
 
+  it(`When a pointer is denylisted, then no entities are reported on it`, async () => {
+    const denylist = denylistWith(P1Target)
+    const decorator = getDecorator(denylist)
+
+    const entities = await decorator.getEntitiesByPointers(entity1.type, [P1])
+
+    expect(entities.length).toBe(0)
+  })
+
+  it(`When a pointer is not denylisted, then it reports the entity correctly`, async () => {
+    const denylist = denylistWith(P1Target)
+    const decorator = getDecorator(denylist)
+
+    const entities = await decorator.getEntitiesByPointers(entity2.type, entity2.pointers)
+
+    expect(entities).toEqual([entity2])
+  })
+
+  it(`When an entity is denylisted, then it is returned by pointers, but without content or metadata`, async () => {
+    const denylist = denylistWith(entity2Target)
+    const decorator = getDecorator(denylist)
+
+    const entities = await decorator.getEntitiesByPointers(entity2.type, entity2.pointers)
+
+    expect(entities.length).toBe(1)
+    const returnedEntity = entities[0]
+    entitiesEqualNonSanitizableProperties(returnedEntity, entity2)
+    expect(returnedEntity.metadata).toEqual(DenylistServiceDecorator.DENYLISTED_METADATA)
+    expect(returnedEntity.content).toBeUndefined()
+  })
+
+  it(`When an entity is not denylisted, then it is returned by pointers correctly`, async () => {
+    const denylist = denylistWith(entity2Target)
+    const decorator = getDecorator(denylist)
+
+    const entities = await decorator.getEntitiesByPointers(entity1.type, entity1.pointers)
+
+    expect(entities).toEqual([entity1])
+  })
+
+  it(`When an entity is denylisted, then it is returned by id, but without content or metadata`, async () => {
+    const denylist = denylistWith(entity2Target)
+    const decorator = getDecorator(denylist)
+
+    const entities = await decorator.getEntitiesByIds([entity2.id])
+
+    expect(entities.length).toBe(1)
+    const returnedEntity = entities[0]
+    entitiesEqualNonSanitizableProperties(returnedEntity, entity2)
+    expect(returnedEntity.metadata).toEqual(DenylistServiceDecorator.DENYLISTED_METADATA)
+    expect(returnedEntity.content).toBeUndefined()
+  })
+
+  it(`When an entity is not denylisted, then it is returned by id correctly`, async () => {
+    const denylist = denylistWith(entity2Target)
+    const decorator = getDecorator(denylist)
+
+    const entities = await decorator.getEntitiesByIds([entity1.id])
+
+    expect(entities).toEqual([entity1])
+  })
+
   it(`When an entity is denylisted, then it is returned on deployments, but without content or metadata`, async () => {
     const denylist = denylistWith(entity2Target)
     const decorator = getDecorator(denylist)
@@ -259,6 +321,13 @@ describe('DenylistServiceDecorator', () => {
     expect(entity.type).toEqual(deployment.entityType)
     expect(entity.pointers).toEqual(deployment.pointers)
     expect(entity.timestamp).toEqual(deployment.entityTimestamp)
+  }
+
+  function entitiesEqualNonSanitizableProperties(entity1: Entity, entity2: Entity) {
+    expect(entity1.id).toEqual(entity2.id)
+    expect(entity1.type).toEqual(entity2.type)
+    expect(entity1.pointers).toEqual(entity2.pointers)
+    expect(entity1.timestamp).toEqual(entity2.timestamp)
   }
 
   function deploymentEquals(entity: Entity, deployment: Deployment) {

--- a/content/test/unit/service/Service.spec.ts
+++ b/content/test/unit/service/Service.spec.ts
@@ -1,6 +1,7 @@
 import { ContentFile } from '@katalyst/content/controller/Controller'
 import { Bean, Environment } from '@katalyst/content/Environment'
 import { ContentAuthenticator } from '@katalyst/content/service/auth/Authenticator'
+import { CacheManager } from '@katalyst/content/service/caching/CacheManager'
 import { Entity } from '@katalyst/content/service/Entity'
 import {
   DeploymentResult,
@@ -24,7 +25,7 @@ import { NoOpDeploymentManager } from './deployments/NoOpDeploymentManager'
 import { NoOpFailedDeploymentsManager } from './errors/NoOpFailedDeploymentsManager'
 import { NoOpPointerManager } from './pointers/NoOpPointerManager'
 
-describe('Service', function () {
+fdescribe('Service', function () {
   const auditInfo: LocalDeploymentAuditInfo = {
     authChain: Authenticator.createSimpleAuthChain('entityId', 'ethAddress', 'signature'),
     version: EntityVersion.V3
@@ -145,6 +146,7 @@ describe('Service', function () {
       .registerBean(Bean.POINTER_MANAGER, NoOpPointerManager.build())
       .registerBean(Bean.DEPLOYMENT_MANAGER, NoOpDeploymentManager.build())
       .registerBean(Bean.REPOSITORY, MockedRepository.build(initialAmountOfDeployments))
+      .registerBean(Bean.CACHE_MANAGER, new CacheManager())
     return ServiceFactory.create(env)
   }
 

--- a/content/test/unit/service/Service.spec.ts
+++ b/content/test/unit/service/Service.spec.ts
@@ -2,7 +2,9 @@ import { ContentFile } from '@katalyst/content/controller/Controller'
 import { Bean, Environment } from '@katalyst/content/Environment'
 import { ContentAuthenticator } from '@katalyst/content/service/auth/Authenticator'
 import { CacheManager } from '@katalyst/content/service/caching/CacheManager'
+import { Deployment } from '@katalyst/content/service/deployments/DeploymentManager'
 import { Entity } from '@katalyst/content/service/Entity'
+import { DELTA_POINTER_RESULT, PointerManager } from '@katalyst/content/service/pointers/PointerManager'
 import {
   DeploymentResult,
   isInvalidDeployment,
@@ -25,7 +27,8 @@ import { NoOpDeploymentManager } from './deployments/NoOpDeploymentManager'
 import { NoOpFailedDeploymentsManager } from './errors/NoOpFailedDeploymentsManager'
 import { NoOpPointerManager } from './pointers/NoOpPointerManager'
 
-fdescribe('Service', function () {
+describe('Service', function () {
+  const POINTERS = ['X1,Y1', 'X2,Y2']
   const auditInfo: LocalDeploymentAuditInfo = {
     authChain: Authenticator.createSimpleAuthChain('entityId', 'ethAddress', 'signature'),
     version: EntityVersion.V3
@@ -39,13 +42,14 @@ fdescribe('Service', function () {
   let entityFile: ContentFile
   let storage: ContentStorage
   let service: MetaverseContentService
+  let pointerManager: PointerManager
 
   beforeAll(async () => {
     randomFile = { name: 'file', content: Buffer.from('1234') }
     randomFileHash = await Hashing.calculateHash(randomFile)
     ;[entity, entityFile] = await buildEntityAndFile(
       EntityType.SCENE,
-      ['X1,Y1', 'X2,Y2'],
+      POINTERS,
       Date.now(),
       new Map([[randomFile.name, randomFileHash]]),
       'metadata'
@@ -54,6 +58,7 @@ fdescribe('Service', function () {
 
   beforeEach(async () => {
     storage = new MockedStorage()
+    pointerManager = NoOpPointerManager.build()
     service = await buildService()
   })
 
@@ -135,6 +140,55 @@ fdescribe('Service', function () {
     expect(status.historySize).toBe(initialAmountOfDeployments)
   })
 
+  it(`When the same pointer is asked twice, then the second time cached result is returned`, async () => {
+    const serviceSpy = spyOn(service, 'getDeployments').and.callFake(() =>
+      Promise.resolve({
+        deployments: [fakeDeployment()],
+        filters: {},
+        pagination: { offset: 0, limit: 0, moreData: true }
+      })
+    )
+
+    // Call the first time
+    await service.getEntitiesByPointers(EntityType.SCENE, POINTERS)
+    expectSpyToBeCalled(serviceSpy, POINTERS)
+
+    // Reset spy and call again
+    serviceSpy.calls.reset()
+    await service.getEntitiesByPointers(EntityType.SCENE, POINTERS)
+    expect(serviceSpy).not.toHaveBeenCalled()
+  })
+
+  it(`When a pointer is affected by a deployment, then it is invalidated from the cache`, async () => {
+    spyOn(pointerManager, 'referenceEntityFromPointers').and.callFake(() =>
+      Promise.resolve(
+        new Map([
+          [POINTERS[0], { before: undefined, after: DELTA_POINTER_RESULT.CLEARED }],
+          [POINTERS[1], { before: undefined, after: DELTA_POINTER_RESULT.CLEARED }]
+        ])
+      )
+    )
+    const serviceSpy = spyOn(service, 'getDeployments').and.callFake(() =>
+      Promise.resolve({
+        deployments: [fakeDeployment()],
+        filters: {},
+        pagination: { offset: 0, limit: 0, moreData: true }
+      })
+    )
+
+    // Call the first time
+    await service.getEntitiesByPointers(EntityType.SCENE, POINTERS)
+    expectSpyToBeCalled(serviceSpy, POINTERS)
+
+    // Make deployment that should invalidate the cache
+    await service.deployEntity([entityFile, randomFile], entity.id, auditInfo, '')
+
+    // Reset spy and call again
+    serviceSpy.calls.reset()
+    await service.getEntitiesByPointers(EntityType.SCENE, POINTERS)
+    expectSpyToBeCalled(serviceSpy, POINTERS)
+  })
+
   async function buildService() {
     const env = new Environment()
       .registerBean(Bean.STORAGE, storage)
@@ -143,7 +197,7 @@ fdescribe('Service', function () {
       .registerBean(Bean.VALIDATIONS, new NoOpValidations())
       .registerBean(Bean.CONTENT_CLUSTER, MockedContentCluster.withoutIdentity())
       .registerBean(Bean.FAILED_DEPLOYMENTS_MANAGER, NoOpFailedDeploymentsManager.build())
-      .registerBean(Bean.POINTER_MANAGER, NoOpPointerManager.build())
+      .registerBean(Bean.POINTER_MANAGER, pointerManager)
       .registerBean(Bean.DEPLOYMENT_MANAGER, NoOpDeploymentManager.build())
       .registerBean(Bean.REPOSITORY, MockedRepository.build(initialAmountOfDeployments))
       .registerBean(Bean.CACHE_MANAGER, new CacheManager())
@@ -157,6 +211,29 @@ fdescribe('Service', function () {
       },
       jasmineToString: function () {
         return `<StorageContent with Data: ${data}>`
+      }
+    }
+  }
+
+  function expectSpyToBeCalled(serviceSpy: jasmine.Spy, pointers: string[]) {
+    expect(serviceSpy).toHaveBeenCalledWith(
+      {
+        filters: { entityTypes: [EntityType.SCENE], pointers: pointers, onlyCurrentlyPointed: true }
+      },
+      undefined
+    )
+  }
+
+  function fakeDeployment(): Deployment {
+    return {
+      entityType: EntityType.SCENE,
+      entityId: '',
+      entityTimestamp: 10,
+      deployedBy: '',
+      pointers: POINTERS,
+      auditInfo: {
+        ...auditInfo,
+        localTimestamp: 10
       }
     }
   }

--- a/content/test/unit/service/Service.spec.ts
+++ b/content/test/unit/service/Service.spec.ts
@@ -140,7 +140,7 @@ describe('Service', function () {
     expect(status.historySize).toBe(initialAmountOfDeployments)
   })
 
-  it(`When the same pointer is asked twice, then the second time cached result is returned`, async () => {
+  it(`When the same pointer is asked twice, then the second time cached the result is returned`, async () => {
     const serviceSpy = spyOn(service, 'getDeployments').and.callFake(() =>
       Promise.resolve({
         deployments: [fakeDeployment()],

--- a/content/test/unit/service/pointers/NoOpPointerManager.ts
+++ b/content/test/unit/service/pointers/NoOpPointerManager.ts
@@ -4,9 +4,12 @@ import { anything, instance, mock, when } from 'ts-mockito'
 export class NoOpPointerManager {
   static build(): PointerManager {
     const mockedManager: PointerManager = mock(PointerManager)
-    when(mockedManager.calculateOverwrites(anything(), anything())).thenReturn(
-      Promise.resolve({ overwrote: new Set(), overwrittenBy: null })
-    )
+    when(mockedManager.calculateOverwrites(anything(), anything())).thenResolve({
+      overwrote: new Set(),
+      overwrittenBy: null
+    })
+    when(mockedManager.referenceEntityFromPointers(anything(), anything(), anything())).thenResolve(new Map())
+
     return instance(mockedManager)
   }
 }


### PR DESCRIPTION
We are now adding a cache to the `/entities` endpoint. The `/deployments` endpoint is too generic, has too many filters and is usually used to get historic deployments, so we decided to had the cache directly to the `/entities` endpoint. 

To do so we added `getEntitiesByIds` and `getEntitiesByPointers` to the service, who will be in charge of caching.

This cache will help a lot in avoiding requests to the database. Since users tend to group together in the world, they will ask for the same scenes & profiles, so the cache makes a lot of sense