### PR TITLE
fix: ask last update to correct cache

### DIFF
--- a/lambdas/src/apis/explore/controllers/explore.ts
+++ b/lambdas/src/apis/explore/controllers/explore.ts
@@ -56,9 +56,9 @@ export async function realmsStatus(daoCache: DAOCache, req: Request, res: Respon
   }
 
   const realmsStatusData = await realmsStatusCache.get()
-  const hotScenesLastUpdate = hotSceneCache.lastUpdate()
+  const realmStatusLastUpdate = realmsStatusCache.lastUpdate()
 
-  res.setHeader('Last-Modified', hotScenesLastUpdate.toUTCString())
+  res.setHeader('Last-Modified', realmStatusLastUpdate.toUTCString())
   res.status(200).send(realmsStatusData)
 }
 


### PR DESCRIPTION
We were asking the wrong cache for the last update timestamp, and it could happen that the other cache wasn't initialized, leading to an error