### PR TITLE
fix: make endpoint casing consistent

### DIFF
--- a/content/src/Server.ts
+++ b/content/src/Server.ts
@@ -79,9 +79,11 @@ export class Server {
     this.registerRoute('/denylist/:type/:id', controller, controller.addToDenylist, HttpMethod.PUT)
     this.registerRoute('/denylist/:type/:id', controller, controller.removeFromDenylist, HttpMethod.DELETE)
     this.registerRoute('/denylist/:type/:id', controller, controller.isTargetDenylisted, HttpMethod.HEAD)
-    this.registerRoute('/failedDeployments', controller, controller.getFailedDeployments)
+    this.registerRoute('/failedDeployments', controller, controller.getFailedDeployments) // TODO: Deprecate
+    this.registerRoute('/failed-deployments', controller, controller.getFailedDeployments)
     this.registerRoute('/challenge', controller, controller.getChallenge)
-    this.registerRoute('/pointerChanges', controller, controller.getPointerChanges)
+    this.registerRoute('/pointerChanges', controller, controller.getPointerChanges) // TODO: Deprecate
+    this.registerRoute('/pointer-changes', controller, controller.getPointerChanges)
     this.registerRoute('/snapshot/:type', controller, controller.getSnapshot)
 
     if (env.getConfig(EnvironmentConfig.ALLOW_LEGACY_ENTITIES)) {

--- a/content/src/controller/Controller.ts
+++ b/content/src/controller/Controller.ts
@@ -687,7 +687,7 @@ export class Controller {
 
   async getFailedDeployments(req: express.Request, res: express.Response) {
     // Method: GET
-    // Path: /failedDeployments
+    // Path: /failed-deployments
 
     const failedDeployments = await this.service.getAllFailedDeployments()
     res.send(failedDeployments)

--- a/content/src/controller/Controller.ts
+++ b/content/src/controller/Controller.ts
@@ -303,7 +303,7 @@ export class Controller {
 
   async getPointerChanges(req: express.Request, res: express.Response) {
     // Method: GET
-    // Path: /pointerChanges
+    // Path: /pointer-changes
     // Query String: ?from={timestamp}&to={timestamp}&offset={number}&limit={number}&entityType={entityType}
     const stringEntityTypes = this.asArray<string>(req.query.entityType)
     const entityTypes: (EntityType | undefined)[] | undefined = stringEntityTypes

--- a/content/test/integration/Server.spec.ts
+++ b/content/test/integration/Server.spec.ts
@@ -109,7 +109,7 @@ describe('Integration - Server', function () {
   })
 
   it(`PointerChanges`, async () => {
-    const response = await fetch(`${address}/pointerChanges?entityType=${entity1.type}`)
+    const response = await fetch(`${address}/pointer-changes?entityType=${entity1.type}`)
     expect(response.ok).toBe(true)
     const { deltas }: { deltas: ControllerPointerChanges[] } = await response.json()
     expect(deltas.length).toBe(1)
@@ -126,7 +126,7 @@ describe('Integration - Server', function () {
   })
 
   it(`PointerChanges with offset too high`, async () => {
-    const response = await fetch(`${address}/pointerChanges?offset=5001`)
+    const response = await fetch(`${address}/pointer-changes?offset=5001`)
     expect(response.status).toBe(400)
     expect(await response.json()).toEqual({
       error: `Offset can't be higher than 5000. Please use the 'next' property for pagination.`

--- a/content/test/integration/TestServer.ts
+++ b/content/test/integration/TestServer.ts
@@ -68,7 +68,7 @@ export class TestServer extends Server {
   }
 
   getFailedDeployments(): Promise<FailedDeployment[]> {
-    return this.makeRequest(`${this.getAddress()}/failedDeployments`)
+    return this.makeRequest(`${this.getAddress()}/failed-deployments`)
   }
 
   getEntitiesByPointers(type: EntityType, pointers: Pointer[]): Promise<ControllerEntity[]> {

--- a/content/test/integration/controller/deployment-pagination.spec.ts
+++ b/content/test/integration/controller/deployment-pagination.spec.ts
@@ -270,7 +270,7 @@ describe('Integration - Deployment Pagination', () => {
 
     const url =
       server.getAddress() +
-      `/pointerChanges?` +
+      `/pointer-changes?` +
       toQueryParams({ fromLocalTimestamp: E1Timestamp, toLocalTimestamp: E2Timestamp, limit: 1 })
     console.log('URL ', url)
     const pointerChanges = await fetchJson(url)
@@ -314,7 +314,7 @@ describe('Integration - Deployment Pagination', () => {
   }
 
   async function fetchPointerChanges(filters: PointerChangesFilters, limit: number) {
-    const url = server.getAddress() + `/pointerChanges?` + toQueryParams({ ...filters, limit: limit })
+    const url = server.getAddress() + `/pointer-changes?` + toQueryParams({ ...filters, limit: limit })
     const response = await fetchJson(url)
     return response
   }

--- a/content/test/manual/check-failed-deployments.spec.ts
+++ b/content/test/manual/check-failed-deployments.spec.ts
@@ -225,7 +225,7 @@ describe('Failed Deployments validations.', () => {
 })
 
 async function getFailedDeployments(): Promise<FailedDeployment[]> {
-  return fetchArray(`https://peer.decentraland.org/content/failedDeployments`)
+  return fetchArray(`https://peer.decentraland.org/content/failed-deployments`)
 }
 
 function onlyUnique<T>(value: T, index: number, self: T[]): boolean {

--- a/docs/content-server-api/CONTENT_SERVER_API.md
+++ b/docs/content-server-api/CONTENT_SERVER_API.md
@@ -2,23 +2,22 @@
 
 ## Endpoints
 
-* Audit: `GET /audit/:type/:entityId`
-* Challenge: `GET /challenge`
-* Contents per hashId: `GET /contents/:hashId`
-* [Get active entity ids per hashId](contents/hashId/active-entities/get.md) : `GET /contents/:hashId/active-entities`
-* Available Content: `GET /available-content`
-* Denylist: `GET /denylist`
-* Put Denylist: `PUT /denylist/:type/:id`
-* Delete Denylist: `DELETE /denylist/:type/:id`
-* Head Denylist: `HEAD /denylist/:type/:id`
-* [Deployments](deployments/get.md) : `GET /deployments`
-* Post Entities: `POST /entities`
-* Get Entities: `GET /entities/:type`
-* Failed Deployments: `GET /failedDeployments`
-* [History](history/get.md) : `GET /history`
-* [Pointer Changes](pointerChanges/get.md) : `GET /pointerChanges'`
-* Snapshot: `GET /snapshot/:type`
-* Status: `GET /status`
-
+- Audit: `GET /audit/:type/:entityId`
+- Challenge: `GET /challenge`
+- Contents per hashId: `GET /contents/:hashId`
+- [Get active entity ids per hashId](contents/hashId/active-entities/get.md) : `GET /contents/:hashId/active-entities`
+- Available Content: `GET /available-content`
+- Denylist: `GET /denylist`
+- Put Denylist: `PUT /denylist/:type/:id`
+- Delete Denylist: `DELETE /denylist/:type/:id`
+- Head Denylist: `HEAD /denylist/:type/:id`
+- [Deployments](deployments/get.md) : `GET /deployments`
+- Post Entities: `POST /entities`
+- Get Entities: `GET /entities/:type`
+- Failed Deployments: `GET /failedDeployments`
+- [History](history/get.md) : `GET /history`
+- [Pointer Changes](pointer-changes/get.md) : `GET /pointer-changes'`
+- Snapshot: `GET /snapshot/:type`
+- Status: `GET /status`
 
 <!-- Documentation template obtained from https://github.com/jamescooke/restapidocs -->

--- a/docs/content-server-api/CONTENT_SERVER_API.md
+++ b/docs/content-server-api/CONTENT_SERVER_API.md
@@ -14,7 +14,7 @@
 - [Deployments](deployments/get.md) : `GET /deployments`
 - Post Entities: `POST /entities`
 - Get Entities: `GET /entities/:type`
-- Failed Deployments: `GET /failedDeployments`
+- Failed Deployments: `GET /failed-deployments`
 - [History](history/get.md) : `GET /history`
 - [Pointer Changes](pointer-changes/get.md) : `GET /pointer-changes'`
 - Snapshot: `GET /snapshot/:type`

--- a/docs/content-server-api/pointer-changes/get.md
+++ b/docs/content-server-api/pointer-changes/get.md
@@ -2,8 +2,7 @@
 
 List all deployment changes made to pointers.
 
-
-**URL** : `/pointerChanges`
+**URL** : `/pointer-changes`
 
 **Method** : `GET`
 
@@ -13,8 +12,8 @@ List all deployment changes made to pointers.
 
 **Query Parameters** :
 
-
 - from
+
   - Format: int
   - Value: timestamp
   - Example: from=1606829553969
@@ -22,6 +21,7 @@ List all deployment changes made to pointers.
   - Description: Acts as a filter in the collection of deployments, this value is the minimum value of timestamp (of the field indicated by SortingField: localTimestamp is the default) that any deployment in the collection will have.
 
 - to
+
   - Format: int
   - Value: timestamp
   - Example: to=1606829553969
@@ -29,6 +29,7 @@ List all deployment changes made to pointers.
   - Description: Acts as a filter in the collection of deployments, this value is the maximum value of timestamp (of the field indicated by SortingField: localTimestamp is the default) that any deployment in the collection will have.
 
 - lastId
+
   - Format: string
   - Value: EntityId
   - Example: lastId=QmNknKv8MuKbfZ73z4QdUEsNbTd1ZAN1fSuwTFGiNGeCt5
@@ -36,6 +37,7 @@ List all deployment changes made to pointers.
   - Description: It is the last entity id that was visited, so it will be skipped when showing current page.
 
 - limit
+
   - Format: int
   - Value: the limit per page number
   - Example: limit=100
@@ -49,37 +51,30 @@ List all deployment changes made to pointers.
   - Default value: scene, profile & wearable
   - Description: The type of entities that will be shown in the collection, many values can be sent. If any string ends with an ‘s’ or has whitespaces, then it will be correctly parsed. If any of the entity types sent is invalid, then the request will return a 404 status code.
 
-
 ```json
-
 {
-   "deltas":[
-      {
-         "entityType":"wearable",
-         "entityId":"Qme4sizD5eWirC2F5mTagPzYa96h6r12sHMAR9uVznATq5",
-         "localTimestamp":1618412529258,
-         "changes":[
-
-         ]
-      },
-      {
-         "entityType":"wearable",
-         "entityId":"QmQkCHbwGC43KF2VopGGBSBzer2MMDLHti12QVQ8AsDLE7",
-         "localTimestamp":1618412528943,
-         "changes":[
-
-         ]
-      }
-   ],
-   "filters":{
-      "to":1618412528943
-   },
-   "pagination":{
-      "offset":0,
-      "limit":2,
-      "moreData":true,
-      "next":"?to=1618412528943&limit=2&lastId=QmQkCHbwGC43KF2VopGGBSBzer2MMDLHti12QVQ8AsDLE7"
-   }
+  "deltas": [
+    {
+      "entityType": "wearable",
+      "entityId": "Qme4sizD5eWirC2F5mTagPzYa96h6r12sHMAR9uVznATq5",
+      "localTimestamp": 1618412529258,
+      "changes": []
+    },
+    {
+      "entityType": "wearable",
+      "entityId": "QmQkCHbwGC43KF2VopGGBSBzer2MMDLHti12QVQ8AsDLE7",
+      "localTimestamp": 1618412528943,
+      "changes": []
+    }
+  ],
+  "filters": {
+    "to": 1618412528943
+  },
+  "pagination": {
+    "offset": 0,
+    "limit": 2,
+    "moreData": true,
+    "next": "?to=1618412528943&limit=2&lastId=QmQkCHbwGC43KF2VopGGBSBzer2MMDLHti12QVQ8AsDLE7"
+  }
 }
-
 ```


### PR DESCRIPTION
For some reason, `/failedDeployments` and `/pointerChanges` were not consistent in casing with the other endpoints. We are taking a first step towards changing that