### PR TITLE
refactor: make service simpler

### DIFF
--- a/content/src/controller/Controller.ts
+++ b/content/src/controller/Controller.ts
@@ -29,6 +29,7 @@ import {
 } from '../service/deployments/DeploymentManager'
 import { Entity } from '../service/Entity'
 import {
+  DeploymentContext,
   DeploymentResult,
   isSuccessfulDeployment,
   LocalDeploymentAuditInfo,
@@ -134,10 +135,11 @@ export class Controller {
         }
       }
 
-      const deploymentResult: DeploymentResult = await this.service.deployLocalLegacy(
+      const deploymentResult: DeploymentResult = await this.service.deployEntity(
         deployFiles.map(({ content }) => content),
         entityId,
-        auditInfo
+        auditInfo,
+        DeploymentContext.LOCAL_LEGACY_ENTITY
       )
 
       if (isSuccessfulDeployment(deploymentResult)) {
@@ -172,16 +174,18 @@ export class Controller {
 
       let deploymentResult: DeploymentResult = { errors: [] }
       if (fixAttempt) {
-        deploymentResult = await this.service.deployToFix(
+        deploymentResult = await this.service.deployEntity(
           deployFiles.map(({ content }) => content),
           entityId,
-          auditInfo
+          auditInfo,
+          DeploymentContext.FIX_ATTEMPT
         )
       } else {
         deploymentResult = await this.service.deployEntity(
           deployFiles.map(({ content }) => content),
           entityId,
-          auditInfo
+          auditInfo,
+          DeploymentContext.LOCAL
         )
       }
 

--- a/content/src/denylist/DenylistServiceDecorator.ts
+++ b/content/src/denylist/DenylistServiceDecorator.ts
@@ -14,6 +14,7 @@ import { Deployment, DeploymentOptions, PointerChangesFilters } from '../service
 import { Entity } from '../service/Entity'
 import { EntityFactory } from '../service/EntityFactory'
 import {
+  DeploymentContext,
   DeploymentFiles,
   DeploymentListener,
   DeploymentResult,
@@ -80,27 +81,11 @@ export class DenylistServiceDecorator implements MetaverseContentService {
     return availability
   }
 
-  async deployToFix(
-    files: DeploymentFiles,
-    entityId: EntityId,
-    auditInfo: LocalDeploymentAuditInfo
-  ): Promise<DeploymentResult> {
-    return this.repository.task(
-      async (task) => {
-        // Validate the deployment
-        const hashedFiles = await this.validateDeployment(task.denylist, files, entityId, auditInfo)
-
-        // If all validations passed, then deploy the entity
-        return this.service.deployToFix(hashedFiles, entityId, auditInfo, task)
-      },
-      { priority: DB_REQUEST_PRIORITY.HIGH }
-    )
-  }
-
   async deployEntity(
     files: DeploymentFiles,
     entityId: EntityId,
-    auditInfo: LocalDeploymentAuditInfo
+    auditInfo: LocalDeploymentAuditInfo,
+    context: DeploymentContext = DeploymentContext.LOCAL
   ): Promise<DeploymentResult> {
     return this.repository.task(
       async (task) => {
@@ -108,24 +93,7 @@ export class DenylistServiceDecorator implements MetaverseContentService {
         const hashedFiles = await this.validateDeployment(task.denylist, files, entityId, auditInfo)
 
         // If all validations passed, then deploy the entity
-        return this.service.deployEntity(hashedFiles, entityId, auditInfo, task)
-      },
-      { priority: DB_REQUEST_PRIORITY.HIGH }
-    )
-  }
-
-  async deployLocalLegacy(
-    files: DeploymentFiles,
-    entityId: string,
-    auditInfo: LocalDeploymentAuditInfo
-  ): Promise<DeploymentResult> {
-    return this.repository.task(
-      async (task) => {
-        // Validate the deployment
-        const hashedFiles = await this.validateDeployment(task.denylist, files, entityId, auditInfo)
-
-        // If all validations passed, then deploy the entity
-        return this.service.deployLocalLegacy(hashedFiles, entityId, auditInfo, task)
+        return this.service.deployEntity(hashedFiles, entityId, auditInfo, context, task)
       },
       { priority: DB_REQUEST_PRIORITY.HIGH }
     )

--- a/content/src/service/Service.ts
+++ b/content/src/service/Service.ts
@@ -29,18 +29,7 @@ export interface MetaverseContentService {
     files: DeploymentFiles,
     entityId: EntityId,
     auditInfo: LocalDeploymentAuditInfo,
-    task?: Database
-  ): Promise<DeploymentResult>
-  deployLocalLegacy(
-    files: DeploymentFiles,
-    entityId: EntityId,
-    auditInfo: LocalDeploymentAuditInfo,
-    task?: Database
-  ): Promise<DeploymentResult>
-  deployToFix(
-    files: DeploymentFiles,
-    entityId: EntityId,
-    auditInfo: LocalDeploymentAuditInfo,
+    context?: DeploymentContext,
     task?: Database
   ): Promise<DeploymentResult>
   isContentAvailable(fileHashes: ContentFileHash[]): Promise<Map<ContentFileHash, boolean>>
@@ -74,11 +63,12 @@ export interface ClusterDeploymentsService {
     reason: FailureReason,
     errorDescription?: string
   ): Promise<null>
-  deployEntityFromCluster(files: Buffer[], entityId: EntityId, auditInfo: AuditInfo): Promise<DeploymentResult>
-  deployOverwrittenEntityFromCluster(
-    entityFile: Buffer,
+  deployEntity(
+    files: Buffer[],
     entityId: EntityId,
-    auditInfo: AuditInfo
+    auditInfo: LocalDeploymentAuditInfo,
+    context: DeploymentContext,
+    task?: Database
   ): Promise<DeploymentResult>
   isContentAvailable(fileHashes: ContentFileHash[]): Promise<Map<ContentFileHash, boolean>>
   areEntitiesAlreadyDeployed(entityIds: EntityId[]): Promise<Map<EntityId, boolean>>

--- a/content/src/service/ServiceImpl.ts
+++ b/content/src/service/ServiceImpl.ts
@@ -67,38 +67,11 @@ export class ServiceImpl implements MetaverseContentService, ClusterDeploymentsS
     }
   }
 
-  deployEntity(
+  async deployEntity(
     files: DeploymentFiles,
     entityId: EntityId,
     auditInfo: LocalDeploymentAuditInfo,
-    task?: Database
-  ): Promise<DeploymentResult> {
-    return this.deployInternal(files, entityId, auditInfo, DeploymentContext.LOCAL, task)
-  }
-
-  deployToFix(
-    files: DeploymentFiles,
-    entityId: EntityId,
-    auditInfo: LocalDeploymentAuditInfo,
-    task?: Database
-  ): Promise<DeploymentResult> {
-    return this.deployInternal(files, entityId, auditInfo, DeploymentContext.FIX_ATTEMPT, task)
-  }
-
-  deployLocalLegacy(
-    files: DeploymentFiles,
-    entityId: string,
-    auditInfo: LocalDeploymentAuditInfo,
-    task?: Database
-  ): Promise<DeploymentResult> {
-    return this.deployInternal(files, entityId, auditInfo, DeploymentContext.LOCAL_LEGACY_ENTITY, task)
-  }
-
-  private async deployInternal(
-    files: DeploymentFiles,
-    entityId: EntityId,
-    auditInfo: LocalDeploymentAuditInfo,
-    context: DeploymentContext,
+    context: DeploymentContext = DeploymentContext.LOCAL,
     task?: Database
   ): Promise<DeploymentResult> {
     // Hash all files
@@ -362,30 +335,6 @@ export class ServiceImpl implements MetaverseContentService, ClusterDeploymentsS
 
   storeContent(fileHash: ContentFileHash, content: Buffer): Promise<void> {
     return this.storage.storeContent(fileHash, content)
-  }
-
-  async deployEntityFromCluster(files: Buffer[], entityId: EntityId, auditInfo: AuditInfo): Promise<DeploymentResult> {
-    const legacy = !!auditInfo.migrationData
-    return await this.deployInternal(
-      files,
-      entityId,
-      auditInfo,
-      legacy ? DeploymentContext.SYNCED_LEGACY_ENTITY : DeploymentContext.SYNCED
-    )
-  }
-
-  async deployOverwrittenEntityFromCluster(
-    entityFile: Buffer,
-    entityId: EntityId,
-    auditInfo: AuditInfo
-  ): Promise<DeploymentResult> {
-    const legacy = !!auditInfo.migrationData
-    return await this.deployInternal(
-      [entityFile],
-      entityId,
-      auditInfo,
-      legacy ? DeploymentContext.OVERWRITTEN_LEGACY_ENTITY : DeploymentContext.OVERWRITTEN
-    )
   }
 
   areEntitiesAlreadyDeployed(entityIds: EntityId[], task?: Database): Promise<Map<EntityId, boolean>> {

--- a/content/test/helpers/service/MockedMetaverseContentService.ts
+++ b/content/test/helpers/service/MockedMetaverseContentService.ts
@@ -9,6 +9,7 @@ import {
 import { Entity } from '@katalyst/content/service/Entity'
 import { FailedDeployment } from '@katalyst/content/service/errors/FailedDeploymentsManager'
 import {
+  DeploymentContext,
   DeploymentListener,
   LocalDeploymentAuditInfo,
   MetaverseContentService
@@ -112,21 +113,13 @@ export class MockedMetaverseContentService implements MetaverseContentService {
     )
   }
 
-  deployEntity(files: Buffer[], entityId: EntityId, auditInfo: LocalDeploymentAuditInfo): Promise<Timestamp> {
-    return Promise.resolve(Date.now())
-  }
-
-  deployToFix(files: Buffer[], entityId: EntityId): Promise<Timestamp> {
-    return Promise.resolve(Date.now())
-  }
-
-  deployLocalLegacy(
+  deployEntity(
     files: Buffer[],
-    entityId: string,
+    entityId: EntityId,
     auditInfo: LocalDeploymentAuditInfo,
-    task?: Database
-  ): Promise<number> {
-    throw new Error('Method not implemented.')
+    context: DeploymentContext
+  ): Promise<Timestamp> {
+    return Promise.resolve(Date.now())
   }
 
   isContentAvailable(fileHashes: ContentFileHash[]): Promise<Map<ContentFileHash, boolean>> {


### PR DESCRIPTION
We are now making the service simpler by removing different versions and just passing the deployment context as a parameter