### PR TITLE
feat: Prefered island support

### DIFF
--- a/comms/lighthouse/src/peers/archipelagoService.ts
+++ b/comms/lighthouse/src/peers/archipelagoService.ts
@@ -1,5 +1,4 @@
-import { ArchipelagoController, defaultArchipelagoController, Island, IslandUpdates } from '@dcl/archipelago'
-import { Position3D } from 'decentraland-catalyst-utils/Positions'
+import { ArchipelagoController, defaultArchipelagoController, Island, IslandUpdates, PeerPositionChange } from '@dcl/archipelago'
 import { LighthouseConfig } from '../config/configService'
 import { AppServices } from '../types'
 import { PeersService } from './peersService'
@@ -30,10 +29,8 @@ export class ArchipelagoService {
     this.peersServiceGetter = peersService
   }
 
-  updatePeerPosition(peerId: string, position?: Position3D) {
-    if (position) {
-      this.controller.setPeersPositions({ id: peerId, position })
-    }
+  updatePeerPosition(peerId: string, positionUpdate: Omit<PeerPositionChange, 'id'>) {
+    this.controller.setPeersPositions({ id: peerId, ...positionUpdate })
   }
 
   get peersService() {

--- a/comms/lighthouse/src/peers/archipelagoService.ts
+++ b/comms/lighthouse/src/peers/archipelagoService.ts
@@ -1,4 +1,10 @@
-import { ArchipelagoController, defaultArchipelagoController, Island, IslandUpdates, PeerPositionChange } from '@dcl/archipelago'
+import {
+  ArchipelagoController,
+  defaultArchipelagoController,
+  Island,
+  IslandUpdates,
+  PeerPositionChange
+} from '@dcl/archipelago'
 import { LighthouseConfig } from '../config/configService'
 import { AppServices } from '../types'
 import { PeersService } from './peersService'

--- a/comms/lighthouse/src/peers/peerMessagesHandler.ts
+++ b/comms/lighthouse/src/peers/peerMessagesHandler.ts
@@ -22,8 +22,8 @@ export function defaultPeerMessagesHandler({ peersService, archipelagoService }:
     peersService().updatePeerPosition(client.getId(), position)
 
     if (position) {
-      const positionUpdate: { position: Position3D, preferedIslandId?: string } = { position }
-      if ("preferedIslandId" in message.payload) {
+      const positionUpdate: { position: Position3D; preferedIslandId?: string } = { position }
+      if ('preferedIslandId' in message.payload) {
         positionUpdate.preferedIslandId = message.payload.preferedIslandId
       }
 

--- a/comms/lighthouse/src/peers/peerMessagesHandler.ts
+++ b/comms/lighthouse/src/peers/peerMessagesHandler.ts
@@ -1,3 +1,4 @@
+import { Position3D } from 'decentraland-catalyst-utils/Positions'
 import { IClient } from '../peerjs-server/models/client'
 import { AppServices } from '../types'
 import { HeartbeatMessage, PeerIncomingMessage, PeerIncomingMessageType } from './protocol/messageTypes'
@@ -19,6 +20,14 @@ export function defaultPeerMessagesHandler({ peersService, archipelagoService }:
     peersService().updateTopology(client.getId(), connectedPeerIds)
     peersService().updatePeerParcel(client.getId(), parcel)
     peersService().updatePeerPosition(client.getId(), position)
-    archipelagoService().updatePeerPosition(client.getId(), position)
+
+    if (position) {
+      const positionUpdate: { position: Position3D, preferedIslandId?: string } = { position }
+      if ("preferedIslandId" in message.payload) {
+        positionUpdate.preferedIslandId = message.payload.preferedIslandId
+      }
+
+      archipelagoService().updatePeerPosition(client.getId(), positionUpdate)
+    }
   }
 }

--- a/comms/lighthouse/src/peers/protocol/messageTypes.ts
+++ b/comms/lighthouse/src/peers/protocol/messageTypes.ts
@@ -52,6 +52,7 @@ export type HeartbeatMessage = {
     connectedPeerIds: string[]
     parcel?: [number, number]
     position?: Position3D
+    preferedIslandId?: string
   }
 }
 

--- a/comms/lighthouse/test/archipelagoService.spec.ts
+++ b/comms/lighthouse/test/archipelagoService.spec.ts
@@ -44,7 +44,7 @@ describe('Archipelago service', () => {
 
   function setPeersPositions(service: ArchipelagoService, ...positions: [string, number, number, number][]) {
     for (const [id, ...pos] of positions) {
-      service.updatePeerPosition(id, pos)
+      service.updatePeerPosition(id, { position: pos })
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -93,8 +93,8 @@
     "migrate": "node-pg-migrate -m content/src/migrations/scripts -j ts"
   },
   "dependencies": {
-    "@dcl/archipelago": "^1.0.0-20210609183931.commit-668cf2c",
-    "@dcl/catalyst-peer": "^1.0.0-20210706172727.commit-a9877de",
+    "@dcl/archipelago": "^1.0.0-20210713173135.commit-dbc0d1c",
+    "@dcl/catalyst-peer": "^1.0.0-20210713201511.commit-523f1ac",
     "@dcl/schemas": "^1.0.0",
     "@dcl/urn-resolver": "1.1.1",
     "@types/destroy": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -916,21 +916,21 @@
     source-map-support "0.5.9"
     tsutils "2.27.2"
 
-"@dcl/archipelago@^1.0.0-20210609183931.commit-668cf2c":
-  version "1.0.0-20210609183931.commit-668cf2c"
-  resolved "https://registry.yarnpkg.com/@dcl/archipelago/-/archipelago-1.0.0-20210609183931.commit-668cf2c.tgz#284a48291052a1cef2dcdcfe2399770f65848f8b"
-  integrity sha512-9cB7NsAN8FY9Gu/Qi9bScdt4TXEFUvVFcJKY1wUPqEjvpfntDlHnzVtytJCugOGiOhBWHUkGmgkjrHZuJf2rZg==
+"@dcl/archipelago@^1.0.0-20210713173135.commit-dbc0d1c":
+  version "1.0.0-20210713173135.commit-dbc0d1c"
+  resolved "https://registry.yarnpkg.com/@dcl/archipelago/-/archipelago-1.0.0-20210713173135.commit-dbc0d1c.tgz#e808cbb1266a1da547f48d7b4d95deb875508c42"
+  integrity sha512-apvpzOy5VVGMW1dlgd9oNwLbaUbjoJDfNQV+qeeLuC02F0ZFJDv3WyPzF61O4SjJfTKOQSMaBOGGNJKTyed+SQ==
   dependencies:
     uuid "^8.3.2"
 
-"@dcl/catalyst-peer@^1.0.0-20210706172727.commit-a9877de":
-  version "1.0.0-20210706172727.commit-a9877de"
-  resolved "https://registry.yarnpkg.com/@dcl/catalyst-peer/-/catalyst-peer-1.0.0-20210706172727.commit-a9877de.tgz#6b0e5d0196261dbd109bd12082a003e8bba167d9"
-  integrity sha512-QYZuhJRrCz1HUsUe2EBn6qxAiN/hmXeMeo6O3dTS+XXdvMOzhMXANvA6L2lhn8FLkhSTfxxlK1SPY/tzNC9m6Q==
+"@dcl/catalyst-peer@^1.0.0-20210713201511.commit-523f1ac":
+  version "1.0.0-experimental.0"
+  resolved "https://registry.yarnpkg.com/@dcl/catalyst-peer/-/catalyst-peer-1.0.0-experimental.0.tgz#3bfd00c8153b20fd5b11006506e18b9dbdbbbab1"
+  integrity sha512-T0mubiHQXDkr5fqRQpYYrnsYACsHZV2y84YiSFY17ISm92cpSXucjmAsVOBoTZtFQgBCJRqBItaOnkM7E2KgTw==
   dependencies:
-    eventemitter3 "^4.0.7"
+    eventemitter3 "^4.0.0"
     fp-future "^1.0.1"
-    protobufjs "^6.11.2"
+    protobufjs "^6.8.8"
     simple-peer "^9.11.0"
 
 "@dcl/schemas@^0.2.0":
@@ -1496,11 +1496,6 @@
   version "13.13.41"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.41.tgz#045a4981318d31a581650ce70f340a32c3461198"
   integrity sha512-qLT9IvHiXJfdrje9VmsLzun7cQ65obsBTmtU3EOnCSLFOoSHx1hpiRHoBnpdbyFqnzqdUUIv81JcEJQCB8un9g==
-
-"@types/node@>=13.7.0":
-  version "16.0.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.0.0.tgz#067a6c49dc7a5c2412a505628e26902ae967bf6f"
-  integrity sha512-TmCW5HoZ2o2/z2EYi109jLqIaPIi9y/lc2LmDCWzuCi35bcaQ+OtUh6nwBiFK7SOu25FAU5+YKdqFZUwtqGSdg==
 
 "@types/node@^10.1.0", "@types/node@^10.12.18", "@types/node@^10.3.2":
   version "10.17.13"
@@ -4099,7 +4094,7 @@ eventemitter3@3.1.2:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.2.tgz#2d3d48f9c346698fce83a85d7d664e98535df6e7"
   integrity sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==
 
-eventemitter3@^4.0.0, eventemitter3@^4.0.4, eventemitter3@^4.0.7:
+eventemitter3@^4.0.0, eventemitter3@^4.0.4:
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
@@ -6980,25 +6975,6 @@ protobufjs@^6.10.2, protobufjs@^6.8.8:
     "@protobufjs/utf8" "^1.1.0"
     "@types/long" "^4.0.1"
     "@types/node" "^13.7.0"
-    long "^4.0.0"
-
-protobufjs@^6.11.2:
-  version "6.11.2"
-  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.11.2.tgz#de39fabd4ed32beaa08e9bb1e30d08544c1edf8b"
-  integrity sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==
-  dependencies:
-    "@protobufjs/aspromise" "^1.1.2"
-    "@protobufjs/base64" "^1.1.2"
-    "@protobufjs/codegen" "^2.0.4"
-    "@protobufjs/eventemitter" "^1.1.0"
-    "@protobufjs/fetch" "^1.1.0"
-    "@protobufjs/float" "^1.0.2"
-    "@protobufjs/inquire" "^1.1.0"
-    "@protobufjs/path" "^1.1.2"
-    "@protobufjs/pool" "^1.1.0"
-    "@protobufjs/utf8" "^1.1.0"
-    "@types/long" "^4.0.1"
-    "@types/node" ">=13.7.0"
     long "^4.0.0"
 
 proxy-addr@~2.0.5:


### PR DESCRIPTION
This PR adds support for receiving the preferred island through the heartbeat, and forwarding it to archipelago.

Closes #571.

See also: https://github.com/decentraland/archipelago/issues/32