### PR TITLE
refactor: remove the need for the version on the audit info

### DIFF
--- a/content/src/controller/Controller.ts
+++ b/content/src/controller/Controller.ts
@@ -128,7 +128,6 @@ export class Controller {
       deployFiles = await this.readFiles(files)
       const auditInfo: LocalDeploymentAuditInfo = {
         authChain,
-        version: CURRENT_CONTENT_VERSION,
         migrationData: {
           originalVersion,
           data: migrationInformation

--- a/content/src/denylist/DenylistServiceDecorator.ts
+++ b/content/src/denylist/DenylistServiceDecorator.ts
@@ -238,7 +238,7 @@ export class DenylistServiceDecorator implements MetaverseContentService {
     }
 
     // Find the entity file
-    const hashes: Map<ContentFileHash, Buffer> = await ServiceImpl.hashFiles(files, auditInfo.version)
+    const hashes: Map<ContentFileHash, Buffer> = await ServiceImpl.hashFiles(files, entityId)
     const entityFile = hashes.get(entityId)
     if (!entityFile) {
       throw new Error(`Failed to find the entity file.`)

--- a/content/src/repository/extensions/DeploymentsRepository.ts
+++ b/content/src/repository/extensions/DeploymentsRepository.ts
@@ -210,7 +210,7 @@ export class DeploymentsRepository {
     return this.db.one(
       `INSERT INTO deployments (deployer_address, version, entity_type, entity_id, entity_timestamp, entity_pointers, entity_metadata, local_timestamp, auth_chain, deleter_deployment)` +
         ` VALUES ` +
-        `($(deployer), $(auditInfo.version), $(entity.type), $(entity.id), to_timestamp($(entity.timestamp) / 1000.0), $(entity.pointers), $(metadata), to_timestamp($(auditInfo.localTimestamp) / 1000.0), $(auditInfo.authChain:json), $(overwrittenBy))` +
+        `($(deployer), $(entity.version), $(entity.type), $(entity.id), to_timestamp($(entity.timestamp) / 1000.0), $(entity.pointers), $(metadata), to_timestamp($(auditInfo.localTimestamp) / 1000.0), $(auditInfo.authChain:json), $(overwrittenBy))` +
         ` RETURNING id`,
       {
         entity,

--- a/content/src/service/Service.ts
+++ b/content/src/service/Service.ts
@@ -74,7 +74,7 @@ export interface ClusterDeploymentsService {
   areEntitiesAlreadyDeployed(entityIds: EntityId[]): Promise<Map<EntityId, boolean>>
 }
 
-export type LocalDeploymentAuditInfo = Pick<AuditInfo, 'version' | 'authChain' | 'migrationData'>
+export type LocalDeploymentAuditInfo = Pick<AuditInfo, 'authChain' | 'migrationData'>
 
 export type DeploymentEvent = {
   entity: Entity

--- a/content/src/service/ServiceImpl.ts
+++ b/content/src/service/ServiceImpl.ts
@@ -3,7 +3,6 @@ import {
   ContentFileHash,
   EntityId,
   EntityType,
-  EntityVersion,
   Hashing,
   PartialDeploymentHistory,
   Pointer,
@@ -76,7 +75,7 @@ export class ServiceImpl implements MetaverseContentService, ClusterDeploymentsS
     task?: Database
   ): Promise<DeploymentResult> {
     // Hash all files
-    const hashes: Map<ContentFileHash, Buffer> = await ServiceImpl.hashFiles(files, auditInfo.version)
+    const hashes: Map<ContentFileHash, Buffer> = await ServiceImpl.hashFiles(files, entityId)
 
     // Find entity file
     const entityFile = hashes.get(entityId)
@@ -133,6 +132,7 @@ export class ServiceImpl implements MetaverseContentService, ClusterDeploymentsS
 
             const auditInfoComplete: AuditInfo = {
               ...auditInfo,
+              version: entity.version,
               localTimestamp
             }
 
@@ -306,14 +306,19 @@ export class ServiceImpl implements MetaverseContentService, ClusterDeploymentsS
    * They could come hashed because the denylist decorator might have already hashed them for its own validations. In order to avoid re-hashing
    * them in the service (because there might be hundreds of files), we will send the hash result.
    */
-  static async hashFiles(files: DeploymentFiles, version: EntityVersion): Promise<Map<ContentFileHash, Buffer>> {
+  static async hashFiles(files: DeploymentFiles, entityId: EntityId): Promise<Map<ContentFileHash, Buffer>> {
     if (files instanceof Map) {
       return files
     } else {
-      const hashEntries: { hash: ContentFileHash; file: Buffer }[] =
-        version === EntityVersion.V3 ? await Hashing.calculateHashes(files) : await Hashing.calculateIPFSHashes(files)
+      const hashEntries: { hash: ContentFileHash; file: Buffer }[] = this.isIPFSHash(entityId)
+        ? await Hashing.calculateIPFSHashes(files)
+        : await Hashing.calculateHashes(files)
       return new Map(hashEntries.map(({ hash, file }) => [hash, file]))
     }
+  }
+
+  static isIPFSHash(hash: string) {
+    return hash.startsWith('bafy') && hash.length === 59
   }
 
   getContent(fileHash: ContentFileHash): Promise<ContentItem | undefined> {

--- a/content/src/service/validations/Validator.ts
+++ b/content/src/service/validations/Validator.ts
@@ -31,9 +31,9 @@ export class ValidatorImpl implements Validator {
     context: DeploymentContext,
     calls: ExternalCalls
   ): Promise<{ ok: true } | { ok: false; errors: Errors }> {
-    const validationsForVersion = ValidatorImpl.VALIDATIONS[deployment.auditInfo.version]
+    const validationsForVersion = ValidatorImpl.VALIDATIONS[deployment.entity.version]
     if (!validationsForVersion) {
-      return { ok: false, errors: [`Unknown entity version ${deployment.auditInfo.version}`] }
+      return { ok: false, errors: [`Unknown entity version ${deployment.entity.version}`] }
     }
     const validationsForContext = validationsForVersion[context]
     if (!validationsForContext) {

--- a/content/test/integration/E2ETestUtils.ts
+++ b/content/test/integration/E2ETestUtils.ts
@@ -116,8 +116,7 @@ export async function deployEntitiesCombo(
   let deploymentResult: DeploymentResult = { errors: [] }
   for (const { deployData } of entitiesCombo) {
     deploymentResult = await service.deployEntity(Array.from(deployData.files.values()), deployData.entityId, {
-      authChain: deployData.authChain,
-      version: EntityVersion.V3
+      authChain: deployData.authChain
     })
   }
   return deploymentResult

--- a/content/test/unit/denylist/DenylistServiceDecorator.spec.ts
+++ b/content/test/unit/denylist/DenylistServiceDecorator.spec.ts
@@ -20,7 +20,7 @@ import {
   MockedMetaverseContentService,
   MockedMetaverseContentServiceBuilder
 } from '@katalyst/test-helpers/service/MockedMetaverseContentService'
-import { EntityVersion, Pointer } from 'dcl-catalyst-commons'
+import { Pointer } from 'dcl-catalyst-commons'
 import { Authenticator } from 'dcl-crypto'
 import { random } from 'faker'
 import { anything, instance, mock, when } from 'ts-mockito'
@@ -33,8 +33,7 @@ describe('DenylistServiceDecorator', () => {
   const content2 = buildRandomContent()
   const ethAddress = random.alphaNumeric(10)
   const auditInfo: LocalDeploymentAuditInfo = {
-    authChain: Authenticator.createSimpleAuthChain('', ethAddress, random.alphaNumeric(10)),
-    version: EntityVersion.V3
+    authChain: Authenticator.createSimpleAuthChain('', ethAddress, random.alphaNumeric(10))
   }
 
   let entity1: Entity

--- a/content/test/unit/repository/DeploymentsRepository.spec.ts
+++ b/content/test/unit/repository/DeploymentsRepository.spec.ts
@@ -318,7 +318,7 @@ describe('DeploymentRepository', () => {
         const overwrittenBy = 10
         await repository.saveDeployment(entity, auditInfo, overwrittenBy)
 
-        const expectedQuery = `INSERT INTO deployments (deployer_address, version, entity_type, entity_id, entity_timestamp, entity_pointers, entity_metadata, local_timestamp, auth_chain, deleter_deployment) VALUES ($(deployer), $(auditInfo.version), $(entity.type), $(entity.id), to_timestamp($(entity.timestamp) / 1000.0), $(entity.pointers), $(metadata), to_timestamp($(auditInfo.localTimestamp) / 1000.0), $(auditInfo.authChain:json), $(overwrittenBy)) RETURNING id`
+        const expectedQuery = `INSERT INTO deployments (deployer_address, version, entity_type, entity_id, entity_timestamp, entity_pointers, entity_metadata, local_timestamp, auth_chain, deleter_deployment) VALUES ($(deployer), $(entity.version), $(entity.type), $(entity.id), to_timestamp($(entity.timestamp) / 1000.0), $(entity.pointers), $(metadata), to_timestamp($(auditInfo.localTimestamp) / 1000.0), $(auditInfo.authChain:json), $(overwrittenBy)) RETURNING id`
 
         const args = capture(db.one).last()
         expect(args[0]).toEqual(expectedQuery)
@@ -354,7 +354,7 @@ describe('DeploymentRepository', () => {
         const overwrittenBy = 10
         await repository.saveDeployment(entity, auditInfo, overwrittenBy)
 
-        const expectedQuery = `INSERT INTO deployments (deployer_address, version, entity_type, entity_id, entity_timestamp, entity_pointers, entity_metadata, local_timestamp, auth_chain, deleter_deployment) VALUES ($(deployer), $(auditInfo.version), $(entity.type), $(entity.id), to_timestamp($(entity.timestamp) / 1000.0), $(entity.pointers), $(metadata), to_timestamp($(auditInfo.localTimestamp) / 1000.0), $(auditInfo.authChain:json), $(overwrittenBy)) RETURNING id`
+        const expectedQuery = `INSERT INTO deployments (deployer_address, version, entity_type, entity_id, entity_timestamp, entity_pointers, entity_metadata, local_timestamp, auth_chain, deleter_deployment) VALUES ($(deployer), $(entity.version), $(entity.type), $(entity.id), to_timestamp($(entity.timestamp) / 1000.0), $(entity.pointers), $(metadata), to_timestamp($(auditInfo.localTimestamp) / 1000.0), $(auditInfo.authChain:json), $(overwrittenBy)) RETURNING id`
 
         const args = capture(db.one).last()
         expect(args[0]).toEqual(expectedQuery)

--- a/content/test/unit/service/Service.spec.ts
+++ b/content/test/unit/service/Service.spec.ts
@@ -29,8 +29,7 @@ import { NoOpPointerManager } from './pointers/NoOpPointerManager'
 describe('Service', function () {
   const POINTERS = ['X1,Y1', 'X2,Y2']
   const auditInfo: LocalDeploymentAuditInfo = {
-    authChain: Authenticator.createSimpleAuthChain('entityId', 'ethAddress', 'signature'),
-    version: EntityVersion.V3
+    authChain: Authenticator.createSimpleAuthChain('entityId', 'ethAddress', 'signature')
   }
 
   const initialAmountOfDeployments: number = 15
@@ -215,6 +214,7 @@ describe('Service', function () {
       pointers: POINTERS,
       auditInfo: {
         ...auditInfo,
+        version: EntityVersion.V3,
         localTimestamp: 10
       }
     }

--- a/content/test/unit/service/validations/Validations.spec.ts
+++ b/content/test/unit/service/validations/Validations.spec.ts
@@ -250,7 +250,6 @@ describe('Validations', function () {
         deployment: {
           entity,
           auditInfo: {
-            version: EntityVersion.V3,
             authChain: ContentAuthenticator.createSimpleAuthChain(
               entity.id,
               '0x29d7d1dd5b6f9c864d9db560d72a247c178ae86b',
@@ -276,10 +275,7 @@ describe('Validations', function () {
       const args = buildArgs({
         deployment: {
           entity,
-          auditInfo: {
-            version: EntityVersion.V3,
-            authChain
-          }
+          auditInfo: { authChain }
         }
       })
 
@@ -296,7 +292,7 @@ describe('Validations', function () {
       const args = buildArgs({
         deployment: {
           entity,
-          auditInfo: { version: EntityVersion.V3, authChain }
+          auditInfo: { authChain }
         }
       })
 
@@ -310,7 +306,7 @@ describe('Validations', function () {
       const args = buildArgs({
         deployment: {
           entity,
-          auditInfo: { version: EntityVersion.V3, authChain: [] }
+          auditInfo: { authChain: [] }
         }
       })
 
@@ -387,6 +383,7 @@ describe('Validations', function () {
 })
 
 function buildEntity(options?: {
+  version?: EntityVersion
   id?: string
   timestamp?: Timestamp
   content?: Map<string, string>
@@ -394,6 +391,7 @@ function buildEntity(options?: {
 }) {
   const opts = Object.assign(
     {
+      version: EntityVersion.V3,
       timestamp: Date.now(),
       content: undefined,
       id: 'bafybeihz4c4cf4icnlh6yjtt7fooaeih3dkv2mz6umod7dybenzmsxkzvq',
@@ -403,7 +401,6 @@ function buildEntity(options?: {
   )
   return {
     ...opts,
-    version: EntityVersion.V3,
     type: EntityType.SCENE
   }
 }
@@ -429,7 +426,7 @@ function deploymentWith(entity: Entity, auditInfo: Partial<AuditInfo>) {
     deployedBy: '0x...',
     content: undefined,
     auditInfo: {
-      version: EntityVersion.V2,
+      version: EntityVersion.V3,
       authChain: [],
       localTimestamp: 20,
       ...auditInfo
@@ -463,10 +460,7 @@ function buildArgs(args: {
   return {
     deployment: {
       files: new Map(),
-      auditInfo: {
-        version: EntityVersion.V3,
-        authChain: []
-      },
+      auditInfo: { authChain: [] },
       ...args.deployment
     },
     env: {


### PR DESCRIPTION
Thanks to https://github.com/decentraland/catalyst/pull/595, we now have the entity's version inside the entity itself. So we don't need to have it on the audit info anymore. Yay