### PR TITLE
Add null values to cache

### DIFF
--- a/content/src/service/ServiceImpl.ts
+++ b/content/src/service/ServiceImpl.ts
@@ -252,7 +252,15 @@ export class ServiceImpl implements MetaverseContentService, ClusterDeploymentsS
       const entries: [Pointer, Entity][][] = entities.map((entity) =>
         entity.pointers.map((pointer) => [pointer, entity])
       )
-      return new Map(entries.flat())
+
+      // Get Deployments only retrieves the active entities, so if a pointer has a null value we need to manually define it
+      const map = new Map<Pointer, Entity | undefined>(entries.flat())
+
+      for (const pointer of pointers) {
+        if (!map.has(pointer)) map.set(pointer, undefined)
+      }
+
+      return map
     })
 
     // Since the same entity might appear many times, we must remove duplicates

--- a/content/src/service/ServiceImpl.ts
+++ b/content/src/service/ServiceImpl.ts
@@ -253,14 +253,13 @@ export class ServiceImpl implements MetaverseContentService, ClusterDeploymentsS
         entity.pointers.map((pointer) => [pointer, entity])
       )
 
+      const pointersMap = new Map<Pointer, Entity | undefined>(entries.flat())
+
       // Get Deployments only retrieves the active entities, so if a pointer has a null value we need to manually define it
-      const map = new Map<Pointer, Entity | undefined>(entries.flat())
-
       for (const pointer of pointers) {
-        if (!map.has(pointer)) map.set(pointer, undefined)
+        if (!pointersMap.has(pointer)) pointersMap.set(pointer, undefined)
       }
-
-      return map
+      return pointersMap
     })
 
     // Since the same entity might appear many times, we must remove duplicates

--- a/content/test/unit/service/Service.spec.ts
+++ b/content/test/unit/service/Service.spec.ts
@@ -150,6 +150,25 @@ describe('Service', function () {
     expect(serviceSpy).not.toHaveBeenCalled()
   })
 
+  it(`Given a pointer with no deployment, when is asked twice, then the second time cached the result is returned`, async () => {
+    const serviceSpy = spyOn(service, 'getDeployments').and.callFake(() =>
+      Promise.resolve({
+        deployments: [],
+        filters: {},
+        pagination: { offset: 0, limit: 0, moreData: true }
+      })
+    )
+
+    // Call the first time
+    await service.getEntitiesByPointers(EntityType.SCENE, POINTERS)
+    expectSpyToBeCalled(serviceSpy, POINTERS)
+
+    // Reset spy and call again
+    serviceSpy.calls.reset()
+    await service.getEntitiesByPointers(EntityType.SCENE, POINTERS)
+    expect(serviceSpy).not.toHaveBeenCalled()
+  })
+
   it(`When a pointer is affected by a deployment, then it is invalidated from the cache`, async () => {
     spyOn(pointerManager, 'referenceEntityFromPointers').and.callFake(() =>
       Promise.resolve(
@@ -173,6 +192,43 @@ describe('Service', function () {
 
     // Make deployment that should invalidate the cache
     await service.deployEntity([entityFile, randomFile], entity.id, auditInfo)
+
+    // Reset spy and call again
+    serviceSpy.calls.reset()
+    await service.getEntitiesByPointers(EntityType.SCENE, POINTERS)
+    expectSpyToBeCalled(serviceSpy, POINTERS)
+  })
+
+  it(`When a pointer has no entity after a deployment, then it is invalidated from the cache`, async () => {
+    spyOn(pointerManager, 'referenceEntityFromPointers').and.callFake(() =>
+      Promise.resolve(
+        new Map([
+          [POINTERS[0], { before: undefined, after: DELTA_POINTER_RESULT.SET }],
+          [POINTERS[1], { before: undefined, after: DELTA_POINTER_RESULT.SET }]
+        ])
+      )
+    )
+    const serviceSpy = spyOn(service, 'getDeployments').and.callFake(() =>
+      Promise.resolve({
+        deployments: [fakeDeployment()],
+        filters: {},
+        pagination: { offset: 0, limit: 0, moreData: true }
+      })
+    )
+
+    // Call the first time
+    await service.getEntitiesByPointers(EntityType.SCENE, POINTERS)
+    expectSpyToBeCalled(serviceSpy, POINTERS)
+
+    // Make deployment that should invalidate the cache
+    const [deleterEntity, deleterEntityFile] = await buildEntityAndFile(
+      EntityType.SCENE,
+      POINTERS.slice(0, 1),
+      Date.now(),
+      new Map([['file', randomFileHash]]),
+      'metadata'
+    )
+    await service.deployEntity([deleterEntityFile, randomFile], deleterEntity.id, auditInfo)
 
     // Reset spy and call again
     serviceSpy.calls.reset()

--- a/content/test/unit/service/Service.spec.ts
+++ b/content/test/unit/service/Service.spec.ts
@@ -142,6 +142,7 @@ describe('Service', function () {
 
     // Call the first time
     await service.getEntitiesByPointers(EntityType.SCENE, POINTERS)
+    // When a pointer is asked the first time, then the database is reached
     expectSpyToBeCalled(serviceSpy, POINTERS)
 
     // Reset spy and call again

--- a/lambdas/src/Server.ts
+++ b/lambdas/src/Server.ts
@@ -71,6 +71,7 @@ export class Server {
     // Backwards compatibility for older Content API
     this.app.use('/contentv2', initializeContentV2Routes(createMetricsProxy(), fetcher))
 
+    // TODO: Remove the route /profile/{id} as it has been migrated to /profiles/{id}
     // Profile API implementation
     this.app.use(
       '/profile',


### PR DESCRIPTION
In https://github.com/decentraland/catalyst/pull/462 we added a cache to store entities from pointers, but we didn't consider the case when a pointer of a scene is null, so we are adding support on the cache for that case.

fixes https://github.com/decentraland/catalyst/issues/629