### PR TITLE
fix: fail with high offsets

### DIFF
--- a/content/src/controller/Controller.ts
+++ b/content/src/controller/Controller.ts
@@ -327,7 +327,7 @@ export class Controller {
     if (offset && offset > 5000) {
       res
         .status(400)
-        .send({ error: `Offset can't be higher than 5000. Please use the 'lastId' property for pagination.` })
+        .send({ error: `Offset can't be higher than 5000. Please use the 'next' property for pagination.` })
       return
     }
 
@@ -429,7 +429,7 @@ export class Controller {
     if (offset && offset > 5000) {
       res
         .status(400)
-        .send({ error: `Offset can't be higher than 5000. Please use the 'lastId' property for pagination.` })
+        .send({ error: `Offset can't be higher than 5000. Please use the 'next' property for pagination.` })
       return
     }
 

--- a/content/src/controller/Controller.ts
+++ b/content/src/controller/Controller.ts
@@ -324,6 +324,13 @@ export class Controller {
       return
     }
 
+    if (offset && offset > 5000) {
+      res
+        .status(400)
+        .send({ error: `Offset can't be higher than 5000. Please use the 'lastId' property for pagination.` })
+      return
+    }
+
     // TODO: remove this when to/from localTimestamp parameter is deprecated to use to/from
     const fromFilter = from ?? fromLocalTimestamp
     const toFilter = to ?? toLocalTimestamp
@@ -416,6 +423,13 @@ export class Controller {
     // Validate type is valid
     if (entityTypes && entityTypes.some((type) => !type)) {
       res.status(400).send({ error: `Found an unrecognized entity type` })
+      return
+    }
+
+    if (offset && offset > 5000) {
+      res
+        .status(400)
+        .send({ error: `Offset can't be higher than 5000. Please use the 'lastId' property for pagination.` })
       return
     }
 

--- a/content/src/service/synchronization/clients/ContentServerClient.ts
+++ b/content/src/service/synchronization/clients/ContentServerClient.ts
@@ -37,6 +37,7 @@ export class ContentServerClient {
     const stream = this.client.streamAllDeployments(
       {
         filters: { from: this.lastLocalDeploymentTimestamp + 1 },
+        fields: DeploymentFields.AUDIT_INFO,
         errorListener: (errorMessage) => {
           error = true
           ContentServerClient.LOGGER.error(

--- a/content/src/service/synchronization/clients/ContentServerClient.ts
+++ b/content/src/service/synchronization/clients/ContentServerClient.ts
@@ -37,7 +37,6 @@ export class ContentServerClient {
     const stream = this.client.streamAllDeployments(
       {
         filters: { from: this.lastLocalDeploymentTimestamp + 1 },
-        fields: DeploymentFields.AUDIT_INFO,
         errorListener: (errorMessage) => {
           error = true
           ContentServerClient.LOGGER.error(

--- a/content/test/integration/Server.spec.ts
+++ b/content/test/integration/Server.spec.ts
@@ -124,4 +124,20 @@ describe('Integration - Server', function () {
     expect(change.before).toBe(undefined)
     expect(change.after).toBe(entity1.id)
   })
+
+  it(`PointerChanges with offset too high`, async () => {
+    const response = await fetch(`${address}/pointerChanges?offset=5001`)
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({
+      error: `Offset can't be higher than 5000. Please use the 'next' property for pagination.`
+    })
+  })
+
+  it(`Deployments with offset too high`, async () => {
+    const response = await fetch(`${address}/deployments?offset=5001`)
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({
+      error: `Offset can't be higher than 5000. Please use the 'next' property for pagination.`
+    })
+  })
 })


### PR DESCRIPTION
We are now setting a limit for high offsets. The `lastId` property can be used if necessary