### PR TITLE
feat: add support for global config

### DIFF
--- a/comms/lighthouse/BUILD.bazel
+++ b/comms/lighthouse/BUILD.bazel
@@ -69,6 +69,7 @@ ts_library(
         "@npm//@types",
         "@npm//cors",
         "@npm//dcl-crypto",
+        "@npm//dcl-catalyst-commons",
         "@npm//express",
         "@npm//fast-deep-equal",
         "@npm//fp-future",
@@ -116,6 +117,7 @@ ts_library(
         "@npm//@types/jasmine",
         "@npm//isomorphic-fetch",
         "@npm//express",
+        "@npm//ts-mockito",
     ],
 )
 

--- a/comms/lighthouse/BUILD.bazel
+++ b/comms/lighthouse/BUILD.bazel
@@ -117,7 +117,6 @@ ts_library(
         "@npm//@types/jasmine",
         "@npm//isomorphic-fetch",
         "@npm//express",
-        "@npm//ts-mockito",
     ],
 )
 

--- a/comms/lighthouse/src/configService.ts
+++ b/comms/lighthouse/src/configService.ts
@@ -103,7 +103,7 @@ export class ConfigService {
       if (this.envWrapper.isInEnv(configEnvironmentName)) {
         newConfigValue = config.fromText(this.envWrapper.readFromEnv(configEnvironmentName))
       } else if (configName in storageConfig) {
-        newConfigValue = storageConfig[configName]
+        newConfigValue = JSON.parse(storageConfig[configName])
       } else if (configName in globalConfig) {
         newConfigValue = globalConfig[configName]
       } else {

--- a/comms/lighthouse/src/configService.ts
+++ b/comms/lighthouse/src/configService.ts
@@ -1,18 +1,63 @@
-import { SimpleStorage } from './simpleStorage'
+import { fetchJson } from 'dcl-catalyst-commons'
+import ms from 'ms'
+import { ISimpleStorage } from './simpleStorage'
 
 export type ConfigKeyValue = {
   key: string
   value?: any
 }
 
-export class ConfigService {
-  private storage: SimpleStorage
+export class LighthouseConfig<T> {
+  static readonly MAX_PEERS_PER_LAYER: LighthouseConfig<number> = new LighthouseConfig({
+    name: 'maxPeersPerLayer',
+    fromText: parseInt,
+    defaultValue: 100
+  })
 
-  constructor(storage: SimpleStorage) {
-    this.storage = storage
+  static readonly ARCHIPELAGO_JOIN_DISTANCE: LighthouseConfig<number> = new LighthouseConfig({
+    name: 'archipelagoJoinDistance',
+    fromText: parseInt,
+    defaultValue: 64
+  })
+
+  static readonly ARCHIPELAGO_LEAVE_DISTANCE: LighthouseConfig<number> = new LighthouseConfig({
+    name: 'archipelagoLeaveDistance',
+    fromText: parseInt,
+    defaultValue: 80
+  })
+
+  readonly name: string
+  readonly fromText: (config: string) => T
+  readonly defaultValue: T
+
+  constructor({ name, fromText, defaultValue }: { name: string; fromText: (config: string) => T; defaultValue: T }) {
+    this.name = name
+    this.fromText = fromText
+    this.defaultValue = defaultValue
   }
 
-  async updateConfigs(configs: ConfigKeyValue[]) {
+  static toEnvironmentName(name: string): string {
+    return name.replace(/[A-Z]/g, (letter) => `_${letter}`).toUpperCase()
+  }
+}
+
+/**
+ * This service handles the lighthouse's configuration. There are four different levels of configuration, with the following precedence:
+ * Environment config >> storage config >> global config >> default config
+ */
+export class ConfigService {
+  private readonly listeners: Map<string, ((newValue: any) => void)[]> = new Map()
+  private readonly config: Config = {}
+
+  constructor(
+    private readonly storage: ISimpleStorage,
+    private readonly fetchGlobalConfig: () => Promise<Config>,
+    private readonly envWrapper: EnvironmentWrapper
+  ) {
+    setInterval(() => this.updateConfig(), ms('15m'))
+  }
+
+  async updateStorageConfigs(configs: ConfigKeyValue[]) {
     for (const it of configs) {
       if (typeof it.value !== 'undefined') {
         await this.storage.setString(it.key, JSON.stringify(it.value))
@@ -21,29 +66,91 @@ export class ConfigService {
       }
     }
 
-    return await this.getConfig()
+    await this.updateConfig()
+    return this.getAllConfig()
   }
 
-  async getConfig() {
-    const items = await this.storage.getAll()
-    Object.keys(items).forEach((key) => (items[key] = JSON.parse(items[key])))
-    return items
+  listenTo<T>(config: LighthouseConfig<T>, listener: (newValue: T) => void): void {
+    const listeners = this.listeners.get(config.name)
+    if (listeners) {
+      listeners.push(listener)
+    } else {
+      this.listeners.set(config.name, [listener])
+    }
   }
 
-  async get(key: string, ifNotPresent: () => any): Promise<any> {
-    const item = await this.storage.getString(key)
-    return typeof item !== 'undefined' ? JSON.parse(item) : ifNotPresent()
+  getAllConfig() {
+    return this.config
   }
 
-  async getMaxPeersPerLayer(): Promise<number | undefined> {
-    return await this.get('maxPeersPerLayer', () => parseInt(process.env.MAX_PER_LAYER ?? '100'))
+  get<T>(config: LighthouseConfig<T>): T {
+    return this.config[config.name]
   }
 
-  async getJoinDistance(): Promise<number> {
-    return await this.get('archipelagoJoinDistance', () => parseInt(process.env.ARCHIPELAGO_JOIN_DISTANCE ?? '64'))
+  /**
+   * This method reads storage and global config, and then updates the current on-memory registry.
+   *
+   * Note: visible for testing purposes
+   */
+  async updateConfig() {
+    const storageConfig = await this.storage.getAll()
+    const globalConfig = await this.fetchGlobalConfig()
+    for (const [, config] of Object.entries(LighthouseConfig)) {
+      const configName = config.name
+      const configEnvironmentName = LighthouseConfig.toEnvironmentName(config.name)
+      const currentConfigValue = this.config[config.name]
+      let newConfigValue: any
+      if (this.envWrapper.isInEnv(configEnvironmentName)) {
+        newConfigValue = config.fromText(this.envWrapper.readFromEnv(configEnvironmentName))
+      } else if (configName in storageConfig) {
+        newConfigValue = storageConfig[configName]
+      } else if (configName in globalConfig) {
+        newConfigValue = globalConfig[configName]
+      } else {
+        newConfigValue = config.defaultValue
+      }
+      if (currentConfigValue !== newConfigValue) {
+        this.config[configName] = newConfigValue
+        this.listeners.get(configName)?.forEach((listener) => listener(newConfigValue))
+      }
+    }
   }
 
-  async getLeaveDistance(): Promise<number> {
-    return await this.get('archipelagoLeaveDistance', () => parseInt(process.env.ARCHIPELAGO_LEAVE_DISTANCE ?? '80'))
+  static async build(options: {
+    storage: ISimpleStorage
+    globalConfig: { ethNetwork: string } | { fetch: () => Promise<Config> }
+    envWrapper?: EnvironmentWrapper
+  }): Promise<ConfigService> {
+    const globalConfig = options.globalConfig
+    const service = new ConfigService(
+      options.storage,
+      'ethNetwork' in globalConfig ? () => fetchGlobalConfig(globalConfig.ethNetwork) : globalConfig.fetch,
+      options.envWrapper ?? buildEnvWrapper()
+    )
+    await service.updateConfig()
+    return service
+  }
+}
+
+export type Config = Record<string, any>
+
+export type EnvironmentWrapper = {
+  isInEnv: (environmentKey: string) => boolean
+  readFromEnv: (environmentKey: string) => string
+}
+
+function buildEnvWrapper(): EnvironmentWrapper {
+  return {
+    isInEnv: (environmentKey: string) => environmentKey in process.env,
+    readFromEnv: (environmentKey: string) => process.env[environmentKey]!
+  }
+}
+
+async function fetchGlobalConfig(ethNetwork: string): Promise<Config> {
+  try {
+    const tld = ethNetwork === 'mainnet' ? 'org' : 'zone'
+    return await fetchJson(`https://config.decentraland.${tld}/catalyst.json`)
+  } catch {
+    return {}
   }
 }

--- a/comms/lighthouse/src/layersService.ts
+++ b/comms/lighthouse/src/layersService.ts
@@ -1,5 +1,5 @@
 import { Gauge } from 'prom-client'
-import { ConfigService } from './configService'
+import { ConfigService, LighthouseConfig } from './configService'
 import { LayerIsFullError, RequestError, UserMustBeInLayerError as PeerMustBeInLayerError } from './errors'
 import { NotificationType, PeersService } from './peersService'
 import { RoomsService } from './roomsService'
@@ -103,7 +103,7 @@ export class LayersService {
     return (this.layers[layerId] = this.newLayer(layerId))
   }
 
-  async setPeerLayer(layerId: string, peer: PeerRequest) {
+  setPeerLayer(layerId: string, peer: PeerRequest) {
     let layer = this.layers[layerId]
 
     if (!layer) {
@@ -117,7 +117,7 @@ export class LayersService {
 
       this.checkLayerPeersIfNeeded(layer)
 
-      const maxPeers = await this.getMaxPeersFor(layer)
+      const maxPeers = this.getMaxPeersFor(layer)
 
       if (maxPeers && layer.peers.length >= maxPeers) {
         throw new LayerIsFullError(layer, peerId)
@@ -141,8 +141,8 @@ export class LayersService {
     return layer
   }
 
-  async getMaxPeersFor(layer: Layer) {
-    return layer.maxPeers ?? (await this.config.configService.getMaxPeersPerLayer())
+  getMaxPeersFor(layer: Layer) {
+    return layer.maxPeers ?? this.config.configService.get(LighthouseConfig.MAX_PEERS_PER_LAYER)
   }
 
   checkLayerPeersIfNeeded(layer: Layer) {

--- a/comms/lighthouse/src/routes.ts
+++ b/comms/lighthouse/src/routes.ts
@@ -152,6 +152,11 @@ export function configureRoutes(app: express.Express, services: Services, option
     }
   }
 
+  const getConfig = async (req, res) => {
+    const config = configService.getAllConfig()
+    res.send(config)
+  }
+
   registerRoute(app, '/status', HttpMethod.GET, [getStatus])
   registerRoute(app, '/layers', HttpMethod.GET, [getLayers])
   registerRoute(app, '/layers/:layerId', HttpMethod.GET, [validateLayerExists, getByLayerId])
@@ -190,6 +195,8 @@ export function configureRoutes(app: express.Express, services: Services, option
     ),
     putConfig
   ])
+
+  registerRoute(app, '/config', HttpMethod.GET, [getConfig])
 
   function registerRoute(app: express.Express, route: string, method: HttpMethod, actions: RequestHandler[]) {
     const handlers: RequestHandler[] = [...Metrics.requestHandlers(), ...actions]

--- a/comms/lighthouse/src/routes.ts
+++ b/comms/lighthouse/src/routes.ts
@@ -2,7 +2,7 @@ import { validateSignatureHandler } from 'decentraland-katalyst-commons/handlers
 import { Metrics } from 'decentraland-katalyst-commons/metrics'
 import express, { RequestHandler } from 'express'
 import { IRealm } from 'peerjs-server'
-import { ConfigService } from './configService'
+import { ConfigService, LighthouseConfig } from './configService'
 import { RequestError } from './errors'
 import { requireAll, requireOneOf, validatePeerToken } from './handlers'
 import { LayersService } from './layersService'
@@ -35,7 +35,7 @@ export function configureRoutes(app: express.Express, services: Services, option
     }
   }
 
-  const getStatus: RequestHandler = async (req, res) => {
+  const getStatus: RequestHandler = (req, res) => {
     const status: any = {
       name: options.name,
       version: options.version,
@@ -44,7 +44,7 @@ export function configureRoutes(app: express.Express, services: Services, option
       ready: true
     }
 
-    const globalMaxPerLayer = await configService.getMaxPeersPerLayer()
+    const globalMaxPerLayer = configService.get(LighthouseConfig.MAX_PEERS_PER_LAYER)
 
     if (req.query.includeLayers === 'true') {
       status.layers = layersService.getLayers().map((it) => mapLayerToJson(it, globalMaxPerLayer, true))
@@ -53,15 +53,15 @@ export function configureRoutes(app: express.Express, services: Services, option
     res.send(status)
   }
 
-  const getLayers: RequestHandler = async (req, res) => {
-    const globalMaxPerLayer = await configService.getMaxPeersPerLayer()
+  const getLayers: RequestHandler = (req, res) => {
+    const globalMaxPerLayer = configService.get(LighthouseConfig.MAX_PEERS_PER_LAYER)
     res.send(
       layersService.getLayers().map((it) => mapLayerToJson(it, globalMaxPerLayer, req.query.usersParcels === 'true'))
     )
   }
 
-  const getByLayerId = async (req, res) => {
-    const globalMaxPerLayer = await configService.getMaxPeersPerLayer()
+  const getByLayerId = (req, res) => {
+    const globalMaxPerLayer = configService.get(LighthouseConfig.MAX_PEERS_PER_LAYER)
     res.send(mapLayerToJson(layersService.getLayer(req.params.layerId)!, globalMaxPerLayer))
   }
 
@@ -82,10 +82,10 @@ export function configureRoutes(app: express.Express, services: Services, option
     }
   }
 
-  const putLayerId = async (req, res, next) => {
+  const putLayerId = (req, res, next) => {
     const { layerId } = req.params
     try {
-      const layer = await layersService.setPeerLayer(layerId, req.body)
+      const layer = layersService.setPeerLayer(layerId, req.body)
       res.send(mapUsersToJson(peersService.getPeersInfo(layer.peers)))
     } catch (err) {
       handleError(err, res, next)
@@ -147,7 +147,7 @@ export function configureRoutes(app: express.Express, services: Services, option
         })
       )
     } else {
-      const config = await configService.updateConfigs(configKeyValues)
+      const config = await configService.updateStorageConfigs(configKeyValues)
       res.send(config)
     }
   }

--- a/comms/lighthouse/src/simpleStorage.ts
+++ b/comms/lighthouse/src/simpleStorage.ts
@@ -9,7 +9,16 @@ const deepCopy = (obj: any) => {
   return v8.deserialize(v8.serialize(obj))
 }
 
-export class SimpleStorage {
+export interface ISimpleStorage {
+  clear(): Promise<void>
+  getAll(): Promise<any>
+  getString(key: string): Promise<string | undefined>
+  getOrSetString(key: string, value: string): Promise<string | undefined>
+  setString(key: string, value: string): Promise<void>
+  deleteKey(key: string): Promise<void>
+}
+
+export class SimpleStorage implements ISimpleStorage {
   private _currentItems: object | undefined
   private _lastFlush: object | undefined
 

--- a/comms/lighthouse/test/configService.spec.ts
+++ b/comms/lighthouse/test/configService.spec.ts
@@ -1,7 +1,7 @@
 import { Config, ConfigService, EnvironmentWrapper, LighthouseConfig } from '../src/configService'
 import { ISimpleStorage } from '../src/simpleStorage'
 
-fdescribe('Config service', () => {
+describe('Config service', () => {
   it('When the config service is built, then environment takes precedence over all', async () => {
     const config = LighthouseConfig.MAX_PEERS_PER_LAYER
 

--- a/comms/lighthouse/test/configService.spec.ts
+++ b/comms/lighthouse/test/configService.spec.ts
@@ -1,0 +1,271 @@
+import { Config, ConfigService, EnvironmentWrapper, LighthouseConfig } from '../src/configService'
+import { ISimpleStorage } from '../src/simpleStorage'
+
+fdescribe('Config service', () => {
+  it('When the config service is built, then environment takes precedence over all', async () => {
+    const config = LighthouseConfig.MAX_PEERS_PER_LAYER
+
+    const service = await buildServiceWith({
+      env: envWrapperWith(config, '5'),
+      storage: storageWith(config, 10),
+      global: globalConfigWith(config, 15)
+    })
+    const value = service.get(config)
+
+    expect(value).toEqual(5)
+  })
+
+  it('When the config service is built, then storage takes precedence over global and defaults', async () => {
+    const config = LighthouseConfig.MAX_PEERS_PER_LAYER
+
+    const service = await buildServiceWith({
+      env: emptyWrapper(),
+      storage: storageWith(config, 10),
+      global: globalConfigWith(config, 15)
+    })
+    const value = service.get(config)
+
+    expect(value).toEqual(10)
+  })
+
+  it('When the config service is built, then global takes precedence over defaults', async () => {
+    const config = LighthouseConfig.MAX_PEERS_PER_LAYER
+
+    const service = await buildServiceWith({
+      env: emptyWrapper(),
+      storage: emptyStorage(),
+      global: globalConfigWith(config, 15)
+    })
+    const value = service.get(config)
+
+    expect(value).toEqual(15)
+  })
+
+  it('When the config service is built and no values were set, then defaults are used', async () => {
+    const config = LighthouseConfig.MAX_PEERS_PER_LAYER
+
+    const service = await buildServiceWith({
+      env: emptyWrapper(),
+      storage: emptyStorage(),
+      global: emptyGlobalConfig()
+    })
+    const value = service.get(config)
+
+    expect(value).toEqual(config.defaultValue)
+  })
+
+  it('When global config is updated, then config service reports it correctly', async () => {
+    const config = LighthouseConfig.MAX_PEERS_PER_LAYER
+    const globalConfig = globalConfigWith(config, 20)
+
+    const service = await buildServiceWith({
+      env: emptyWrapper(),
+      storage: emptyStorage(),
+      global: globalConfig
+    })
+
+    // Update global config
+    globalConfig.setConfig(config, 30)
+    await service.updateConfig()
+    const value = service.get(config)
+
+    expect(value).toEqual(30)
+  })
+
+  it('When storage config is updated, then config service reports it correctly', async () => {
+    const config = LighthouseConfig.MAX_PEERS_PER_LAYER
+    const storageConfig = storageWith(config, 20)
+
+    const service = await buildServiceWith({
+      env: emptyWrapper(),
+      storage: storageConfig,
+      global: emptyGlobalConfig()
+    })
+
+    // Update storage config
+    storageConfig.setConfig(config, 30)
+    await service.updateConfig()
+    const value = service.get(config)
+
+    expect(value).toEqual(30)
+  })
+
+  it('When a change happens in global config, then the appropriate listener is called correctly', async () => {
+    const config = LighthouseConfig.MAX_PEERS_PER_LAYER
+    const globalConfig = globalConfigWith(config, 20)
+    let listenedMaxPeers: number | undefined = undefined
+    let listenedJoinDistance: number | undefined = undefined
+
+    const service = await buildServiceWith({
+      env: emptyWrapper(),
+      storage: emptyStorage(),
+      global: globalConfig
+    })
+
+    // Add listeners
+    service.listenTo(config, (newValue) => (listenedMaxPeers = newValue))
+    service.listenTo(LighthouseConfig.ARCHIPELAGO_JOIN_DISTANCE, (newValue) => (listenedJoinDistance = newValue))
+
+    // Update global config
+    globalConfig.setConfig(config, 30)
+    await service.updateConfig()
+
+    expect(listenedMaxPeers!).toEqual(30)
+    expect(listenedJoinDistance).toBeUndefined()
+  })
+
+  it('When a change happens in storage config, then the appropriate listener is called correctly', async () => {
+    const config = LighthouseConfig.MAX_PEERS_PER_LAYER
+    const storageConfig = storageWith(config, 20)
+    let listenedMaxPeers: number | undefined = undefined
+    let listenedJoinDistance: number | undefined = undefined
+
+    const service = await buildServiceWith({
+      env: emptyWrapper(),
+      storage: storageConfig,
+      global: emptyGlobalConfig()
+    })
+
+    // Add listeners
+    service.listenTo(config, (newValue) => (listenedMaxPeers = newValue))
+    service.listenTo(LighthouseConfig.ARCHIPELAGO_JOIN_DISTANCE, (newValue) => (listenedJoinDistance = newValue))
+
+    // Update storage config
+    storageConfig.setConfig(config, 30)
+    await service.updateConfig()
+
+    expect(listenedMaxPeers!).toEqual(30)
+    expect(listenedJoinDistance).toBeUndefined()
+  })
+
+  it('When storage config is deleted, then config service reports it correctly', async () => {
+    const config = LighthouseConfig.MAX_PEERS_PER_LAYER
+    const storageConfig = storageWith(config, 20)
+
+    const service = await buildServiceWith({
+      env: emptyWrapper(),
+      storage: storageConfig,
+      global: emptyGlobalConfig()
+    })
+
+    // Delete storage config
+    await service.updateStorageConfigs([{ key: config.name }])
+    const value = service.get(config)
+
+    expect(value).toEqual(config.defaultValue)
+  })
+
+  it('When global config is deleted, then config service reports it correctly', async () => {
+    const config = LighthouseConfig.MAX_PEERS_PER_LAYER
+    const globalConfig = globalConfigWith(config, 20)
+
+    const service = await buildServiceWith({
+      env: emptyWrapper(),
+      storage: emptyStorage(),
+      global: globalConfig
+    })
+
+    // Delete global config
+    globalConfig.deleteConfig(config)
+    await service.updateConfig()
+    const value = service.get(config)
+
+    expect(value).toEqual(config.defaultValue)
+  })
+})
+
+function buildServiceWith({
+  env,
+  global,
+  storage
+}: {
+  env: EnvironmentWrapper
+  global: CustomGlobalConfig
+  storage: CustomStorage
+}): Promise<ConfigService> {
+  return ConfigService.build({
+    storage,
+    globalConfig: { fetch: () => global.getAllConfig() },
+    envWrapper: env
+  })
+}
+
+function globalConfigWith<T>(config: LighthouseConfig<T>, value: T): CustomGlobalConfig {
+  const globalConfig = emptyGlobalConfig()
+  globalConfig.setConfig(config, value)
+  return globalConfig
+}
+
+function emptyGlobalConfig(): CustomGlobalConfig {
+  return new CustomGlobalConfig()
+}
+
+function emptyWrapper(): EnvironmentWrapper {
+  return {
+    isInEnv: (_) => false,
+    readFromEnv: (_) => {
+      throw new Error('Should never get here')
+    }
+  }
+}
+
+function envWrapperWith<T>(config: LighthouseConfig<T>, value: string): EnvironmentWrapper {
+  return {
+    isInEnv: (key) => key === LighthouseConfig.toEnvironmentName(config.name),
+    readFromEnv: (_) => value
+  }
+}
+
+function emptyStorage(): CustomStorage {
+  return new CustomStorage()
+}
+
+function storageWith<T>(config: LighthouseConfig<T>, value: T): CustomStorage {
+  const storage = emptyStorage()
+  storage.setConfig(config, value)
+  return storage
+}
+
+class CustomStorage implements ISimpleStorage {
+  private readonly values: Config = {}
+  setConfig<T>(config: LighthouseConfig<T>, value: T) {
+    this.values[config.name] = value
+  }
+
+  getAll(): Promise<any> {
+    return Promise.resolve(this.values)
+  }
+  setString(key: string, value: string): Promise<void> {
+    this.values[key] = value
+    return Promise.resolve()
+  }
+  deleteKey(key: string): Promise<void> {
+    delete this.values[key]
+    return Promise.resolve()
+  }
+  getString(key: string): Promise<string | undefined> {
+    throw new Error('Method not implemented.')
+  }
+  getOrSetString(key: string, value: string): Promise<string | undefined> {
+    throw new Error('Method not implemented.')
+  }
+  clear(): Promise<void> {
+    throw new Error('Method not implemented.')
+  }
+}
+
+class CustomGlobalConfig {
+  private readonly values: Config = {}
+
+  setConfig<T>(config: LighthouseConfig<T>, value: T) {
+    this.values[config.name] = value
+  }
+
+  deleteConfig<T>(config: LighthouseConfig<T>) {
+    delete this.values[config.name]
+  }
+
+  getAllConfig(): Promise<Config> {
+    return Promise.resolve(this.values)
+  }
+}


### PR DESCRIPTION
**tl;dr;**
* We are adding a new source of configuration. This new source is an endpoint that is polled every 15 min
* We are adding a new endpoint `/config` to read server's the current configuration
* We are adding listeners to the `configService`, so other services can react to the change in config. By doing this, we are avoiding the need for whole server restarts


### What are we doing here?
We are now giving a lot more love to the `configService`. There will be 4 different sources for configuration, with the following precedence:
```
Environment config >> storage config >> global config >> defaults
```

The main change is that now, there is a global configuration. This configuration can be controlled by the foundation, but it can be easily overridden by catalyst owners. This approach will make it easier to test different configuration 
without having to connect to the server and restart it.

We are also created the concept of `LighthouseConfig`, so we avoid strings that can lead to problems with typos

_Note: this change was tested in .zone, by changing the global config and making sure that the server updates its config correctly._