### PR TITLE
Breaking Change: Remove origin url and timestamp from deployments

### DIFF
--- a/content/README.md
+++ b/content/README.md
@@ -23,6 +23,10 @@ If you set up a local content server, it will receive all updates by those other
 
     `yarn bazel run content:server`
 
+* To connect to the database locally
+
+    `docker exec -it postgres psql -U postgres -d content`
+
 
 ## Configuration
 
@@ -40,7 +44,7 @@ These are some of the more important configuration values:
 | LOG_LEVEL | Minimum log level | 'info' |
 
 ## Run unit tests
-`bazel run content:unit_test`
+    `yarn bazel run content:unit_test`
 
 ## Run integration tests
- `bazel run content:integration_test`
+    `yarn bazel run content:integration_test`

--- a/content/README.md
+++ b/content/README.md
@@ -38,3 +38,9 @@ These are some of the more important configuration values:
 | STORAGE_ROOT_FOLDER | Folder where all content will be stored | 'storage' |
 | SERVER_PORT | Port to be used by the service | 6969 |
 | LOG_LEVEL | Minimum log level | 'info' |
+
+## Run unit tests
+`bazel run content:unit_test`
+
+## Run integration tests
+ `bazel run content:integration_test`

--- a/content/src/migrations/scripts/1620070748842_remove_origin.ts
+++ b/content/src/migrations/scripts/1620070748842_remove_origin.ts
@@ -5,7 +5,6 @@ import { MigrationBuilder } from 'node-pg-migrate'
  */
 
 export async function up(pgm: MigrationBuilder): Promise<void> {
-  pgm.sql(`DROP INDEX IF EXISTS deployments_origin_timestamp_idx;`)
   pgm.sql(`ALTER TABLE IF EXISTS deployments DROP COLUMN origin_server_url ;`)
   pgm.sql(`ALTER TABLE IF EXISTS deployments DROP COLUMN origin_timestamp;`)
   pgm.sql(`ALTER TABLE IF EXISTS failed_deployments DROP COLUMN origin_server_url;`)
@@ -13,8 +12,6 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
 }
 
 export async function down(pgm: MigrationBuilder): Promise<void> {
-  pgm.sql(`CREATE INDEX ON deployments ( origin_timestamp DESC );`) // Using plain SQL since lib doesn't expose DESC
-
   pgm.sql(
     `ALTER TABLE deployments ADD COLUMN origin_server_url text  DEFAULT 'https://peer.decentraland.org/content' NOT NULL;`
   )
@@ -24,4 +21,7 @@ export async function down(pgm: MigrationBuilder): Promise<void> {
     `ALTER TABLE failed_deployments ADD COLUMN origin_server_url text  DEFAULT 'https://peer.decentraland.org/content' NOT NULL;`
   )
   pgm.sql(`ALTER TABLE deployments ADD COLUMN origin_timestamp text  DEFAULT NOW() NOT NULL;`)
+
+  pgm.sql(`CREATE INDEX ON deployments ( origin_timestamp DESC );`) // Using plain SQL since lib doesn't expose DESC
+
 }

--- a/content/src/migrations/scripts/1620070748842_remove_origin.ts
+++ b/content/src/migrations/scripts/1620070748842_remove_origin.ts
@@ -23,5 +23,4 @@ export async function down(pgm: MigrationBuilder): Promise<void> {
   pgm.sql(`ALTER TABLE deployments ADD COLUMN origin_timestamp text  DEFAULT NOW() NOT NULL;`)
 
   pgm.sql(`CREATE INDEX ON deployments ( origin_timestamp DESC );`) // Using plain SQL since lib doesn't expose DESC
-
 }

--- a/content/src/migrations/scripts/1620070748842_remove_origin.ts
+++ b/content/src/migrations/scripts/1620070748842_remove_origin.ts
@@ -5,18 +5,20 @@ import { MigrationBuilder } from 'node-pg-migrate'
  */
 
 export async function up(pgm: MigrationBuilder): Promise<void> {
-    pgm.sql(`DROP INDEX IF EXISTS deployments_origin_timestamp_idx;`)
-    pgm.sql(`ALTER TABLE IF EXISTS deployments DROP COLUMN origin_server_url ;`)
-    pgm.sql(`ALTER TABLE IF EXISTS deployments DROP COLUMN origin_timestamp;`)
-    pgm.sql(`ALTER TABLE IF EXISTS failed_deployments DROP COLUMN origin_server_url;`)
-    pgm.sql(`ALTER TABLE IF EXISTS failed_deployments DROP COLUMN origin_timestamp;`)
+  pgm.sql(`DROP INDEX IF EXISTS deployments_origin_timestamp_idx;`)
+  pgm.sql(`ALTER TABLE IF EXISTS deployments DROP COLUMN origin_server_url ;`)
+  pgm.sql(`ALTER TABLE IF EXISTS deployments DROP COLUMN origin_timestamp;`)
+  pgm.sql(`ALTER TABLE IF EXISTS failed_deployments DROP COLUMN origin_server_url;`)
+  pgm.sql(`ALTER TABLE IF EXISTS failed_deployments DROP COLUMN origin_timestamp;`)
 }
 
 export async function down(pgm: MigrationBuilder): Promise<void> {
-    pgm.sql(`CREATE INDEX ON deployments ( origin_timestamp DESC );`) // Using plain SQL since lib doesn't expose DESC
+  pgm.sql(`CREATE INDEX ON deployments ( origin_timestamp DESC );`) // Using plain SQL since lib doesn't expose DESC
 
-    pgm.sql(`ALTER TABLE deployments ADD COLUMN origin_server_url text  DEFAULT 'https://peer.decentraland.org/content' NOT NULL;`)
-    pgm.sql(`ALTER TABLE deployments ADD COLUMN origin_timestamp text  DEFAULT NOW() NOT NULL;`)
-    pgm.sql(`ALTER TABLE failed_deployments DROP COLUMN origin_server_url IF EXISTS;`)
-    pgm.sql(`ALTER TABLE failed_deployments DROP COLUMN origin_timestamp IF EXISTS;`)
+  pgm.sql(
+    `ALTER TABLE deployments ADD COLUMN origin_server_url text  DEFAULT 'https://peer.decentraland.org/content' NOT NULL;`
+  )
+  pgm.sql(`ALTER TABLE deployments ADD COLUMN origin_timestamp text  DEFAULT NOW() NOT NULL;`)
+  pgm.sql(`ALTER TABLE failed_deployments DROP COLUMN origin_server_url IF EXISTS;`)
+  pgm.sql(`ALTER TABLE failed_deployments DROP COLUMN origin_timestamp IF EXISTS;`)
 }

--- a/content/src/migrations/scripts/1620070748842_remove_origin.ts
+++ b/content/src/migrations/scripts/1620070748842_remove_origin.ts
@@ -1,0 +1,22 @@
+import { MigrationBuilder } from 'node-pg-migrate'
+
+/*
+  In this migration, we are removing the origin_server_url and origin_timestamp colums
+ */
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+    pgm.sql(`DROP INDEX IF EXISTS deployments_origin_timestamp_idx;`)
+    pgm.sql(`ALTER TABLE IF EXISTS deployments DROP COLUMN origin_server_url ;`)
+    pgm.sql(`ALTER TABLE IF EXISTS deployments DROP COLUMN origin_timestamp;`)
+    pgm.sql(`ALTER TABLE IF EXISTS failed_deployments DROP COLUMN origin_server_url;`)
+    pgm.sql(`ALTER TABLE IF EXISTS failed_deployments DROP COLUMN origin_timestamp;`)
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+    pgm.sql(`CREATE INDEX ON deployments ( origin_timestamp DESC );`) // Using plain SQL since lib doesn't expose DESC
+
+    pgm.sql(`ALTER TABLE deployments ADD COLUMN origin_server_url text  DEFAULT 'https://peer.decentraland.org/content' NOT NULL;`)
+    pgm.sql(`ALTER TABLE deployments ADD COLUMN origin_timestamp text  DEFAULT NOW() NOT NULL;`)
+    pgm.sql(`ALTER TABLE failed_deployments DROP COLUMN origin_server_url IF EXISTS;`)
+    pgm.sql(`ALTER TABLE failed_deployments DROP COLUMN origin_timestamp IF EXISTS;`)
+}

--- a/content/src/migrations/scripts/1620070748842_remove_origin.ts
+++ b/content/src/migrations/scripts/1620070748842_remove_origin.ts
@@ -18,7 +18,10 @@ export async function down(pgm: MigrationBuilder): Promise<void> {
   pgm.sql(
     `ALTER TABLE deployments ADD COLUMN origin_server_url text  DEFAULT 'https://peer.decentraland.org/content' NOT NULL;`
   )
+  pgm.sql(`ALTER TABLE failed_deployments ADD COLUMN origin_timestamp text  DEFAULT NOW() NOT NULL;`)
+
+  pgm.sql(
+    `ALTER TABLE failed_deployments ADD COLUMN origin_server_url text  DEFAULT 'https://peer.decentraland.org/content' NOT NULL;`
+  )
   pgm.sql(`ALTER TABLE deployments ADD COLUMN origin_timestamp text  DEFAULT NOW() NOT NULL;`)
-  pgm.sql(`ALTER TABLE failed_deployments DROP COLUMN origin_server_url IF EXISTS;`)
-  pgm.sql(`ALTER TABLE failed_deployments DROP COLUMN origin_timestamp IF EXISTS;`)
 }

--- a/content/src/repository/extensions/DeploymentsRepository.ts
+++ b/content/src/repository/extensions/DeploymentsRepository.ts
@@ -14,7 +14,7 @@ import {
 import { Authenticator } from 'dcl-crypto'
 
 export class DeploymentsRepository {
-  constructor(private readonly db: Database) { }
+  constructor(private readonly db: Database) {}
 
   async areEntitiesDeployed(entityIds: EntityId[]): Promise<Map<EntityId, boolean>> {
     if (entityIds.length === 0) {

--- a/content/src/repository/extensions/DeploymentsRepository.ts
+++ b/content/src/repository/extensions/DeploymentsRepository.ts
@@ -14,7 +14,7 @@ import {
 import { Authenticator } from 'dcl-crypto'
 
 export class DeploymentsRepository {
-  constructor(private readonly db: Database) {}
+  constructor(private readonly db: Database) { }
 
   async areEntitiesDeployed(entityIds: EntityId[]): Promise<Map<EntityId, boolean>> {
     if (entityIds.length === 0) {
@@ -71,8 +71,6 @@ export class DeploymentsRepository {
                 dep1.deployer_address,
                 dep1.version,
                 dep1.auth_chain,
-                dep1.origin_server_url,
-                date_part('epoch', dep1.origin_timestamp) * 1000 AS origin_timestamp,
                 date_part('epoch', dep1.local_timestamp) * 1000 AS local_timestamp,
                 dep2.entity_id AS overwritten_by
             FROM deployments AS dep1

--- a/content/src/repository/extensions/DeploymentsRepository.ts
+++ b/content/src/repository/extensions/DeploymentsRepository.ts
@@ -14,7 +14,7 @@ import {
 import { Authenticator } from 'dcl-crypto'
 
 export class DeploymentsRepository {
-  constructor(private readonly db: Database) {}
+  constructor(private readonly db: Database) { }
 
   async areEntitiesDeployed(entityIds: EntityId[]): Promise<Map<EntityId, boolean>> {
     if (entityIds.length === 0) {
@@ -168,8 +168,6 @@ export class DeploymentsRepository {
       deployerAddress: row.deployer_address,
       version: row.version,
       authChain: row.auth_chain,
-      originServerUrl: row.origin_server_url,
-      originTimestamp: row.origin_timestamp,
       localTimestamp: row.local_timestamp,
       overwrittenBy: row.overwritten_by ?? undefined
     }))
@@ -225,8 +223,6 @@ export class DeploymentsRepository {
                 entity_timestamp,
                 entity_pointers,
                 entity_metadata,
-                origin_server_url,
-                origin_timestamp,
                 local_timestamp,
                 auth_chain,
                 deleter_deployment
@@ -238,8 +234,6 @@ export class DeploymentsRepository {
                 to_timestamp($(entity.timestamp) / 1000.0),
                 $(entity.pointers),
                 $(metadata),
-                'https://peer.decentraland.org/content',
-                to_timestamp($(auditInfo.localTimestamp) / 1000.0),
                 to_timestamp($(auditInfo.localTimestamp) / 1000.0),
                 $(auditInfo.authChain:json),
                 $(overwrittenBy)

--- a/content/src/repository/extensions/FailedDeploymentsRepository.ts
+++ b/content/src/repository/extensions/FailedDeploymentsRepository.ts
@@ -3,7 +3,7 @@ import { FailedDeployment, FailureReason } from '@katalyst/content/service/error
 import { EntityId, EntityType, Timestamp } from 'dcl-catalyst-commons'
 
 export class FailedDeploymentsRepository {
-  constructor(private readonly db: Database) { }
+  constructor(private readonly db: Database) {}
 
   getAllFailedDeployments(): Promise<FailedDeployment[]> {
     return this.db.map(

--- a/content/src/service/Service.ts
+++ b/content/src/service/Service.ts
@@ -5,7 +5,6 @@ import {
   EntityType,
   PartialDeploymentHistory,
   Pointer,
-
   ServerStatus,
   Timestamp
 } from 'dcl-catalyst-commons'

--- a/content/src/service/Service.ts
+++ b/content/src/service/Service.ts
@@ -5,7 +5,7 @@ import {
   EntityType,
   PartialDeploymentHistory,
   Pointer,
-  ServerAddress,
+
   ServerStatus,
   Timestamp
 } from 'dcl-catalyst-commons'
@@ -74,8 +74,6 @@ export interface ClusterDeploymentsService {
   reportErrorDuringSync(
     entityType: EntityType,
     entityId: EntityId,
-    originTimestamp: Timestamp,
-    originServerUrl: ServerAddress,
     reason: FailureReason,
     errorDescription?: string
   ): Promise<null>

--- a/content/src/service/deployments/DeploymentManager.ts
+++ b/content/src/service/deployments/DeploymentManager.ts
@@ -66,8 +66,6 @@ export class DeploymentManager {
       auditInfo: {
         version: result.version,
         authChain: result.authChain,
-        originServerUrl: result.originServerUrl,
-        originTimestamp: result.originTimestamp,
         localTimestamp: result.localTimestamp,
         overwrittenBy: result.overwrittenBy,
         migrationData: migrationData.get(result.deploymentId)

--- a/content/src/service/errors/FailedDeploymentsManager.ts
+++ b/content/src/service/errors/FailedDeploymentsManager.ts
@@ -1,5 +1,5 @@
 import { FailedDeploymentsRepository } from '@katalyst/content/repository/extensions/FailedDeploymentsRepository'
-import { EntityId, EntityType, ServerAddress, Timestamp } from 'dcl-catalyst-commons'
+import { EntityId, EntityType, Timestamp } from 'dcl-catalyst-commons'
 
 /**
  * This manager will handle all failed deployments
@@ -9,16 +9,12 @@ export class FailedDeploymentsManager {
     failedDeploymentsRepo: FailedDeploymentsRepository,
     entityType: EntityType,
     entityId: EntityId,
-    originTimestamp: Timestamp,
-    originServerUrl: ServerAddress,
     reason: FailureReason,
     errorDescription?: string
   ): Promise<null> {
     return failedDeploymentsRepo.reportFailure(
       entityType,
       entityId,
-      originTimestamp,
-      originServerUrl,
       Date.now(),
       reason,
       errorDescription
@@ -58,8 +54,6 @@ export class FailedDeploymentsManager {
 export type FailedDeployment = {
   entityType: EntityType
   entityId: EntityId
-  originTimestamp: Timestamp
-  originServerUrl: ServerAddress
   failureTimestamp: Timestamp
   reason: FailureReason
   errorDescription?: string

--- a/content/src/service/errors/FailedDeploymentsManager.ts
+++ b/content/src/service/errors/FailedDeploymentsManager.ts
@@ -12,13 +12,7 @@ export class FailedDeploymentsManager {
     reason: FailureReason,
     errorDescription?: string
   ): Promise<null> {
-    return failedDeploymentsRepo.reportFailure(
-      entityType,
-      entityId,
-      Date.now(),
-      reason,
-      errorDescription
-    )
+    return failedDeploymentsRepo.reportFailure(entityType, entityId, Date.now(), reason, errorDescription)
   }
 
   getAllFailedDeployments(failedDeploymentsRepo: FailedDeploymentsRepository): Promise<FailedDeployment[]> {

--- a/content/src/service/synchronization/EventDeployer.ts
+++ b/content/src/service/synchronization/EventDeployer.ts
@@ -92,19 +92,22 @@ export class EventDeployer {
     for (let i = 0; i < unknownFileHashes.length; i++) {
       const fileHash = unknownFileHashes[i]
       EventDeployer.LOGGER.trace(
-        `Going to download file ${i + 1}/${unknownFileHashes.length} for entity (${entity.type}, ${entity.id
+        `Going to download file ${i + 1}/${unknownFileHashes.length} for entity (${entity.type}, ${
+          entity.id
         }). Hash is ${fileHash}`
       )
       const file = await this.getFileOrUndefined(fileHash, source)
       if (file) {
         files.push(file)
         EventDeployer.LOGGER.trace(
-          `Downloaded file ${i + 1}/${unknownFileHashes.length} for entity (${entity.type}, ${entity.id
+          `Downloaded file ${i + 1}/${unknownFileHashes.length} for entity (${entity.type}, ${
+            entity.id
           }). Hash was ${fileHash}`
         )
       } else {
         EventDeployer.LOGGER.trace(
-          `Failed to download file ${i + 1}/${unknownFileHashes.length} for entity (${entity.type}, ${entity.id
+          `Failed to download file ${i + 1}/${unknownFileHashes.length} for entity (${entity.type}, ${
+            entity.id
           }). Hash was ${fileHash}. Will cancel content download`
         )
         return undefined
@@ -159,12 +162,7 @@ export class EventDeployer {
     source?: ContentServerClient
   }): Promise<null> {
     const { entityType, entityId } = options.deployment
-    return this.service.reportErrorDuringSync(
-      entityType,
-      entityId,
-      options.reason,
-      options.description
-    )
+    return this.service.reportErrorDuringSync(entityType, entityId, options.reason, options.description)
   }
 
   private buildDeploymentExecution(

--- a/content/src/service/synchronization/EventDeployer.ts
+++ b/content/src/service/synchronization/EventDeployer.ts
@@ -92,22 +92,19 @@ export class EventDeployer {
     for (let i = 0; i < unknownFileHashes.length; i++) {
       const fileHash = unknownFileHashes[i]
       EventDeployer.LOGGER.trace(
-        `Going to download file ${i + 1}/${unknownFileHashes.length} for entity (${entity.type}, ${
-          entity.id
+        `Going to download file ${i + 1}/${unknownFileHashes.length} for entity (${entity.type}, ${entity.id
         }). Hash is ${fileHash}`
       )
       const file = await this.getFileOrUndefined(fileHash, source)
       if (file) {
         files.push(file)
         EventDeployer.LOGGER.trace(
-          `Downloaded file ${i + 1}/${unknownFileHashes.length} for entity (${entity.type}, ${
-            entity.id
+          `Downloaded file ${i + 1}/${unknownFileHashes.length} for entity (${entity.type}, ${entity.id
           }). Hash was ${fileHash}`
         )
       } else {
         EventDeployer.LOGGER.trace(
-          `Failed to download file ${i + 1}/${unknownFileHashes.length} for entity (${entity.type}, ${
-            entity.id
+          `Failed to download file ${i + 1}/${unknownFileHashes.length} for entity (${entity.type}, ${entity.id
           }). Hash was ${fileHash}. Will cancel content download`
         )
         return undefined
@@ -161,13 +158,10 @@ export class EventDeployer {
     description?: string
     source?: ContentServerClient
   }): Promise<null> {
-    const { entityType, entityId, auditInfo } = options.deployment
-    const { localTimestamp } = auditInfo
+    const { entityType, entityId } = options.deployment
     return this.service.reportErrorDuringSync(
       entityType,
       entityId,
-      localTimestamp,
-      options.source?.getAddress() ?? 'https://peer.decentraland.org/content',
       options.reason,
       options.description
     )

--- a/content/test/integration/E2EAssertions.ts
+++ b/content/test/integration/E2EAssertions.ts
@@ -25,7 +25,8 @@ export async function assertEntitiesAreDeployedButNotActive(server: TestServer, 
     assert.equal(
       unexpectedEntities.length,
       0,
-      `Expected not to find entity with id ${entity.id} when checking for pointer ${entity.pointers
+      `Expected not to find entity with id ${entity.id} when checking for pointer ${
+        entity.pointers
       } on server '${server.getAddress()}.'`
     )
     await assertEntityIsOnServer(server, entity)
@@ -89,7 +90,8 @@ export async function assertDeploymentsAreReported(server: TestServer, ...expect
   assert.equal(
     deployments.length,
     expectedDeployments.length,
-    `Expected to find ${expectedDeployments.length} deployments on server ${server.getAddress()}. Instead, found ${deployments.length
+    `Expected to find ${expectedDeployments.length} deployments on server ${server.getAddress()}. Instead, found ${
+      deployments.length
     }.`
   )
 
@@ -125,11 +127,7 @@ export async function assertThereIsAFailedDeployment(server: TestServer): Promis
   return failedDeployments[0]
 }
 
-export async function assertDeploymentFailed(
-  server: TestServer,
-  reason: FailureReason,
-  entity: ControllerEntity
-) {
+export async function assertDeploymentFailed(server: TestServer, reason: FailureReason, entity: ControllerEntity) {
   const failedDeployment = await assertThereIsAFailedDeployment(server)
   assert.equal(failedDeployment.entityType, entity.type)
   assert.equal(failedDeployment.entityId, entity.id)

--- a/content/test/integration/E2EAssertions.ts
+++ b/content/test/integration/E2EAssertions.ts
@@ -25,8 +25,7 @@ export async function assertEntitiesAreDeployedButNotActive(server: TestServer, 
     assert.equal(
       unexpectedEntities.length,
       0,
-      `Expected not to find entity with id ${entity.id} when checking for pointer ${
-        entity.pointers
+      `Expected not to find entity with id ${entity.id} when checking for pointer ${entity.pointers
       } on server '${server.getAddress()}.'`
     )
     await assertEntityIsOnServer(server, entity)
@@ -90,8 +89,7 @@ export async function assertDeploymentsAreReported(server: TestServer, ...expect
   assert.equal(
     deployments.length,
     expectedDeployments.length,
-    `Expected to find ${expectedDeployments.length} deployments on server ${server.getAddress()}. Instead, found ${
-      deployments.length
+    `Expected to find ${expectedDeployments.length} deployments on server ${server.getAddress()}. Instead, found ${deployments.length
     }.`
   )
 
@@ -130,14 +128,12 @@ export async function assertThereIsAFailedDeployment(server: TestServer): Promis
 export async function assertDeploymentFailed(
   server: TestServer,
   reason: FailureReason,
-  entity: ControllerEntity,
-  originTimestamp: Timestamp
+  entity: ControllerEntity
 ) {
   const failedDeployment = await assertThereIsAFailedDeployment(server)
   assert.equal(failedDeployment.entityType, entity.type)
   assert.equal(failedDeployment.entityId, entity.id)
   assert.equal(failedDeployment.reason, reason)
-  assert.ok(failedDeployment.failureTimestamp > originTimestamp)
 }
 
 function assertEqualsDeployment(actualDeployment: ControllerDeployment, expectedDeployment: ControllerDeployment) {

--- a/content/test/integration/errors/FailedDeploymentManager.spec.ts
+++ b/content/test/integration/errors/FailedDeploymentManager.spec.ts
@@ -72,9 +72,6 @@ describe('Integration - Failed Deployments Manager', function () {
   })
 
   function assertFailureWasDueToDeployment(failedDeployment: FailedDeployment, deployment: FakeDeployment) {
-    console.log('deployment', JSON.stringify(deployment, null, 4))
-    console.log('failedDeployment', JSON.stringify(failedDeployment, null, 4))
-
     expect(failedDeployment.entityId).toEqual(deployment.entityId)
     expect(failedDeployment.entityType).toEqual(deployment.entityType)
   }

--- a/content/test/integration/errors/FailedDeploymentManager.spec.ts
+++ b/content/test/integration/errors/FailedDeploymentManager.spec.ts
@@ -7,8 +7,8 @@ import {
   FailureReason,
   NoFailure
 } from '@katalyst/content/service/errors/FailedDeploymentsManager'
-import { EntityId, EntityType, ServerAddress, Timestamp } from 'dcl-catalyst-commons'
-import { internet, random } from 'faker'
+import { EntityId, EntityType } from 'dcl-catalyst-commons'
+import { random } from 'faker'
 import { loadStandaloneTestEnvironment } from '../E2ETestEnvironment'
 
 describe('Integration - Failed Deployments Manager', function () {
@@ -72,11 +72,11 @@ describe('Integration - Failed Deployments Manager', function () {
   })
 
   function assertFailureWasDueToDeployment(failedDeployment: FailedDeployment, deployment: FakeDeployment) {
+    console.log('deployment', JSON.stringify(deployment, null, 4));
+    console.log('failedDeployment', JSON.stringify(failedDeployment, null, 4));
+
     expect(failedDeployment.entityId).toEqual(deployment.entityId)
     expect(failedDeployment.entityType).toEqual(deployment.entityType)
-    expect(failedDeployment.originServerUrl).toEqual(deployment.originServerUrl)
-    expect(failedDeployment.originTimestamp).toEqual(deployment.originTimestamp)
-    expect(failedDeployment.failureTimestamp).toBeGreaterThanOrEqual(deployment.originTimestamp)
   }
 
   function reportDeployment({
@@ -88,14 +88,12 @@ describe('Integration - Failed Deployments Manager', function () {
     reason: FailureReason
     description?: string
   }): Promise<null> {
-    const { entityType, entityId, originTimestamp, originServerUrl } = deployment
+    const { entityType, entityId } = deployment
     return repository.run((db) =>
       manager.reportFailure(
         db.failedDeployments,
         entityType,
         entityId,
-        originTimestamp,
-        originServerUrl,
         reason,
         description
       )
@@ -109,13 +107,9 @@ describe('Integration - Failed Deployments Manager', function () {
   }
 
   function buildRandomDeployment(): FakeDeployment {
-    const originTimestamp = Date.now()
-    const originServerUrl = internet.url()
-    const event = {
+    const event: FakeDeployment = {
       entityType: EntityType.PROFILE,
       entityId: random.alphaNumeric(10),
-      originTimestamp,
-      originServerUrl
     }
     return event
   }
@@ -124,6 +118,4 @@ describe('Integration - Failed Deployments Manager', function () {
 type FakeDeployment = {
   entityType: EntityType
   entityId: EntityId
-  originTimestamp: Timestamp
-  originServerUrl: ServerAddress
 }

--- a/content/test/integration/errors/FailedDeploymentManager.spec.ts
+++ b/content/test/integration/errors/FailedDeploymentManager.spec.ts
@@ -72,8 +72,8 @@ describe('Integration - Failed Deployments Manager', function () {
   })
 
   function assertFailureWasDueToDeployment(failedDeployment: FailedDeployment, deployment: FakeDeployment) {
-    console.log('deployment', JSON.stringify(deployment, null, 4));
-    console.log('failedDeployment', JSON.stringify(failedDeployment, null, 4));
+    console.log('deployment', JSON.stringify(deployment, null, 4))
+    console.log('failedDeployment', JSON.stringify(failedDeployment, null, 4))
 
     expect(failedDeployment.entityId).toEqual(deployment.entityId)
     expect(failedDeployment.entityType).toEqual(deployment.entityType)
@@ -90,13 +90,7 @@ describe('Integration - Failed Deployments Manager', function () {
   }): Promise<null> {
     const { entityType, entityId } = deployment
     return repository.run((db) =>
-      manager.reportFailure(
-        db.failedDeployments,
-        entityType,
-        entityId,
-        reason,
-        description
-      )
+      manager.reportFailure(db.failedDeployments, entityType, entityId, reason, description)
     )
   }
 
@@ -109,7 +103,7 @@ describe('Integration - Failed Deployments Manager', function () {
   function buildRandomDeployment(): FakeDeployment {
     const event: FakeDeployment = {
       entityType: EntityType.PROFILE,
-      entityId: random.alphaNumeric(10),
+      entityId: random.alphaNumeric(10)
     }
     return event
   }

--- a/content/test/integration/syncronization/error-handling.spec.ts
+++ b/content/test/integration/syncronization/error-handling.spec.ts
@@ -154,7 +154,7 @@ describe('End 2 end - Error handling', () => {
     await server2.start()
 
     // Assert deployment is marked as failed
-    await awaitUntil(() => assertDeploymentFailed(server2, errorType, entityBeingDeployed, deploymentTimestamp))
+    await awaitUntil(() => assertDeploymentFailed(server2, errorType, entityBeingDeployed))
 
     // Assert entity wasn't deployed
     await assertEntityWasNotDeployed(server2, entityBeingDeployed)

--- a/content/test/manual/check-failed-deployments.spec.ts
+++ b/content/test/manual/check-failed-deployments.spec.ts
@@ -27,15 +27,10 @@ describe('Failed Deployments validations.', () => {
       const failedDeployments: FailedDeployment[] = await getFailedDeployments()
       const failedScenes = failedDeployments.filter((fd) => fd.entityType === EntityType.SCENE)
       const failedProfiles = failedDeployments.filter((fd) => fd.entityType === EntityType.PROFILE)
-      const servers = failedProfiles.map((fd) => fd.originServerUrl).filter(onlyUnique)
 
       console.log(`Total Failed Deployments: ${failedDeployments.length}`)
       console.log(`Scenes  : ${failedScenes.length}`)
       console.log(`Profiles: ${failedProfiles.length}`)
-      console.log('------------------------------')
-
-      console.log(`Servers:`)
-      servers.forEach((server) => console.log(`  ${server}`))
       console.log('------------------------------')
 
       // Retrieve Access Snapshots
@@ -44,7 +39,7 @@ describe('Failed Deployments validations.', () => {
         await Promise.all(
           failedDeployments.map(async (fd) => {
             console.log(`=> ${accessSnapshotsCount++ + 1} of ${failedDeployments.length}`)
-            return await getAccessSnapshot(fd.originServerUrl, fd.entityType, fd.entityId)
+            return await getAccessSnapshot('https://peer.decentraland.org/content', fd.entityType, fd.entityId)
           })
         )
       ).filter(notEmpty)
@@ -76,10 +71,10 @@ describe('Failed Deployments validations.', () => {
             } else {
               const overwriteEntity: Entity | undefined = accessSnapshot.overwrittenBy
                 ? await fetchEntity(
-                    'https://peer.decentraland.org/content',
-                    EntityType.SCENE,
-                    accessSnapshot.overwrittenBy
-                  )
+                  'https://peer.decentraland.org/content',
+                  EntityType.SCENE,
+                  accessSnapshot.overwrittenBy
+                )
                 : undefined
               console.log(
                 ' => Invalid',
@@ -230,7 +225,7 @@ describe('Failed Deployments validations.', () => {
 })
 
 async function getFailedDeployments(): Promise<FailedDeployment[]> {
-  return fetchArray(`https://bot1-catalyst.decentraland.org/content/failedDeployments`)
+  return fetchArray(`https://peer.decentraland.org/content/failedDeployments`)
 }
 
 function onlyUnique<T>(value: T, index: number, self: T[]): boolean {
@@ -254,7 +249,7 @@ function groupBy<K extends keyof V, V>(items: V[], groupingProperty: K): Associa
   return items.reduce(function (rv: AssociativeArray<V>, x: V) {
     const index = x[groupingProperty]
     if (isAssociativeIndex(index)) {
-      ;(rv[index] = rv[index] || []).push(x)
+      ; (rv[index] = rv[index] || []).push(x)
     }
     return rv
   }, {})

--- a/content/test/manual/check-failed-deployments.spec.ts
+++ b/content/test/manual/check-failed-deployments.spec.ts
@@ -71,10 +71,10 @@ describe('Failed Deployments validations.', () => {
             } else {
               const overwriteEntity: Entity | undefined = accessSnapshot.overwrittenBy
                 ? await fetchEntity(
-                  'https://peer.decentraland.org/content',
-                  EntityType.SCENE,
-                  accessSnapshot.overwrittenBy
-                )
+                    'https://peer.decentraland.org/content',
+                    EntityType.SCENE,
+                    accessSnapshot.overwrittenBy
+                  )
                 : undefined
               console.log(
                 ' => Invalid',
@@ -249,7 +249,7 @@ function groupBy<K extends keyof V, V>(items: V[], groupingProperty: K): Associa
   return items.reduce(function (rv: AssociativeArray<V>, x: V) {
     const index = x[groupingProperty]
     if (isAssociativeIndex(index)) {
-      ; (rv[index] = rv[index] || []).push(x)
+      ;(rv[index] = rv[index] || []).push(x)
     }
     return rv
   }, {})

--- a/content/test/manual/service/reporters/SQSDeploymentReporter.spec.ts
+++ b/content/test/manual/service/reporters/SQSDeploymentReporter.spec.ts
@@ -4,7 +4,7 @@ import { SQSDeploymentReporter } from '@katalyst/content/service/reporters/SQSDe
 describe('SQS Deployment Reporter', () => {
   const MAX_SAFE_TIMEOUT = Math.pow(2, 31) - 1
 
-  fit(
+  it(
     `Simple event reporting`,
     async () => {
       const sqsAccessKey = process.env.SQS_ACCESS_KEY_ID ?? ''

--- a/content/test/unit/service/errors/NoOpFailedDeploymentsManager.ts
+++ b/content/test/unit/service/errors/NoOpFailedDeploymentsManager.ts
@@ -9,8 +9,6 @@ export class NoOpFailedDeploymentsManager {
       Promise.resolve({
         entityType: EntityType.PROFILE,
         entityId: 'id',
-        originTimestamp: 10,
-        originServerUrl: 'ServerAddress',
         failureTimestamp: 20,
         reason: FailureReason.DEPLOYMENT_ERROR
       })

--- a/yarn.lock
+++ b/yarn.lock
@@ -3161,10 +3161,10 @@ date-format@^3.0.0:
   resolved "https://registry.yarnpkg.com/date-format/-/date-format-3.0.0.tgz#eb8780365c7d2b1511078fb491e6479780f3ad95"
   integrity sha512-eyTcpKOcamdhWJXj56DpQMo1ylSQpcGtGKXcU0Tb97+K56/CF5amAqqqNj0+KvA0iw2ynxtHWFsPDSClCxe48w==
 
-dcl-catalyst-client@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/dcl-catalyst-client/-/dcl-catalyst-client-5.0.0.tgz#e9b75c90f3a6ddeff17d2ee1ed38930ad9211ba9"
-  integrity sha512-JjrkTDv1O499H8zqNgDxWd3DFYrJHa4xCXwItH4UP/oZtCFwVZKzQPFVgK0UlgcyZmvSpimrIge6FZRuHDaZCA==
+dcl-catalyst-client@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/dcl-catalyst-client/-/dcl-catalyst-client-5.0.1.tgz#52a0fddda8b045092dae967f405ad42c16e2224f"
+  integrity sha512-wQrSjV4gflJZPdj30QNQHFWFWFnQfBMtPGcQ5Z0ZaZSYkVp+f/Zc/2xTukY0NPHS25yYKnM5iqijfh3VmLqfIg==
   dependencies:
     "@types/form-data" "^2.5.0"
     async-iterator-to-array "0.0.1"


### PR DESCRIPTION
This PR removes the origin timestamp and origin server url from the deployments table and the corresponding endpoints responses.

Changes:
- <b> \* Breaking change \*</b> Add DB migration script to remove the correct columns and indexes in `deployments` and `failed_deployments` 
- Remove `origin_server_url` and `origin_timestamp` from the repository queries for deployments
- Remove `origin_server_url` and `origin_timestamp` from the repository queries for failed_deployments
- Add doc on how to run tests 
- Add doc on how to connect to db locally
- Update `dcl-catalyst-client` version to `5.0.1`

Fixes #273 