### PR TITLE
refactor: move eth network to authenticator

### DIFF
--- a/content/src/service/ServiceImpl.ts
+++ b/content/src/service/ServiceImpl.ts
@@ -98,7 +98,7 @@ export class ServiceImpl implements MetaverseContentService, ClusterDeploymentsS
   private async deployInternal(
     files: DeploymentFiles,
     entityId: EntityId,
-    auditInfo: AuditInfo | LocalDeploymentAuditInfo,
+    auditInfo: LocalDeploymentAuditInfo,
     validationContext: ValidationContext,
     task?: Database
   ): Promise<DeploymentResult> {

--- a/content/src/service/auth/Authenticator.ts
+++ b/content/src/service/auth/Authenticator.ts
@@ -1,9 +1,12 @@
 import { AuthChain, Authenticator, EthAddress, ValidationResult } from 'dcl-crypto'
 import { DECENTRALAND_ADDRESS } from 'decentraland-katalyst-commons/addresses'
-import { EthereumProvider } from 'web3x/providers'
+import { httpProviderForNetwork } from 'decentraland-katalyst-contracts/utils'
 
 export class ContentAuthenticator extends Authenticator {
-  constructor(private readonly decentralandAddress: EthAddress = DECENTRALAND_ADDRESS) {
+  constructor(
+    private readonly network: string,
+    private readonly decentralandAddress: EthAddress = DECENTRALAND_ADDRESS
+  ) {
     super()
   }
 
@@ -16,13 +19,12 @@ export class ContentAuthenticator extends Authenticator {
   async validateSignature(
     expectedFinalAuthority: string,
     authChain: AuthChain,
-    provider: EthereumProvider,
     dateToValidateExpirationInMillis: number
   ): Promise<ValidationResult> {
     return Authenticator.validateSignature(
       expectedFinalAuthority,
       authChain,
-      provider,
+      httpProviderForNetwork(this.network),
       dateToValidateExpirationInMillis
     )
   }

--- a/content/src/service/auth/AuthenticatorFactory.ts
+++ b/content/src/service/auth/AuthenticatorFactory.ts
@@ -3,6 +3,9 @@ import { ContentAuthenticator } from './Authenticator'
 
 export class AuthenticatorFactory {
   static create(env: Environment): ContentAuthenticator {
-    return new ContentAuthenticator(env.getConfig(EnvironmentConfig.DECENTRALAND_ADDRESS))
+    return new ContentAuthenticator(
+      env.getConfig(EnvironmentConfig.ETH_NETWORK),
+      env.getConfig(EnvironmentConfig.DECENTRALAND_ADDRESS)
+    )
   }
 }

--- a/content/src/service/validations/Validations.ts
+++ b/content/src/service/validations/Validations.ts
@@ -9,7 +9,6 @@ import {
 } from 'dcl-catalyst-commons'
 import { AuthChain, EthAddress } from 'dcl-crypto'
 import ms from 'ms'
-import { httpProviderForNetwork } from '../../../../contracts/utils'
 import { AccessChecker } from '../access/AccessChecker'
 import { ContentAuthenticator } from '../auth/Authenticator'
 import { Deployment } from '../deployments/DeploymentManager'
@@ -29,7 +28,6 @@ export class Validations {
   constructor(
     private readonly accessChecker: AccessChecker,
     private readonly authenticator: ContentAuthenticator,
-    private readonly network: string,
     private readonly requestTtlBackwards: number,
     private readonly maxUploadSizePerTypeInMB: Map<EntityType, number> = Validations.MAX_UPLOAD_SIZE_PER_POINTER_MB
   ) {}
@@ -38,7 +36,6 @@ export class Validations {
     return new ValidatorInstance(
       this.accessChecker,
       this.authenticator,
-      this.network,
       this.requestTtlBackwards,
       this.maxUploadSizePerTypeInMB
     )
@@ -51,7 +48,6 @@ export class ValidatorInstance {
   constructor(
     private readonly accessChecker: AccessChecker,
     private readonly authenticator: ContentAuthenticator,
-    private readonly network: string,
     private readonly requestTtlBackwards: number,
     private readonly maxUploadSizePerTypeInMB: Map<EntityType, number>
   ) {}
@@ -100,12 +96,7 @@ export class ValidatorInstance {
     validationContext: ValidationContext
   ): Promise<void> {
     if (validationContext.shouldValidate(Validation.SIGNATURE)) {
-      const validationResult = await this.authenticator.validateSignature(
-        entityId,
-        authChain,
-        httpProviderForNetwork(this.network),
-        entityTimestamp
-      )
+      const validationResult = await this.authenticator.validateSignature(entityId, authChain, entityTimestamp)
       if (!validationResult.ok) {
         this.errors.push('The signature is invalid. ' + validationResult.message)
       }

--- a/content/src/service/validations/ValidationsFactory.ts
+++ b/content/src/service/validations/ValidationsFactory.ts
@@ -6,7 +6,6 @@ export class ValidationsFactory {
     return new Validations(
       env.getBean(Bean.ACCESS_CHECKER),
       env.getBean(Bean.AUTHENTICATOR),
-      env.getConfig(EnvironmentConfig.ETH_NETWORK),
       env.getConfig(EnvironmentConfig.REQUEST_TTL_BACKWARDS)
     )
   }

--- a/content/test/integration/service/access/AccessCheckerImpl.spec.ts
+++ b/content/test/integration/service/access/AccessCheckerImpl.spec.ts
@@ -5,6 +5,7 @@ import {
 import { AccessCheckerImpl, AccessCheckerImplParams } from '@katalyst/content/service/access/AccessCheckerImpl'
 import { ContentAuthenticator } from '@katalyst/content/service/auth/Authenticator'
 import { EntityType, Fetcher } from 'dcl-catalyst-commons'
+import { mock } from 'ts-mockito'
 
 describe('Integration - AccessCheckerImpl', function () {
   it(`When access URL is wrong while checking scene access it reports an error`, async () => {
@@ -66,7 +67,7 @@ describe('Integration - AccessCheckerImpl', function () {
 
   function buildAccessCheckerImpl(params: Partial<AccessCheckerImplParams>) {
     const finalParams = {
-      authenticator: new ContentAuthenticator(),
+      authenticator: mock<ContentAuthenticator>(),
       fetcher: new Fetcher(),
       landManagerSubgraphUrl: 'Unused URL',
       collectionsL1SubgraphUrl: 'Unused URL',

--- a/content/test/unit/service/Service.spec.ts
+++ b/content/test/unit/service/Service.spec.ts
@@ -20,6 +20,7 @@ import { NoOpValidations } from '@katalyst/test-helpers/service/validations/NoOp
 import assert from 'assert'
 import { ContentFileHash, EntityType, EntityVersion, Hashing } from 'dcl-catalyst-commons'
 import { Authenticator } from 'dcl-crypto'
+import { mock } from 'ts-mockito'
 import { MockedStorage } from '../storage/MockedStorage'
 import { NoOpDeploymentManager } from './deployments/NoOpDeploymentManager'
 import { NoOpFailedDeploymentsManager } from './errors/NoOpFailedDeploymentsManager'
@@ -184,7 +185,7 @@ describe('Service', function () {
     const env = new Environment()
       .registerBean(Bean.STORAGE, storage)
       .registerBean(Bean.ACCESS_CHECKER, new MockedAccessChecker())
-      .registerBean(Bean.AUTHENTICATOR, new ContentAuthenticator())
+      .registerBean(Bean.AUTHENTICATOR, mock<ContentAuthenticator>())
       .registerBean(Bean.VALIDATIONS, new NoOpValidations())
       .registerBean(Bean.CONTENT_CLUSTER, MockedContentCluster.withoutIdentity())
       .registerBean(Bean.FAILED_DEPLOYMENTS_MANAGER, NoOpFailedDeploymentsManager.build())

--- a/content/test/unit/service/access/AccessCheckerForProfiles.spec.ts
+++ b/content/test/unit/service/access/AccessCheckerForProfiles.spec.ts
@@ -48,7 +48,7 @@ describe('AccessCheckerForProfiles', function () {
   })
 
   function buildAccessChecker() {
-    const authenticator = new ContentAuthenticator()
+    const authenticator = new ContentAuthenticator('')
     return new AccessCheckerForProfiles(authenticator)
   }
 })

--- a/content/test/unit/service/access/AccessCheckerForScenes.spec.ts
+++ b/content/test/unit/service/access/AccessCheckerForScenes.spec.ts
@@ -33,7 +33,7 @@ describe('AccessCheckerForScenes', function () {
 
   function buildAccessChecker(params?: Partial<AccessCheckerImplParams>): AccessCheckerForScenes {
     const { authenticator, fetcher, landManagerSubgraphUrl } = {
-      authenticator: new ContentAuthenticator(),
+      authenticator: new ContentAuthenticator(''),
       fetcher: new Fetcher(),
       landManagerSubgraphUrl: 'Unused URL',
       ...params

--- a/content/test/unit/service/validations/Validations.spec.ts
+++ b/content/test/unit/service/validations/Validations.spec.ts
@@ -457,8 +457,7 @@ function getValidatorWithMockedAccess(options?: { maxSizePerPointer: { type: Ent
     : new Map()
   return new Validations(
     new MockedAccessChecker(),
-    new ContentAuthenticator(),
-    'ropsten',
+    new ContentAuthenticator('ropsten'),
     ms('10m'),
     maxSizeMap
   ).getInstance()


### PR DESCRIPTION
We are simply moving the network from `Validations` into the `Authenticator`, so we can reduce coupling and make `Validations` easier to modify