### PR TITLE
fix: remove bugged optimization

### DIFF
--- a/lambdas/src/utils/SmartContentClient.ts
+++ b/lambdas/src/utils/SmartContentClient.ts
@@ -119,7 +119,7 @@ export class SmartContentClient implements ContentAPI {
       try {
         const fetcher = new Fetcher()
         await fetcher.fetchJson(`${SmartContentClient.INTERNAL_CONTENT_SERVER_URL}/status`, {
-          attempts: 1,
+          attempts: 6,
           waitTime: '10s'
         })
         SmartContentClient.LOGGER.info('Will use the internal content server url')

--- a/lambdas/src/utils/SmartContentClient.ts
+++ b/lambdas/src/utils/SmartContentClient.ts
@@ -119,7 +119,7 @@ export class SmartContentClient implements ContentAPI {
       try {
         const fetcher = new Fetcher()
         await fetcher.fetchJson(`${SmartContentClient.INTERNAL_CONTENT_SERVER_URL}/status`, {
-          attempts: 6,
+          attempts: 1,
           waitTime: '10s'
         })
         SmartContentClient.LOGGER.info('Will use the internal content server url')


### PR DESCRIPTION
When querying for wearables ownership, we used to have an optimization in place so that we only queried the subgraph that the wearables belonged to. For example, if a wearable was created in ethereum, we would only check the L1 subgraph.

This optimization had a bug though, that used the urn's protocol to determine the correct subgraph to use. The problem was that a "mumbai" (matic's testnet) urn would not match any of the layers used (only "mainnet" or "matic").

Since we want to support assets that move from one chain to the other in the near future, we will just remove this optimization, instead of trying to fix it. We were going to remove it anyways to support this new need.