### PR TITLE
fix: workspace dependencies references and fix start scripts

### DIFF
--- a/comms/lighthouse/src/peers/auth.ts
+++ b/comms/lighthouse/src/peers/auth.ts
@@ -1,4 +1,4 @@
-import { httpProviderForNetwork } from '@catalyst/contracts/utils'
+import { httpProviderForNetwork } from '@catalyst/contracts'
 import { Authenticator } from 'dcl-crypto'
 import { IdType, MessageType } from '../peerjs-server/enums'
 import { IClient } from '../peerjs-server/models/client'

--- a/content/package.json
+++ b/content/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "cleanup": "shx rm -rf dist node_modules",
     "build": "tsc -b",
-    "start:server": "node -r ts-path-mapping/register ./dist/src/entrypoints/run-server.js",
-    "start:db": "node -r ts-path-mapping/register ./dist/src/entrypoints/run-local-database.js",
+    "start:server": "node ./dist/src/entrypoints/run-server.js",
+    "start:db": "node ./dist/src/entrypoints/run-local-database.js",
     "copy-test-resources": "yarn cpy test/integration/resources/* dist --parents",
     "test": "run-p 'test:*'",
     "test:unit": "jasmine --config=jasmine.unit.json",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "mock-socket": "8.0.5",
     "node-pg-migrate": "5.9.0",
     "npm-run-all": "4.1.5",
+    "pg": "8.7.1",
     "prettier": "2.3.2",
     "puppeteer": "10.2.0",
     "shx": "0.3.3",


### PR DESCRIPTION
# Description

This changes are required to successfully start services that currently don't (lighthouse and content).

- Start content server
```
yarn workspace @catalyst/content-server start:server
```
- Start lighthouse server
```
yarn workspace @catalyst/lighthouse-server start:server
```