### PR TITLE
feat: avoid the need to name the entity file

### DIFF
--- a/content/src/controller/Controller.ts
+++ b/content/src/controller/Controller.ts
@@ -197,14 +197,14 @@ export class Controller {
 
   private async readFiles(files: { [fieldname: string]: Express.Multer.File[] } | Express.Multer.File[]) {
     if (files instanceof Array) {
-      return await Promise.all(files.map((f) => this.readFile(f.fieldname, f.path)))
+      return await Promise.all(files.map((f) => this.readFile(f.path)))
     } else {
       return []
     }
   }
 
-  private async readFile(name: string, path: string): Promise<ContentFile> {
-    return { name, path, content: await fs.promises.readFile(path) }
+  private async readFile(path: string): Promise<ContentFile> {
+    return { path, content: await fs.promises.readFile(path) }
   }
 
   private async deleteUploadedFiles(deployFiles: ContentFile[]): Promise<void> {
@@ -715,7 +715,6 @@ export type ControllerDenylistData = {
 }
 
 export type ContentFile = {
-  name: string
   path?: string
   content: Buffer
 }

--- a/content/src/service/Service.ts
+++ b/content/src/service/Service.ts
@@ -27,20 +27,20 @@ import { FailedDeployment, FailureReason } from './errors/FailedDeploymentsManag
 export interface MetaverseContentService {
   start(): Promise<void>
   deployEntity(
-    files: ContentFile[],
+    files: DeploymentFiles,
     entityId: EntityId,
     auditInfo: LocalDeploymentAuditInfo,
     origin: string,
     task?: Database
   ): Promise<DeploymentResult>
   deployLocalLegacy(
-    files: ContentFile[],
+    files: DeploymentFiles,
     entityId: EntityId,
     auditInfo: LocalDeploymentAuditInfo,
     task?: Database
   ): Promise<DeploymentResult>
   deployToFix(
-    files: ContentFile[],
+    files: DeploymentFiles,
     entityId: EntityId,
     auditInfo: LocalDeploymentAuditInfo,
     origin: string,
@@ -100,6 +100,8 @@ export type DeploymentListener = (deployment: DeploymentEvent) => void | Promise
 export type InvalidResult = { errors: string[] }
 
 export type DeploymentResult = Timestamp | InvalidResult
+
+export type DeploymentFiles = ContentFile[] | Map<ContentFileHash, ContentFile>
 
 export function isSuccessfulDeployment(deploymentResult: DeploymentResult): deploymentResult is Timestamp {
   return typeof deploymentResult === 'number'

--- a/content/src/service/ServiceImpl.ts
+++ b/content/src/service/ServiceImpl.ts
@@ -384,6 +384,11 @@ export class ServiceImpl implements MetaverseContentService, ClusterDeploymentsS
     }
   }
 
+  /**
+   * This function will take some deployment files and hash them. They might come already hashed, and if that is the case we will just return them.
+   * They could come hashed because the denylist decorator might have already hashed them for its own validations. In order to avoid re-hashing
+   * them in the service (because there might be hundreds of files), we will send the hash result.
+   */
   static async hashFiles(files: DeploymentFiles): Promise<Map<ContentFileHash, ContentFile>> {
     if (files instanceof Map) {
       return files

--- a/content/src/service/ServiceImpl.ts
+++ b/content/src/service/ServiceImpl.ts
@@ -115,9 +115,8 @@ export class ServiceImpl implements MetaverseContentService, ClusterDeploymentsS
     // Hash all files, and validate them
     const hashes: Map<ContentFileHash, ContentFile> = await ServiceImpl.hashFiles(files)
 
-    // Find entity file and make sure its hash is the expected
+    // Find entity file
     const entityFile = hashes.get(entityId)
-
     if (!entityFile) {
       return { errors: [`Failed to find the entity file.`] }
     }

--- a/content/src/service/ServiceImpl.ts
+++ b/content/src/service/ServiceImpl.ts
@@ -3,7 +3,6 @@ import {
   ContentFileHash,
   EntityId,
   EntityType,
-  ENTITY_FILE_NAME,
   Hashing,
   PartialDeploymentHistory,
   Pointer,
@@ -33,6 +32,7 @@ import { FailedDeploymentsManager, FailureReason } from './errors/FailedDeployme
 import { PointerManager } from './pointers/PointerManager'
 import {
   ClusterDeploymentsService,
+  DeploymentFiles,
   DeploymentListener,
   DeploymentResult,
   InvalidResult,
@@ -74,7 +74,7 @@ export class ServiceImpl implements MetaverseContentService, ClusterDeploymentsS
   }
 
   deployEntity(
-    files: ContentFile[],
+    files: DeploymentFiles,
     entityId: EntityId,
     auditInfo: LocalDeploymentAuditInfo,
     origin: string,
@@ -84,7 +84,7 @@ export class ServiceImpl implements MetaverseContentService, ClusterDeploymentsS
   }
 
   deployToFix(
-    files: ContentFile[],
+    files: DeploymentFiles,
     entityId: EntityId,
     auditInfo: LocalDeploymentAuditInfo,
     origin: string,
@@ -94,7 +94,7 @@ export class ServiceImpl implements MetaverseContentService, ClusterDeploymentsS
   }
 
   deployLocalLegacy(
-    files: ContentFile[],
+    files: DeploymentFiles,
     entityId: string,
     auditInfo: LocalDeploymentAuditInfo,
     task?: Database
@@ -103,7 +103,7 @@ export class ServiceImpl implements MetaverseContentService, ClusterDeploymentsS
   }
 
   private async deployInternal(
-    files: ContentFile[],
+    files: DeploymentFiles,
     entityId: EntityId,
     auditInfo: AuditInfo | LocalDeploymentAuditInfo,
     validationContext: ValidationContext,
@@ -112,10 +112,15 @@ export class ServiceImpl implements MetaverseContentService, ClusterDeploymentsS
   ): Promise<DeploymentResult> {
     const validation = this.validations.getInstance()
 
+    // Hash all files, and validate them
+    const hashes: Map<ContentFileHash, ContentFile> = await ServiceImpl.hashFiles(files)
+
     // Find entity file and make sure its hash is the expected
-    const entityFile: ContentFile = ServiceImpl.findEntityFile(files)
-    const entityFileHash = await Hashing.calculateHash(entityFile)
-    validation.validateEntityHash(entityId, entityFileHash, validationContext)
+    const entityFile = hashes.get(entityId)
+
+    if (!entityFile) {
+      return { errors: [`Failed to find the entity file.`] }
+    }
 
     // Parse entity file into an Entity
     const entity: Entity = EntityFactory.fromFile(entityFile, entityId)
@@ -136,14 +141,10 @@ export class ServiceImpl implements MetaverseContentService, ClusterDeploymentsS
     validation.validateDecentralandAddress(ownerAddress, validationContext)
 
     // Validate request size
-    validation.validateRequestSize(files, entity.type, entity.pointers, validationContext)
+    validation.validateRequestSize(hashes, entity.type, entity.pointers, validationContext)
 
     // Validate ethAddress access
     await validation.validateAccess(entity.type, entity.pointers, entity.timestamp, ownerAddress, validationContext)
-
-    // Hash all files, and validate them
-    const hashEntries: { hash: ContentFileHash; file: ContentFile }[] = await Hashing.calculateHashes(files)
-    const hashes: Map<ContentFileHash, ContentFile> = new Map(hashEntries.map(({ hash, file }) => [hash, file]))
 
     // Check for if content is already stored
     const alreadyStoredContent: Map<ContentFileHash, boolean> = await this.isContentAvailable(
@@ -384,16 +385,13 @@ export class ServiceImpl implements MetaverseContentService, ClusterDeploymentsS
     }
   }
 
-  static findEntityFile(files: ContentFile[]): ContentFile {
-    const filesWithName = files.filter((file) => file.name === ENTITY_FILE_NAME)
-    if (filesWithName.length === 0) {
-      throw new Error(`Failed to find the entity file. Please make sure that it is named '${ENTITY_FILE_NAME}'.`)
-    } else if (filesWithName.length > 1) {
-      throw new Error(
-        `Found more than one file called '${ENTITY_FILE_NAME}'. Please make sure you upload only one with that name.`
-      )
+  static async hashFiles(files: DeploymentFiles): Promise<Map<ContentFileHash, ContentFile>> {
+    if (files instanceof Map) {
+      return files
+    } else {
+      const hashEntries: { hash: ContentFileHash; file: ContentFile }[] = await Hashing.calculateHashes(files)
+      return new Map(hashEntries.map(({ hash, file }) => [hash, file]))
     }
-    return filesWithName[0]
   }
 
   getContent(fileHash: ContentFileHash): Promise<ContentItem | undefined> {

--- a/content/src/service/ServiceImpl.ts
+++ b/content/src/service/ServiceImpl.ts
@@ -388,7 +388,9 @@ export class ServiceImpl implements MetaverseContentService, ClusterDeploymentsS
     if (files instanceof Map) {
       return files
     } else {
-      const hashEntries: { hash: ContentFileHash; file: ContentFile }[] = await Hashing.calculateHashes(files)
+      const hashEntries: { hash: ContentFileHash; file: ContentFile }[] = await Hashing.calculateHashes(
+        files.map(({ content }) => ({ name: 'empty', content })) // We need to add the name manually until we update the catalyst-commons library
+      )
       return new Map(hashEntries.map(({ hash, file }) => [hash, file]))
     }
   }

--- a/content/src/service/synchronization/EventDeployer.ts
+++ b/content/src/service/synchronization/EventDeployer.ts
@@ -1,4 +1,4 @@
-import { ContentFileHash, DeploymentWithAuditInfo, ENTITY_FILE_NAME } from 'dcl-catalyst-commons'
+import { ContentFileHash, DeploymentWithAuditInfo } from 'dcl-catalyst-commons'
 import log4js from 'log4js'
 import { Readable } from 'stream'
 import { ContentFile } from '../../controller/Controller'
@@ -117,17 +117,11 @@ export class EventDeployer {
     return files
   }
 
-  private async getEntityFile(
+  private getEntityFile(
     deployment: DeploymentWithAuditInfo,
     source?: ContentServerClient
   ): Promise<ContentFile | undefined> {
-    const file: ContentFile | undefined = await this.getFileOrUndefined(deployment.entityId, source)
-
-    // If we could download the entity file, rename it
-    if (file) {
-      file.name = ENTITY_FILE_NAME
-    }
-    return file
+    return this.getFileOrUndefined(deployment.entityId, source)
   }
 
   /**

--- a/content/src/service/synchronization/clients/ContentServerClient.ts
+++ b/content/src/service/synchronization/clients/ContentServerClient.ts
@@ -79,7 +79,7 @@ export class ContentServerClient {
 
   async getContentFile(fileHash: ContentFileHash): Promise<ContentFile> {
     const content = await this.client.downloadContent(fileHash, { attempts: 3, waitTime: '0.5s' })
-    return { name: fileHash, content }
+    return { content }
   }
 
   getAddress(): ServerAddress {

--- a/content/src/service/validations/Validations.ts
+++ b/content/src/service/validations/Validations.ts
@@ -94,14 +94,6 @@ export class ValidatorInstance {
     }
   }
 
-  validateEntityHash(entityId: EntityId, entityFileHash: ContentFileHash, validationContext: ValidationContext) {
-    if (validationContext.shouldValidate(Validation.ENTITY_HASH)) {
-      if (entityId !== entityFileHash) {
-        this.errors.push("Entity file's hash didn't match the signed entity id.")
-      }
-    }
-  }
-
   /** Validate that the signature belongs to the Ethereum address */
   async validateSignature(
     entityId: EntityId,
@@ -124,7 +116,7 @@ export class ValidatorInstance {
 
   /** Validate that the full request size is within limits */
   validateRequestSize(
-    files: ContentFile[],
+    files: Map<ContentFileHash, ContentFile>,
     entityType: EntityType,
     pointers: Pointer[],
     validationContext: ValidationContext

--- a/content/src/service/validations/Validations.ts
+++ b/content/src/service/validations/Validations.ts
@@ -254,6 +254,8 @@ export class ValidatorInstance {
     if (validationContext.shouldValidate(Validation.CONTENT)) {
       if (entity.content) {
         const entityHashes: string[] = Array.from(entity.content?.values() ?? [])
+        console.log(entityHashes)
+        console.log(Array.from(hashes.keys()))
 
         // Validate that all hashes in entity were uploaded, or were already stored on the service
         entityHashes
@@ -266,7 +268,7 @@ export class ValidatorInstance {
 
         // Validate that all hashes that belong to uploaded files are actually reported on the entity
         Array.from(hashes.keys())
-          .filter((hash) => !entityHashes.includes(hash) || hash !== entity.id)
+          .filter((hash) => !entityHashes.includes(hash) && hash !== entity.id)
           .forEach((unreferencedHash) =>
             this.errors.push(`This hash was uploaded but is not referenced in the entity: ${unreferencedHash}`)
           )

--- a/content/src/service/validations/Validations.ts
+++ b/content/src/service/validations/Validations.ts
@@ -254,8 +254,6 @@ export class ValidatorInstance {
     if (validationContext.shouldValidate(Validation.CONTENT)) {
       if (entity.content) {
         const entityHashes: string[] = Array.from(entity.content?.values() ?? [])
-        console.log(entityHashes)
-        console.log(Array.from(hashes.keys()))
 
         // Validate that all hashes in entity were uploaded, or were already stored on the service
         entityHashes

--- a/content/src/service/validations/Validations.ts
+++ b/content/src/service/validations/Validations.ts
@@ -4,7 +4,6 @@ import {
   EntityId,
   EntityType,
   EntityVersion,
-  ENTITY_FILE_NAME,
   Pointer,
   Timestamp
 } from 'dcl-catalyst-commons'
@@ -266,10 +265,8 @@ export class ValidatorInstance {
           )
 
         // Validate that all hashes that belong to uploaded files are actually reported on the entity
-        Array.from(hashes.entries())
-          .filter(([, file]) => file.name !== ENTITY_FILE_NAME)
-          .map(([hash]) => hash)
-          .filter((hash) => !entityHashes.includes(hash))
+        Array.from(hashes.keys())
+          .filter((hash) => !entityHashes.includes(hash) || hash !== entity.id)
           .forEach((unreferencedHash) =>
             this.errors.push(`This hash was uploaded but is not referenced in the entity: ${unreferencedHash}`)
           )

--- a/content/test/helpers/service/EntityTestFactory.ts
+++ b/content/test/helpers/service/EntityTestFactory.ts
@@ -24,14 +24,14 @@ export async function buildEntityAndFile(
 }
 
 /** Build a file with the given entity as the content */
-export function entityToFile(entity: Entity, fileName?: string): ContentFile {
+export function entityToFile(entity: Entity): ContentFile {
   const copy: any = Object.assign({}, entity)
   copy.content =
     !copy.content || !(copy.content instanceof Map)
       ? copy.content
       : Array.from(copy.content.entries()).map(([key, value]) => ({ file: key, hash: value }))
   delete copy.id
-  return { name: fileName ?? 'name', content: Buffer.from(JSON.stringify(copy)) }
+  return { content: Buffer.from(JSON.stringify(copy)) }
 }
 
 export function randomEntity(type?: EntityType): Entity {

--- a/content/test/integration/E2ETestUtils.ts
+++ b/content/test/integration/E2ETestUtils.ts
@@ -1,4 +1,3 @@
-import { ContentFile } from '@katalyst/content/controller/Controller'
 import { ControllerEntityFactory } from '@katalyst/content/controller/ControllerEntityFactory'
 import { retry } from '@katalyst/content/helpers/RetryHelper'
 import { Entity } from '@katalyst/content/service/Entity'
@@ -6,6 +5,7 @@ import { EntityFactory } from '@katalyst/content/service/EntityFactory'
 import { DeploymentResult, MetaverseContentService } from '@katalyst/content/service/Service'
 import { DeploymentBuilder } from 'dcl-catalyst-client'
 import {
+  ContentFile,
   ContentFileHash,
   Entity as ControllerEntity,
   EntityId,

--- a/content/test/integration/legacy-entities.spec.ts
+++ b/content/test/integration/legacy-entities.spec.ts
@@ -2,6 +2,7 @@ import { ContentFile } from '@katalyst/content/controller/Controller'
 import { Bean, EnvironmentConfig } from '@katalyst/content/Environment'
 import { assertPromiseRejectionIs } from '@katalyst/test-helpers/PromiseAssertions'
 import { addModelToFormData } from 'dcl-catalyst-client'
+import { ContentFileHash } from 'dcl-catalyst-commons'
 import { Authenticator } from 'dcl-crypto'
 import FormData from 'form-data'
 import fetch from 'node-fetch'
@@ -72,7 +73,7 @@ async function deployLegacy(server: TestServer, deployData: DeployData) {
   form.append('version', 'v2')
   form.append('migration_data', JSON.stringify({ data: 'data' }))
 
-  deployData.files.forEach((f: ContentFile) => form.append(f.name, f.content, { filename: f.name }))
+  deployData.files.forEach((f: ContentFile, hash: ContentFileHash) => form.append(hash, f.content, { filename: hash }))
 
   const deployResponse = await fetch(`${server.getAddress()}/legacy-entities`, { method: 'POST', body: form })
   await assertResponseIsOkOrThrow(deployResponse)

--- a/content/test/integration/upload-and-download.spec.ts
+++ b/content/test/integration/upload-and-download.spec.ts
@@ -1,4 +1,3 @@
-import { ContentFile } from '@katalyst/content/controller/Controller'
 import { Bean } from '@katalyst/content/Environment'
 import { MockedSynchronizationManager } from '@katalyst/test-helpers/service/synchronization/MockedSynchronizationManager'
 import { Entity as ControllerEntity, EntityType } from 'dcl-catalyst-commons'
@@ -80,26 +79,14 @@ describe('End 2 end deploy test', () => {
 
     expect(scene.content).toBeDefined()
     expect(scene.content!.length).toBe(2)
-    expect(findInArray(scene.content, Array.from(deployData.files.values())[0].name)).toBeDefined()
-    expect(findInArray(scene.content, Array.from(deployData.files.values())[1].name)).toBeDefined()
 
     for (const contentElement of scene.content!) {
       const downloadedContent = await server.downloadContent(contentElement.hash)
-      expect(downloadedContent).toEqual(
-        findInFileArray(Array.from(deployData.files.values()), contentElement.file)?.content ?? Buffer.from([])
-      )
+      expect(downloadedContent).toEqual(deployData.files.get(contentElement.hash)!.content)
     }
   }
 })
 
 function equalsCaseInsensitive(text1: string, text2: string): boolean {
   return text1.toLowerCase() === text2.toLowerCase()
-}
-
-function findInArray<T extends { file: string }>(elements: T[] | undefined, key: string): T | undefined {
-  return elements?.find((e) => e.file === key)
-}
-
-function findInFileArray(elements: ContentFile[] | undefined, key: string): ContentFile | undefined {
-  return elements?.find((e) => e.name === key)
 }

--- a/content/test/unit/denylist/DenylistServiceDecorator.spec.ts
+++ b/content/test/unit/denylist/DenylistServiceDecorator.spec.ts
@@ -316,6 +316,16 @@ describe('DenylistServiceDecorator', () => {
     )
   })
 
+  it(`When there is no file matching the entity id, then the deployment fails`, async () => {
+    const denylist = denylistWith()
+    const decorator = getDecorator(denylist)
+
+    await assertPromiseRejectionIs(
+      () => decorator.deployEntity([entityFile1], 'some-random-id', auditInfo, ''),
+      `Failed to find the entity file.`
+    )
+  })
+
   function deploymentEqualsNonSanitizableProperties(entity: Entity, deployment: Deployment) {
     expect(entity.id).toEqual(deployment.entityId)
     expect(entity.type).toEqual(deployment.entityType)

--- a/content/test/unit/service/EntityFactory.spec.ts
+++ b/content/test/unit/service/EntityFactory.spec.ts
@@ -23,7 +23,7 @@ describe('Service', () => {
   })
 
   it(`When the entity file can't be parsed into an entity, then an exception is thrown`, () => {
-    const invalidFile: ContentFile = { name: `invalid-file`, content: Buffer.from('Hello') }
+    const invalidFile: ContentFile = { content: Buffer.from('Hello') }
 
     assertInvalidFile(invalidFile, `id`, `Failed to parse the entity file. Please make sure that it is a valid json.`)
   })

--- a/content/test/unit/service/validations/Validations.spec.ts
+++ b/content/test/unit/service/validations/Validations.spec.ts
@@ -456,7 +456,7 @@ describe('Validations', function () {
   it(`when an entity is too big per pointer, then it fails`, async () => {
     const validation = getValidatorWithMockedAccess({ maxSizePerPointer: { type: EntityType.SCENE, size: 2 } })
 
-    validation.validateRequestSize([getFileWithSize(3)], EntityType.SCENE, ['pointer1'], ValidationContext.ALL)
+    validation.validateRequestSize(getFileWithSize(3), EntityType.SCENE, ['pointer1'], ValidationContext.ALL)
 
     expect(validation.getErrors().length).toBe(1)
     expect(validation.getErrors()[0]).toMatch('The deployment is too big. The maximum allowed size per pointer is *')
@@ -466,7 +466,7 @@ describe('Validations', function () {
     const validation = getValidatorWithMockedAccess({ maxSizePerPointer: { type: EntityType.SCENE, size: 2 } })
 
     validation.validateRequestSize(
-      [getFileWithSize(3)],
+      getFileWithSize(3),
       EntityType.SCENE,
       ['pointer1', 'pointer2'],
       ValidationContext.ALL
@@ -506,7 +506,7 @@ function getValidatorWithRealAccess() {
 }
 
 function getFileWithSize(sizeInMB: number) {
-  return { name: '', content: Buffer.alloc(sizeInMB * 1024 * 1024) }
+  return new Map([['someHash', { name: '', content: Buffer.alloc(sizeInMB * 1024 * 1024) }]])
 }
 
 function getValidatorWithMockedAccess(options?: { maxSizePerPointer: { type: EntityType; size: number } }) {


### PR DESCRIPTION
Before this change, the entity file had to be named `entity.json`. We required this naming so that we could find it easily. The thing is, that we were already hashing the files, so we could just find it by its hash. 

By doing this change, we can now forget about names when deploying and just send the files without any other considerations.