### PR TITLE
refactor: remove origin

### DIFF
--- a/content/src/controller/Controller.ts
+++ b/content/src/controller/Controller.ts
@@ -163,7 +163,6 @@ export class Controller {
     const ethAddress: EthAddress = req.body.ethAddress
     const signature: Signature = req.body.signature
     const files = req.files
-    const origin = req.header('x-upload-origin') ?? 'unknown'
     const fixAttempt: boolean = req.query.fix === 'true'
 
     let deployFiles: ContentFile[] = []
@@ -176,15 +175,13 @@ export class Controller {
         deploymentResult = await this.service.deployToFix(
           deployFiles.map(({ content }) => content),
           entityId,
-          auditInfo,
-          origin
+          auditInfo
         )
       } else {
         deploymentResult = await this.service.deployEntity(
           deployFiles.map(({ content }) => content),
           entityId,
-          auditInfo,
-          origin
+          auditInfo
         )
       }
 

--- a/content/src/denylist/DenylistServiceDecorator.ts
+++ b/content/src/denylist/DenylistServiceDecorator.ts
@@ -83,8 +83,7 @@ export class DenylistServiceDecorator implements MetaverseContentService {
   async deployToFix(
     files: DeploymentFiles,
     entityId: EntityId,
-    auditInfo: LocalDeploymentAuditInfo,
-    origin: string
+    auditInfo: LocalDeploymentAuditInfo
   ): Promise<DeploymentResult> {
     return this.repository.task(
       async (task) => {
@@ -92,7 +91,7 @@ export class DenylistServiceDecorator implements MetaverseContentService {
         const hashedFiles = await this.validateDeployment(task.denylist, files, entityId, auditInfo)
 
         // If all validations passed, then deploy the entity
-        return this.service.deployToFix(hashedFiles, entityId, auditInfo, origin, task)
+        return this.service.deployToFix(hashedFiles, entityId, auditInfo, task)
       },
       { priority: DB_REQUEST_PRIORITY.HIGH }
     )
@@ -101,8 +100,7 @@ export class DenylistServiceDecorator implements MetaverseContentService {
   async deployEntity(
     files: DeploymentFiles,
     entityId: EntityId,
-    auditInfo: LocalDeploymentAuditInfo,
-    origin: string
+    auditInfo: LocalDeploymentAuditInfo
   ): Promise<DeploymentResult> {
     return this.repository.task(
       async (task) => {
@@ -110,7 +108,7 @@ export class DenylistServiceDecorator implements MetaverseContentService {
         const hashedFiles = await this.validateDeployment(task.denylist, files, entityId, auditInfo)
 
         // If all validations passed, then deploy the entity
-        return this.service.deployEntity(hashedFiles, entityId, auditInfo, origin, task)
+        return this.service.deployEntity(hashedFiles, entityId, auditInfo, task)
       },
       { priority: DB_REQUEST_PRIORITY.HIGH }
     )

--- a/content/src/service/Service.ts
+++ b/content/src/service/Service.ts
@@ -29,7 +29,6 @@ export interface MetaverseContentService {
     files: DeploymentFiles,
     entityId: EntityId,
     auditInfo: LocalDeploymentAuditInfo,
-    origin: string,
     task?: Database
   ): Promise<DeploymentResult>
   deployLocalLegacy(
@@ -42,7 +41,6 @@ export interface MetaverseContentService {
     files: DeploymentFiles,
     entityId: EntityId,
     auditInfo: LocalDeploymentAuditInfo,
-    origin: string,
     task?: Database
   ): Promise<DeploymentResult>
   isContentAvailable(fileHashes: ContentFileHash[]): Promise<Map<ContentFileHash, boolean>>
@@ -91,7 +89,6 @@ export type LocalDeploymentAuditInfo = Pick<AuditInfo, 'version' | 'authChain' |
 export type DeploymentEvent = {
   entity: Entity
   auditInfo: AuditInfo
-  origin: string
 }
 
 export type DeploymentListener = (deployment: DeploymentEvent) => void | Promise<void>

--- a/content/src/service/ServiceImpl.ts
+++ b/content/src/service/ServiceImpl.ts
@@ -72,20 +72,18 @@ export class ServiceImpl implements MetaverseContentService, ClusterDeploymentsS
     files: DeploymentFiles,
     entityId: EntityId,
     auditInfo: LocalDeploymentAuditInfo,
-    origin: string,
     task?: Database
   ): Promise<DeploymentResult> {
-    return this.deployInternal(files, entityId, auditInfo, ValidationContext.LOCAL, origin, task)
+    return this.deployInternal(files, entityId, auditInfo, ValidationContext.LOCAL, task)
   }
 
   deployToFix(
     files: DeploymentFiles,
     entityId: EntityId,
     auditInfo: LocalDeploymentAuditInfo,
-    origin: string,
     task?: Database
   ): Promise<DeploymentResult> {
-    return this.deployInternal(files, entityId, auditInfo, ValidationContext.FIX_ATTEMPT, origin, task)
+    return this.deployInternal(files, entityId, auditInfo, ValidationContext.FIX_ATTEMPT, task)
   }
 
   deployLocalLegacy(
@@ -94,7 +92,7 @@ export class ServiceImpl implements MetaverseContentService, ClusterDeploymentsS
     auditInfo: LocalDeploymentAuditInfo,
     task?: Database
   ): Promise<DeploymentResult> {
-    return this.deployInternal(files, entityId, auditInfo, ValidationContext.LOCAL_LEGACY_ENTITY, 'legacy', task)
+    return this.deployInternal(files, entityId, auditInfo, ValidationContext.LOCAL_LEGACY_ENTITY, task)
   }
 
   private async deployInternal(
@@ -102,7 +100,6 @@ export class ServiceImpl implements MetaverseContentService, ClusterDeploymentsS
     entityId: EntityId,
     auditInfo: AuditInfo | LocalDeploymentAuditInfo,
     validationContext: ValidationContext,
-    origin: string,
     task?: Database
   ): Promise<DeploymentResult> {
     const validation = this.validations.getInstance()
@@ -270,9 +267,7 @@ export class ServiceImpl implements MetaverseContentService, ClusterDeploymentsS
         return response
       } else if (response.wasEntityDeployed) {
         // Report deployment to listeners
-        await Promise.all(
-          this.listeners.map((listener) => listener({ entity, auditInfo: response.auditInfoComplete, origin }))
-        )
+        await Promise.all(this.listeners.map((listener) => listener({ entity, auditInfo: response.auditInfoComplete })))
 
         // Since we are still reporting the history size, add one to it
         this.historySize++
@@ -418,8 +413,7 @@ export class ServiceImpl implements MetaverseContentService, ClusterDeploymentsS
       files,
       entityId,
       auditInfo,
-      legacy ? ValidationContext.SYNCED_LEGACY_ENTITY : ValidationContext.SYNCED,
-      'sync'
+      legacy ? ValidationContext.SYNCED_LEGACY_ENTITY : ValidationContext.SYNCED
     )
   }
 
@@ -433,8 +427,7 @@ export class ServiceImpl implements MetaverseContentService, ClusterDeploymentsS
       [entityFile],
       entityId,
       auditInfo,
-      legacy ? ValidationContext.OVERWRITTEN_LEGACY_ENTITY : ValidationContext.OVERWRITTEN,
-      'sync'
+      legacy ? ValidationContext.OVERWRITTEN_LEGACY_ENTITY : ValidationContext.OVERWRITTEN
     )
   }
 

--- a/content/test/integration/E2ETestUtils.ts
+++ b/content/test/integration/E2ETestUtils.ts
@@ -116,12 +116,10 @@ export async function deployEntitiesCombo(
 ): Promise<DeploymentResult> {
   let deploymentResult: DeploymentResult = { errors: [] }
   for (const { deployData } of entitiesCombo) {
-    deploymentResult = await service.deployEntity(
-      Array.from(deployData.files.values()),
-      deployData.entityId,
-      { authChain: deployData.authChain, version: EntityVersion.V2 },
-      ''
-    )
+    deploymentResult = await service.deployEntity(Array.from(deployData.files.values()), deployData.entityId, {
+      authChain: deployData.authChain,
+      version: EntityVersion.V2
+    })
   }
   return deploymentResult
 }

--- a/content/test/integration/service/deployments/deployment-filters.spec.ts
+++ b/content/test/integration/service/deployments/deployment-filters.spec.ts
@@ -126,8 +126,7 @@ describe('Integration - Deployment Filters', () => {
       const deploymentResult: DeploymentResult = await service.deployEntity(
         Array.from(deployData.files.values()),
         deployData.entityId,
-        newAuditInfo,
-        ''
+        newAuditInfo
       )
       if (isSuccessfulDeployment(deploymentResult)) {
         result.push(deploymentResult)

--- a/content/test/unit/denylist/DenylistServiceDecorator.spec.ts
+++ b/content/test/unit/denylist/DenylistServiceDecorator.spec.ts
@@ -282,7 +282,7 @@ describe('DenylistServiceDecorator', () => {
     const denylist = denylistWith()
     const decorator = getDecorator(denylist)
 
-    await decorator.deployEntity([entityFile1], entity1.id, auditInfo, '')
+    await decorator.deployEntity([entityFile1], entity1.id, auditInfo)
   })
 
   it(`When address is denylisted, then it can't deploy entities`, async () => {
@@ -290,7 +290,7 @@ describe('DenylistServiceDecorator', () => {
     const decorator = getDecorator(denylist)
 
     await assertPromiseRejectionIs(
-      () => decorator.deployEntity([entityFile1], entity1.id, auditInfo, ''),
+      () => decorator.deployEntity([entityFile1], entity1.id, auditInfo),
       `Can't allow a deployment from address '${ethAddress}' since it was denylisted.`
     )
   })
@@ -300,7 +300,7 @@ describe('DenylistServiceDecorator', () => {
     const decorator = getDecorator(denylist)
 
     await assertPromiseRejectionIs(
-      () => decorator.deployEntity([entityFile1], entity1.id, auditInfo, ''),
+      () => decorator.deployEntity([entityFile1], entity1.id, auditInfo),
       `Can't allow the deployment since the entity contains a denylisted pointer.`
     )
   })
@@ -310,7 +310,7 @@ describe('DenylistServiceDecorator', () => {
     const decorator = getDecorator(denylist)
 
     await assertPromiseRejectionIs(
-      () => decorator.deployEntity([entityFile1], entity1.id, auditInfo, ''),
+      () => decorator.deployEntity([entityFile1], entity1.id, auditInfo),
       `Can't allow the deployment since the entity contains a denylisted content.`
     )
   })
@@ -320,7 +320,7 @@ describe('DenylistServiceDecorator', () => {
     const decorator = getDecorator(denylist)
 
     await assertPromiseRejectionIs(
-      () => decorator.deployEntity([entityFile1], 'some-random-id', auditInfo, ''),
+      () => decorator.deployEntity([entityFile1], 'some-random-id', auditInfo),
       `Failed to find the entity file.`
     )
   })

--- a/content/test/unit/service/Service.spec.ts
+++ b/content/test/unit/service/Service.spec.ts
@@ -61,7 +61,7 @@ describe('Service', function () {
   })
 
   it(`When no file matches the given entity id, then deployment fails`, async () => {
-    const deploymentResult = await service.deployEntity([randomFile], 'not-actual-hash', auditInfo, '')
+    const deploymentResult = await service.deployEntity([randomFile], 'not-actual-hash', auditInfo)
     if (isInvalidDeployment(deploymentResult)) {
       expect(deploymentResult.errors).toEqual([`Failed to find the entity file.`])
     } else {
@@ -75,8 +75,7 @@ describe('Service', function () {
     const deploymentResult: DeploymentResult = await service.deployEntity(
       [entityFile, randomFile],
       entity.id,
-      auditInfo,
-      ''
+      auditInfo
     )
     if (isInvalidDeployment(deploymentResult)) {
       assert.fail(
@@ -98,7 +97,7 @@ describe('Service', function () {
     )
     const storeSpy = spyOn(storage, 'store')
 
-    await service.deployEntity([entityFile, randomFile], entity.id, auditInfo, '')
+    await service.deployEntity([entityFile, randomFile], entity.id, auditInfo)
 
     expect(storeSpy).toHaveBeenCalledWith(entity.id, entityFile)
     expect(storeSpy).not.toHaveBeenCalledWith(randomFileHash, randomFile)
@@ -114,7 +113,7 @@ describe('Service', function () {
 
   it(`When a new deployment is made, then the amount of deployments is increased`, async () => {
     await service.start()
-    await service.deployEntity([entityFile, randomFile], entity.id, auditInfo, '')
+    await service.deployEntity([entityFile, randomFile], entity.id, auditInfo)
 
     const status = service.getStatus()
 
@@ -124,7 +123,7 @@ describe('Service', function () {
   it(`When a new deployment is made and fails, then the amount of deployments is not modified`, async () => {
     await service.start()
     try {
-      await service.deployEntity([randomFile], randomFileHash, auditInfo, '')
+      await service.deployEntity([randomFile], randomFileHash, auditInfo)
     } catch {}
 
     const status = service.getStatus()
@@ -173,7 +172,7 @@ describe('Service', function () {
     expectSpyToBeCalled(serviceSpy, POINTERS)
 
     // Make deployment that should invalidate the cache
-    await service.deployEntity([entityFile, randomFile], entity.id, auditInfo, '')
+    await service.deployEntity([entityFile, randomFile], entity.id, auditInfo)
 
     // Reset spy and call again
     serviceSpy.calls.reset()


### PR DESCRIPTION
In https://github.com/decentraland/catalyst/pull/579 we removed the Segment.io reporter since it wasn't being used anymore. With that change, we can now get read of the origin that we've been passing around the code everywhere.

This "origin" property was only used in that reporter, so it doesn't make much sense to keep it around