### PR TITLE
fix: add fields to next link

### DIFF
--- a/commons/servers/QueryParameters.ts
+++ b/commons/servers/QueryParameters.ts
@@ -12,10 +12,11 @@ function convertFiltersToQueryParams(filters?: Record<string, any>): Map<string,
   const entries = Object.entries(filters)
     .filter(([_, value]) => !!value)
     .map<[string, string[]]>(([name, value]) => {
-      const newName = name.endsWith('s') ? name.slice(0, -1) : name
+      let newName = name
       let newValues: string[]
       // Force coercion of number, boolean, or string into string
       if (Array.isArray(value)) {
+        newName = name.endsWith('s') ? name.slice(0, -1) : newName
         newValues = [...value].filter(isValidQueryParamValue).map((_) => `${_}`)
       } else if (isValidQueryParamValue(value)) {
         newValues = [`${value}`]

--- a/content/src/controller/Controller.ts
+++ b/content/src/controller/Controller.ts
@@ -280,6 +280,7 @@ export class Controller {
     }
 
     const { deployments } = await this.service.getDeployments({
+      fields: [DeploymentField.AUDIT_INFO],
       filters: { entityIds: [entityId], entityTypes: [type] }
     })
 
@@ -308,7 +309,7 @@ export class Controller {
     const entityTypes: (EntityType | undefined)[] | undefined = stringEntityTypes
       ? stringEntityTypes.map((type) => this.parseEntityType(type))
       : undefined
-    //deprecated
+    // deprecated
     const fromLocalTimestamp: Timestamp | undefined = this.asInt(req.query.fromLocalTimestamp)
     // deprecated
     const toLocalTimestamp: Timestamp | undefined = this.asInt(req.query.toLocalTimestamp)
@@ -434,7 +435,7 @@ export class Controller {
     }
 
     // Validate fields are correct or empty
-    let enumFields: DeploymentField[] = [...DEFAULT_FIELDS_ON_DEPLOYMENTS]
+    let enumFields: DeploymentField[] = DEFAULT_FIELDS_ON_DEPLOYMENTS
     if (fields && fields.trim().length > 0) {
       const acceptedValues = Object.values(DeploymentField).map((e) => e.toString())
       enumFields = fields
@@ -487,6 +488,7 @@ export class Controller {
     }
 
     const deploymentOptions = {
+      fields: enumFields,
       filters: requestFilters,
       sortBy: sortBy,
       offset: offset,
@@ -525,8 +527,12 @@ export class Controller {
         nextFilters.to = lastDeployment.entityTimestamp
       }
     }
+
+    const fields = !options.fields || options.fields === DEFAULT_FIELDS_ON_DEPLOYMENTS ? '' : options.fields.join(',')
+
     const nextQueryParams = toQueryParams({
       ...nextFilters,
+      fields,
       sortingField: field,
       sortingOrder: order,
       lastId: lastDeployment.entityId,

--- a/content/src/service/deployments/DeploymentManager.ts
+++ b/content/src/service/deployments/DeploymentManager.ts
@@ -1,3 +1,4 @@
+import { DeploymentField } from '@katalyst/content/controller/Controller'
 import { ContentFilesRepository } from '@katalyst/content/repository/extensions/ContentFilesRepository'
 import { DeploymentPointerChangesRepository } from '@katalyst/content/repository/extensions/DeploymentPointerChangesRepository'
 import { DeploymentId, DeploymentsRepository } from '@katalyst/content/repository/extensions/DeploymentsRepository'
@@ -209,6 +210,7 @@ export type PartialDeploymentPointerChanges = {
 }
 
 export type DeploymentOptions = {
+  fields?: DeploymentField[]
   filters?: DeploymentFilters
   sortBy?: DeploymentSorting
   offset?: number


### PR DESCRIPTION
We realized that the the `next` field in the `/deployments` endpoint did not include the query param `fields`, even when it was included in the original request. We are now fixing that