### PR TITLE
Fix: Deployed by filter capitalization

### DIFF
--- a/content/src/migrations/scripts/1620221157277_add_lowercase_deployer_index.ts
+++ b/content/src/migrations/scripts/1620221157277_add_lowercase_deployer_index.ts
@@ -10,5 +10,6 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
 }
 
 export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.addIndex('deployments', 'deployer_address')
   pgm.sql(`DROP INDEX deployer_address_lower_case;`)
 }

--- a/content/src/migrations/scripts/1620221157277_add_lowercase_deployer_index.ts
+++ b/content/src/migrations/scripts/1620221157277_add_lowercase_deployer_index.ts
@@ -1,0 +1,13 @@
+import { MigrationBuilder } from 'node-pg-migrate'
+
+/*
+  In this migration, we are creating a index in deployments table with the 'entity_timestamp' and 'entity_id' columns
+ */
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.sql(`CREATE INDEX deployer_address_lower_case on deployments (LOWER(deployer_address) text_pattern_ops);`)
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.sql(`DROP INDEX deployer_address_lower_case;`)
+}

--- a/content/src/migrations/scripts/1620221157277_add_lowercase_deployer_index.ts
+++ b/content/src/migrations/scripts/1620221157277_add_lowercase_deployer_index.ts
@@ -5,6 +5,7 @@ import { MigrationBuilder } from 'node-pg-migrate'
  */
 
 export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.sql(`DROP INDEX deployments_deployer_address_index;`)
   pgm.sql(`CREATE INDEX deployer_address_lower_case on deployments (LOWER(deployer_address) text_pattern_ops);`)
 }
 

--- a/content/src/repository/extensions/DeploymentsRepository.ts
+++ b/content/src/repository/extensions/DeploymentsRepository.ts
@@ -27,7 +27,6 @@ export class DeploymentsRepository {
     )
 
     const deployedIds = new Set(result)
-    console.log('deployedIds', deployedIds)
     return new Map(entityIds.map((entityId) => [entityId, deployedIds.has(entityId)]))
   }
 

--- a/content/src/repository/extensions/DeploymentsRepository.ts
+++ b/content/src/repository/extensions/DeploymentsRepository.ts
@@ -50,7 +50,7 @@ export class DeploymentsRepository {
     lastId?: string
   ) {
     const sorting = Object.assign({ field: SortingField.LOCAL_TIMESTAMP, order: SortingOrder.DESCENDING }, sortBy)
-    return this.getDeploymentsBy(sorting?.field, sorting?.order, offset, limit, filters, lastId)
+    return this.getDeploymentsBy(sorting.field, sorting.order, offset, limit, filters, lastId)
   }
 
   private getDeploymentsBy(

--- a/content/src/repository/extensions/DeploymentsRepository.ts
+++ b/content/src/repository/extensions/DeploymentsRepository.ts
@@ -25,7 +25,9 @@ export class DeploymentsRepository {
       [entityIds],
       ({ entity_id }) => entity_id
     )
+
     const deployedIds = new Set(result)
+    console.log('deployedIds', deployedIds)
     return new Map(entityIds.map((entityId) => [entityId, deployedIds.has(entityId)]))
   }
 
@@ -130,8 +132,8 @@ export class DeploymentsRepository {
     }
 
     if (filters?.deployedBy && filters.deployedBy.length > 0) {
-      values.deployedBy = filters.deployedBy
-      whereClause.push(`dep1.deployer_address IN ($(deployedBy:list))`)
+      values.deployedBy = filters.deployedBy.map((deployedBy) => deployedBy.toLocaleLowerCase())
+      whereClause.push(`LOWER(dep1.deployer_address) IN ($(deployedBy:list))`)
     }
 
     if (filters?.entityTypes && filters.entityTypes.length > 0) {

--- a/content/src/repository/extensions/DeploymentsRepository.ts
+++ b/content/src/repository/extensions/DeploymentsRepository.ts
@@ -176,7 +176,7 @@ export class DeploymentsRepository {
 
   private createOrClause(timestampField: string, compare: string, timestampFilter: string): string {
     const equalWithEntityIdComparison = `(LOWER(dep1.entity_id) ${compare} LOWER($(lastId)) AND dep1.${timestampField} = to_timestamp($(${timestampFilter}) / 1000.0))`
-    const timestampComparison = `(dep1.entity_timestamp ${compare} to_timestamp($(${timestampFilter}) / 1000.0))`
+    const timestampComparison = `(dep1.${timestampField} ${compare} to_timestamp($(${timestampFilter}) / 1000.0))`
     return `(${equalWithEntityIdComparison} OR ${timestampComparison})`
   }
 

--- a/content/test/integration/service/deployments/deployment-filters.spec.ts
+++ b/content/test/integration/service/deployments/deployment-filters.spec.ts
@@ -56,8 +56,8 @@ describe('Integration - Deployment Filters', () => {
     await assertDeploymentsWithFilterAre({ entityIds: [E1.entity.id, E2.entity.id] }, E1, E2)
   })
 
-  it('When deployed by filter is set, then results are calculated correctly', async () => {
-    const identity1 = 'some-identity'
+  it('When deployed by filter is set, then results are calculated ignoring the casing', async () => {
+    const identity1 = 'Some-Identity'
     const identity2 = 'another-identity'
 
     // Deploy E1 and E2
@@ -66,6 +66,7 @@ describe('Integration - Deployment Filters', () => {
 
     await assertDeploymentsWithFilterAre({}, E1, E2)
     await assertDeploymentsWithFilterAre({ deployedBy: [identity1] }, E1)
+    await assertDeploymentsWithFilterAre({ deployedBy: [identity1.toLowerCase()] }, E1)
     await assertDeploymentsWithFilterAre({ deployedBy: [identity2] }, E2)
     await assertDeploymentsWithFilterAre({ deployedBy: [identity1, identity2] }, E1, E2)
     await assertDeploymentsWithFilterAre({ deployedBy: ['not-and-identity'] })

--- a/content/test/unit/repository/DeploymentsRepository.spec.ts
+++ b/content/test/unit/repository/DeploymentsRepository.spec.ts
@@ -1,10 +1,10 @@
 import { DeploymentsRepository } from '@katalyst/content/repository/extensions/DeploymentsRepository'
 import { Entity } from '@katalyst/content/service/Entity'
 import { EntityType, EntityVersion, SortingField, SortingOrder } from 'dcl-catalyst-commons'
-import { anything, capture, deepEqual, instance, mock, verify, when } from 'ts-mockito'
+import { anything, capture, deepEqual, instance, mock, spy, verify, when } from 'ts-mockito'
 import MockedDataBase from './MockedDataBase'
 
-fdescribe('DeploymentRepository', () => {
+describe('DeploymentRepository', () => {
   let repository: DeploymentsRepository
   let db: MockedDataBase
 
@@ -416,5 +416,41 @@ fdescribe('DeploymentRepository', () => {
       })
     })
   })
-  describe('setEntitiesAsOverwritten', () => {})
+
+  describe('setEntitiesAsOverwritten', () => {
+    const overwrittenBy = 150
+    const overwrittenDeploymentId = 250
+    const overwrittenDeployments = [
+      overwrittenDeploymentId,
+      overwrittenDeploymentId + 1,
+      overwrittenDeploymentId + 2,
+      overwrittenDeploymentId + 3
+    ]
+
+    beforeEach(() => {
+      db = spy(new MockedDataBase())
+      const dbInstance = instance(db)
+      repository = new DeploymentsRepository(dbInstance as any)
+
+      when(db.none(anything(), anything(), anything()))
+        .thenReturn(...overwrittenDeployments.map((x) => x as any))
+        .thenThrow(new Error('Unexpected call'))
+      ;(dbInstance as any).txIf = (callBack) => callBack({ batch: dbInstance.batch })
+    })
+
+    it('should call the update for each override', async () => {
+      await repository.setEntitiesAsOverwritten(new Set(overwrittenDeployments), overwrittenBy)
+
+      overwrittenDeployments.forEach((overwrittenDeployment) => {
+        verify(
+          db.none(
+            'UPDATE deployments SET deleter_deployment = $1 WHERE id = $2',
+            deepEqual([overwrittenBy, overwrittenDeployment])
+          )
+        ).once()
+      })
+
+      verify(db.batch(anything())).once()
+    })
+  })
 })

--- a/content/test/unit/repository/DeploymentsRepository.spec.ts
+++ b/content/test/unit/repository/DeploymentsRepository.spec.ts
@@ -1,5 +1,5 @@
 import { DeploymentsRepository } from '@katalyst/content/repository/extensions/DeploymentsRepository'
-import { anything, capture, instance, mock, when } from 'ts-mockito'
+import { anything, deepEqual, instance, mock, verify, when } from 'ts-mockito'
 import MockedDataBase from './MockedDataBase'
 
 describe('DeploymentRepository', () => {
@@ -27,10 +27,9 @@ describe('DeploymentRepository', () => {
 
         expect(result).toEqual(new Map(entities.map((entityId) => [entityId, entitiesSet.has(entityId)])))
 
-        const args = capture(db.map).last()
-
-        expect(args[0]).toEqual('SELECT entity_id FROM deployments WHERE entity_id IN ($1:list)')
-        expect(args[1]).toEqual([entities])
+        verify(
+          db.map('SELECT entity_id FROM deployments WHERE entity_id IN ($1:list)', deepEqual([entities]), anything())
+        ).once()
       })
     })
   })

--- a/content/test/unit/repository/DeploymentsRepository.spec.ts
+++ b/content/test/unit/repository/DeploymentsRepository.spec.ts
@@ -1,0 +1,37 @@
+import { DeploymentsRepository } from '@katalyst/content/repository/extensions/DeploymentsRepository'
+import { anything, capture, instance, mock, when } from 'ts-mockito'
+import MockedDataBase from './MockedDataBase'
+
+describe('DeploymentRepository', () => {
+  let repository: DeploymentsRepository
+  let db: MockedDataBase
+
+  beforeEach(() => {
+    db = mock(MockedDataBase)
+    repository = new DeploymentsRepository(instance(db) as any)
+  })
+
+  describe('areEntitiesDeployed', () => {
+    describe('when the entities list is not empty', () => {
+      const dbResult = ['1', '2']
+
+      beforeEach(() => {
+        when(db.map(anything(), anything(), anything())).thenReturn(Promise.resolve(dbResult))
+      })
+
+      fit('should return a map of entity id to the deployment status', async () => {
+        const entities = ['1', '3']
+        const result = await repository.areEntitiesDeployed(entities)
+
+        const entitiesSet = new Set(dbResult)
+
+        expect(result).toEqual(new Map(entities.map((entityId) => [entityId, entitiesSet.has(entityId)])))
+
+        const args = capture(db.map).last()
+
+        expect(args[0]).toEqual('SELECT entity_id FROM deployments WHERE entity_id IN ($1:list)')
+        expect(args[1]).toEqual([entities])
+      })
+    })
+  })
+})

--- a/content/test/unit/repository/DeploymentsRepository.spec.ts
+++ b/content/test/unit/repository/DeploymentsRepository.spec.ts
@@ -1,8 +1,9 @@
 import { DeploymentsRepository } from '@katalyst/content/repository/extensions/DeploymentsRepository'
-import { anything, deepEqual, instance, mock, verify, when } from 'ts-mockito'
+import { SortingField, SortingOrder } from 'dcl-catalyst-commons'
+import { anything, capture, deepEqual, instance, mock, verify, when } from 'ts-mockito'
 import MockedDataBase from './MockedDataBase'
 
-describe('DeploymentRepository', () => {
+fdescribe('DeploymentRepository', () => {
   let repository: DeploymentsRepository
   let db: MockedDataBase
 
@@ -12,6 +13,11 @@ describe('DeploymentRepository', () => {
   })
 
   describe('areEntitiesDeployed', () => {
+    beforeEach(() => {
+      db = mock(MockedDataBase)
+      repository = new DeploymentsRepository(instance(db) as any)
+    })
+
     describe('when the entities list is not empty', () => {
       const dbResult = ['1', '2']
 
@@ -19,17 +25,94 @@ describe('DeploymentRepository', () => {
         when(db.map(anything(), anything(), anything())).thenReturn(Promise.resolve(dbResult))
       })
 
-      fit('should return a map of entity id to the deployment status', async () => {
+      it('should return a map of entity id to the deployment status', async () => {
         const entities = ['1', '3']
         const result = await repository.areEntitiesDeployed(entities)
 
-        const entitiesSet = new Set(dbResult)
-
-        expect(result).toEqual(new Map(entities.map((entityId) => [entityId, entitiesSet.has(entityId)])))
+        expect(result).toEqual(
+          new Map([
+            ['1', true],
+            ['3', false]
+          ])
+        )
 
         verify(
           db.map('SELECT entity_id FROM deployments WHERE entity_id IN ($1:list)', deepEqual([entities]), anything())
         ).once()
+      })
+    })
+
+    describe('when the entities list is empty', () => {
+      it('should return an empty map', async () => {
+        const result = await repository.areEntitiesDeployed([])
+
+        expect(result).toEqual(new Map())
+
+        verify(db.map(anything(), anything(), anything())).never()
+      })
+    })
+  })
+
+  describe('getAmountOfDeployments', () => {
+    let result
+    const expectedResult = [
+      ['1', true],
+      ['2', false]
+    ]
+
+    beforeEach(async () => {
+      db = mock(MockedDataBase)
+      repository = new DeploymentsRepository(instance(db) as any)
+
+      when(db.map(anything(), anything(), anything())).thenReturn(Promise.resolve(expectedResult))
+      result = await repository.getAmountOfDeployments()
+    })
+
+    it('should call the database with the expected query', () => {
+      verify(
+        db.map(`SELECT entity_type, COUNT(*) AS count FROM deployments GROUP BY entity_type`, deepEqual([]), anything())
+      ).once()
+    })
+
+    it('should return a Map with the result', () => {
+      expect(result).toEqual(new Map(expectedResult as any))
+    })
+  })
+
+  describe('getHistoricalDeployments', () => {
+    beforeEach(() => {
+      db = mock(MockedDataBase)
+      repository = new DeploymentsRepository(instance(db) as any)
+    })
+
+    describe('when it receives a field or order to sort by', () => {
+      beforeEach(() => {
+        when(db.map(anything(), anything(), anything())).thenReturn(Promise.resolve([]))
+      })
+
+      it('should call the database with the expected sorting', async () => {
+        await repository.getHistoricalDeployments(0, 10, undefined, {
+          field: SortingField.ENTITY_TIMESTAMP,
+          order: SortingOrder.ASCENDING
+        })
+
+        const args = capture(db.map).last()
+
+        expect(args[0]).toContain(`ORDER BY dep1.entity_timestamp ASC`)
+      })
+    })
+
+    describe("when it doesn't receive a field or order to sort by", () => {
+      beforeEach(() => {
+        when(db.map(anything(), anything(), anything())).thenReturn(Promise.resolve([]))
+      })
+
+      it('should call the database with the default sorting', async () => {
+        await repository.getHistoricalDeployments(0, 10)
+
+        const args = capture(db.map).last()
+
+        expect(args[0]).toContain(`ORDER BY dep1.local_timestamp DESC`)
       })
     })
   })

--- a/content/test/unit/repository/DeploymentsRepository.spec.ts
+++ b/content/test/unit/repository/DeploymentsRepository.spec.ts
@@ -291,5 +291,22 @@ describe('DeploymentRepository', () => {
         expect(args[1]).toEqual(jasmine.objectContaining({ pointers: pointers.map((x) => x.toLowerCase()) }))
       })
     })
+
+    describe('when there is no filter', () => {
+      beforeEach(() => {
+        db = mock(MockedDataBase)
+        repository = new DeploymentsRepository(instance(db) as any)
+
+        when(db.map(anything(), anything(), anything())).thenReturn(Promise.resolve([]))
+      })
+
+      it('should not add a where clause', async () => {
+        await repository.getHistoricalDeployments(0, 10)
+
+        const args = capture(db.map).last()
+
+        expect(args[0]).not.toContain(`WHERE`)
+      })
+    })
   })
 })

--- a/content/test/unit/repository/MockedDataBase.ts
+++ b/content/test/unit/repository/MockedDataBase.ts
@@ -1,0 +1,21 @@
+export default class MockedDataBase {
+  public one = (query: string, args: any, mapping: (row: any) => any): Promise<any> => {
+    return Promise.resolve(null)
+  }
+
+  public map = (query: string, args: any, mapping: (row: any) => any): Promise<any[]> => {
+    return Promise.resolve([])
+  }
+
+  public none = (query: string, args: any, mapping: (row: any) => any): Promise<any> => {
+    return Promise.resolve()
+  }
+
+  public batch = (...args: any[]): Promise<any[]> => {
+    return Promise.resolve(args)
+  }
+
+  public txIf = (transactionFunction: (transaction: any) => Promise<any>): Promise<any> => {
+    return transactionFunction(this)
+  }
+}

--- a/content/test/unit/repository/MockedDataBase.ts
+++ b/content/test/unit/repository/MockedDataBase.ts
@@ -7,15 +7,11 @@ export default class MockedDataBase {
     return Promise.resolve([])
   }
 
-  public none = (query: string, args: any, mapping: (row: any) => any): Promise<any> => {
+  public none(query: string, args: any, mapping?: (row: any) => any): Promise<any> {
     return Promise.resolve()
   }
 
-  public batch = (...args: any[]): Promise<any[]> => {
+  public batch(...args: any[]): Promise<any[]> {
     return Promise.resolve(args)
-  }
-
-  public txIf = (transactionFunction: (transaction: any) => Promise<any>): Promise<any> => {
-    return transactionFunction(this)
   }
 }


### PR DESCRIPTION
This PR:
- Introduces a new index for deployer_address for the lowercase of the column, since we'll be searching ignoring case, but saving values as they come
- Creates a test suite for DeploymentRepository, achieving ~100% coverage mocking the database
- Fixes a bug in the `createOrClause` method where the timestamp type was hardcoded and didn't change based on the filter type
- Modifies the query for deployer_address so that it looks for the LOWER of the incoming address
- Modifies some queries from multiline to single line to make them more testable

Fixes #291 