### PR TITLE
chore: remove entries from failed deployments

### DIFF
--- a/content/src/migrations/Helper.ts
+++ b/content/src/migrations/Helper.ts
@@ -3,5 +3,5 @@ import { MigrationBuilder } from 'node-pg-migrate'
 
 export function deleteFailedDeployments(pgm: MigrationBuilder, ...entityIds: EntityId[]) {
   const inClause = entityIds.map((entityId) => `'${entityId}'`).join(',')
-  pgm.sql(`DELETE FROM deployments WHERE entityId IN (${inClause})`)
+  pgm.sql(`DELETE FROM failed_deployments WHERE entity_id IN (${inClause})`)
 }

--- a/content/src/migrations/Helper.ts
+++ b/content/src/migrations/Helper.ts
@@ -1,0 +1,7 @@
+import { EntityId } from 'dcl-catalyst-commons'
+import { MigrationBuilder } from 'node-pg-migrate'
+
+export function deleteFailedDeployments(pgm: MigrationBuilder, ...entityIds: EntityId[]) {
+  const inClause = entityIds.map((entityId) => `'${entityId}'`).join(',')
+  pgm.sql(`DELETE FROM deployments WHERE entityId IN (${inClause})`)
+}

--- a/content/src/migrations/scripts/1623671909421_delete_failed_deployments.ts
+++ b/content/src/migrations/scripts/1623671909421_delete_failed_deployments.ts
@@ -1,0 +1,21 @@
+import { MigrationBuilder } from 'node-pg-migrate'
+import { deleteFailedDeployments } from '../Helper'
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  deleteFailedDeployments(
+    pgm,
+    'QmTBPcZLFQf1rZpZg2T8nMDwWRoqeftRdvkaexgAECaqHp',
+    'QmXibTSJ6wBpXiG3gc2RND9Z6k75AssvHrwpdCVZNjVGbt',
+    'QmVktBsdgFSQHs68rDJCZrHQgCUFhyJ4QEiGPWivrenpcd',
+    'QmaG2d2bsb4fW8En9ZUVVhjvAghSpPbfD1XSeoHrYPpn3P',
+    'QmeT7cLXPPrNZk6vUis4Zut7ArXJ4rAfCh6LyMb8C4t8gA',
+    'QmTjLddBe7qxyabcxCWNaYKUyro8uh76PCmB6ASKSwGtCA',
+    'QmfEKyT78Pb5rAGaASLPPCyZbUn8rVY4YqKcdtRpYFVzbZ',
+    'QmPiUvhZ6HkDxJLZ65t3wkwrkfEKc2NScPqnSzSZCqSfUC',
+    'Qma7kh4ooweKroG5PEDgrm4dVnKuxPqBexnFkDhDVBzG4P',
+    'QmUKsDTqsVnxxcQT4g5ewGjtFF6Btc7ofbGAbyfcdRkJw4',
+    'QmYzeUZASCJVaD16dZxTr9Kf7oinGtaebqNghEaRouqaNt'
+  )
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {}


### PR DESCRIPTION
All prod catalysts have a subset these same failed deployments. 
```
'QmTBPcZLFQf1rZpZg2T8nMDwWRoqeftRdvkaexgAECaqHp',
'QmXibTSJ6wBpXiG3gc2RND9Z6k75AssvHrwpdCVZNjVGbt',
'QmVktBsdgFSQHs68rDJCZrHQgCUFhyJ4QEiGPWivrenpcd',
'QmaG2d2bsb4fW8En9ZUVVhjvAghSpPbfD1XSeoHrYPpn3P',
'QmeT7cLXPPrNZk6vUis4Zut7ArXJ4rAfCh6LyMb8C4t8gA',
'QmTjLddBe7qxyabcxCWNaYKUyro8uh76PCmB6ASKSwGtCA',
'QmfEKyT78Pb5rAGaASLPPCyZbUn8rVY4YqKcdtRpYFVzbZ',
'QmPiUvhZ6HkDxJLZ65t3wkwrkfEKc2NScPqnSzSZCqSfUC',
'Qma7kh4ooweKroG5PEDgrm4dVnKuxPqBexnFkDhDVBzG4P',
'QmUKsDTqsVnxxcQT4g5ewGjtFF6Btc7ofbGAbyfcdRkJw4',
'QmYzeUZASCJVaD16dZxTr9Kf7oinGtaebqNghEaRouqaNt'
```

The first 9 of these deployments were deployed in `decentraland.org.cn`, back when it was part of the DAO-approved list of catalysts. The problem is that the server didn't work correctly, so these deployments couldn't be synced with other servers.

The last 2 of these deployments where deployed in `peer.decentral.games` just before it was restarted from scratch. So the files were lost.

Since prod catalysts are all in sync, and we can't get those deployment files from anywhere, we will simply remove these entities from the failed list.

_Note: this change has been tested in peer-testing.decentraland.org_ 