### PR TITLE
Add a rate limit for deploying profiles

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,8 +6,9 @@
   "typescript.tsdk": "node_modules/typescript/lib",
   "editor.formatOnSave": true,
   "cSpell.words": [
+    "comms",
     "Ethereum",
-    "comms"
+    "IPFS"
   ],
   "editor.rulers": [
     120

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,7 +8,9 @@
   "cSpell.words": [
     "comms",
     "Ethereum",
-    "IPFS"
+    "IPFS",
+    "Metaverse",
+    "openapi"
   ],
   "editor.rulers": [
     120

--- a/content/package.json
+++ b/content/package.json
@@ -36,6 +36,7 @@
     "morgan": "1.10.0",
     "ms": "2.1.3",
     "multer": "1.4.3",
+    "node-cache": "^5.1.2",
     "node-fetch": "2.6.1",
     "node-pg-migrate": "5.10.0",
     "on-finished": "2.3.0",

--- a/content/package.json
+++ b/content/package.json
@@ -9,7 +9,7 @@
     "start:db": "node ./dist/src/entrypoints/run-local-database.js",
     "copy-test-resources": "yarn cpy test/integration/resources/* dist --parents",
     "test": "run-p 'test:*'",
-    "test:unit": "jasmine --config=jasmine.unit.json",
+    "test:unit": "yarn build && jasmine --config=jasmine.unit.json",
     "test:integration": "yarn copy-test-resources && jasmine --config=jasmine.integration.json"
   },
   "dependencies": {

--- a/content/src/Environment.ts
+++ b/content/src/Environment.ts
@@ -145,6 +145,7 @@ export enum EnvironmentConfig {
   CHECK_SYNC_RANGE,
   ALLOW_LEGACY_ENTITIES,
   DECENTRALAND_ADDRESS,
+  DEPLOYMENTS_RATE_LIMIT_TTL,
   ETH_NETWORK,
   LOG_LEVEL,
   FETCH_REQUEST_TIMEOUT,
@@ -233,6 +234,11 @@ export class EnvironmentBuilder {
       () => process.env.CHECK_SYNC_RANGE ?? ms('20m')
     )
     this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.DECENTRALAND_ADDRESS, () => DECENTRALAND_ADDRESS)
+    this.registerConfigIfNotAlreadySet(
+      env,
+      EnvironmentConfig.DEPLOYMENTS_RATE_LIMIT_TTL,
+      () => process.env.ALLOW_LEGACY_ENTITIES ?? 1000
+    )
     this.registerConfigIfNotAlreadySet(
       env,
       EnvironmentConfig.ALLOW_LEGACY_ENTITIES,

--- a/content/src/Environment.ts
+++ b/content/src/Environment.ts
@@ -2,6 +2,7 @@ import { DECENTRALAND_ADDRESS } from '@catalyst/commons'
 import { EntityType, EntityVersion } from 'dcl-catalyst-commons'
 import log4js from 'log4js'
 import ms from 'ms'
+import NodeCache from 'node-cache'
 import { ControllerFactory } from './controller/ControllerFactory'
 import { DenylistFactory } from './denylist/DenylistFactory'
 import { FetcherFactory } from './helpers/FetcherFactory'
@@ -127,6 +128,7 @@ export const enum Bean {
   VALIDATOR,
   CHALLENGE_SUPERVISOR,
   REPOSITORY,
+  DEPLOYMENTS_RATE_LIMIT_CACHE,
   MIGRATION_MANAGER,
   GARBAGE_COLLECTION_MANAGER,
   SYSTEM_PROPERTIES_MANAGER,
@@ -436,6 +438,11 @@ export class EnvironmentBuilder {
     this.registerBeanIfNotAlreadySet(env, Bean.POINTER_MANAGER, () => PointerManagerFactory.create(env))
     this.registerBeanIfNotAlreadySet(env, Bean.ACCESS_CHECKER, () => AccessCheckerImplFactory.create(env))
     this.registerBeanIfNotAlreadySet(env, Bean.FAILED_DEPLOYMENTS_MANAGER, () => new FailedDeploymentsManager())
+    this.registerBeanIfNotAlreadySet(
+      env,
+      Bean.DEPLOYMENTS_RATE_LIMIT_CACHE,
+      () => new NodeCache({ stdTTL: env.getConfig(EnvironmentConfig.DEPLOYMENTS_RATE_LIMIT_TTL) })
+    )
     this.registerBeanIfNotAlreadySet(env, Bean.VALIDATOR, () => ValidatorFactory.create(env))
     this.registerBeanIfNotAlreadySet(env, Bean.SERVICE, () => ServiceFactory.create(env))
     this.registerBeanIfNotAlreadySet(env, Bean.SNAPSHOT_MANAGER, () => SnapshotManagerFactory.create(env))

--- a/content/src/Server.ts
+++ b/content/src/Server.ts
@@ -69,7 +69,7 @@ export class Server {
     this.synchronizationManager = env.getBean(Bean.SYNCHRONIZATION_MANAGER)
 
     if (env.getConfig(EnvironmentConfig.USE_COMPRESSION_MIDDLEWARE)) {
-      this.app.use(compression({ filter: (req, res) => true }))
+      this.app.use(compression({ filter: (_req, _res) => true }))
     }
 
     this.app.use(cors(corsOptions))

--- a/content/src/repository/RepositoryQueue.ts
+++ b/content/src/repository/RepositoryQueue.ts
@@ -3,8 +3,8 @@ import PQueue from 'p-queue'
 import { metricsComponent } from '../metrics'
 
 /**
- * All database requests go through this queue. All pending requests will be queued as long as the limit isn't reached. If if it, then
- * low priority requests will be rejected before being queued.
+ * All database requests go through this queue. All pending requests will be queued as long as the limit isn't reached.
+ * If it is, then low priority requests will be rejected before being queued.
  */
 export class RepositoryQueue {
   public static readonly TOO_MANY_QUEUED_ERROR =

--- a/content/src/service/ServiceFactory.ts
+++ b/content/src/service/ServiceFactory.ts
@@ -1,5 +1,6 @@
 import { Pointer } from 'dcl-catalyst-commons'
-import { Bean, Environment } from '../Environment'
+import NodeCache from 'node-cache'
+import { Bean, Environment, EnvironmentConfig } from '../Environment'
 import { CacheManager, ENTITIES_BY_POINTERS_CACHE_CONFIG } from './caching/CacheManager'
 import { Entity } from './Entity'
 import { ClusterDeploymentsService, MetaverseContentService } from './Service'
@@ -18,7 +19,8 @@ export class ServiceFactory {
       env.getBean(Bean.DEPLOYMENT_MANAGER),
       env.getBean(Bean.VALIDATOR),
       env.getBean(Bean.REPOSITORY),
-      cache
+      cache,
+      new NodeCache({ stdTTL: env.getConfig(EnvironmentConfig.DEPLOYMENTS_RATE_LIMIT_TTL) })
     )
   }
 }

--- a/content/src/service/ServiceFactory.ts
+++ b/content/src/service/ServiceFactory.ts
@@ -1,6 +1,5 @@
 import { Pointer } from 'dcl-catalyst-commons'
-import NodeCache from 'node-cache'
-import { Bean, Environment, EnvironmentConfig } from '../Environment'
+import { Bean, Environment } from '../Environment'
 import { CacheManager, ENTITIES_BY_POINTERS_CACHE_CONFIG } from './caching/CacheManager'
 import { Entity } from './Entity'
 import { ClusterDeploymentsService, MetaverseContentService } from './Service'
@@ -20,7 +19,7 @@ export class ServiceFactory {
       env.getBean(Bean.VALIDATOR),
       env.getBean(Bean.REPOSITORY),
       cache,
-      new NodeCache({ stdTTL: env.getConfig(EnvironmentConfig.DEPLOYMENTS_RATE_LIMIT_TTL) })
+      env.getBean(Bean.DEPLOYMENTS_RATE_LIMIT_CACHE)
     )
   }
 }

--- a/content/src/service/ServiceFactory.ts
+++ b/content/src/service/ServiceFactory.ts
@@ -1,5 +1,5 @@
 import { Pointer } from 'dcl-catalyst-commons'
-import { Bean, Environment } from '../Environment'
+import { Bean, Environment, EnvironmentConfig } from '../Environment'
 import { CacheManager, ENTITIES_BY_POINTERS_CACHE_CONFIG } from './caching/CacheManager'
 import { Entity } from './Entity'
 import { ClusterDeploymentsService, MetaverseContentService } from './Service'
@@ -19,7 +19,10 @@ export class ServiceFactory {
       env.getBean(Bean.VALIDATOR),
       env.getBean(Bean.REPOSITORY),
       cache,
-      env.getBean(Bean.DEPLOYMENTS_RATE_LIMIT_CACHE)
+      {
+        cache: env.getBean(Bean.DEPLOYMENTS_RATE_LIMIT_CACHE),
+        maxSize: env.getConfig(EnvironmentConfig.DEPLOYMENTS_RATE_LIMIT_MAX)
+      }
     )
   }
 }

--- a/content/src/service/ServiceImpl.ts
+++ b/content/src/service/ServiceImpl.ts
@@ -26,7 +26,7 @@ import {
 } from './deployments/DeploymentManager'
 import { Entity } from './Entity'
 import { EntityFactory } from './EntityFactory'
-import { FailedDeploymentsManager, FailureReason } from './errors/FailedDeploymentsManager'
+import { FailedDeployment, FailedDeploymentsManager, FailureReason } from './errors/FailedDeploymentsManager'
 import { PointerManager } from './pointers/PointerManager'
 import {
   ClusterDeploymentsService,
@@ -62,7 +62,7 @@ export class ServiceImpl implements MetaverseContentService, ClusterDeploymentsS
     const amountOfDeployments = await this.repository.task((task) => task.deployments.getAmountOfDeployments(), {
       priority: DB_REQUEST_PRIORITY.HIGH
     })
-    for (const [_, amount] of amountOfDeployments) {
+    for (const [, amount] of amountOfDeployments) {
       this.historySize += amount
     }
   }
@@ -106,119 +106,142 @@ export class ServiceImpl implements MetaverseContentService, ClusterDeploymentsS
       Array.from(entity.content?.values() ?? [])
     )
     try {
-      const response:
+      const storeResult:
         | { auditInfoComplete: AuditInfo; wasEntityDeployed: boolean; affectedPointers: Pointer[] | undefined }
-        | InvalidResult = await this.repository.reuseIfPresent(
+        | InvalidResult = await this.storeDeploymentInDatabase(
         task,
-        (db) =>
-          db.txIf(async (transaction) => {
-            const isEntityAlreadyDeployed = await this.isEntityAlreadyDeployed(entityId, transaction)
-
-            const validationResult = await this.validator.validate({ entity, auditInfo, files: hashes }, context, {
-              fetchDeployments: (filters) => this.getDeployments({ filters }, transaction),
-              areThereNewerEntities: (entity) => this.areThereNewerEntitiesOnPointers(entity, transaction),
-              fetchDeploymentStatus: (type, id) =>
-                this.failedDeploymentsManager.getDeploymentStatus(transaction.failedDeployments, type, id),
-              isContentStoredAlready: () => Promise.resolve(alreadyStoredContent), // We know that the validation asks for the same content we already checked
-              isEntityDeployedAlready: (entityIdToCheck: EntityId) =>
-                Promise.resolve(isEntityAlreadyDeployed && entityId === entityIdToCheck),
-              isEntityRateLimited: (entity, authChain) => this.isEntityRateLimited(entity, authChain)
-            })
-
-            if (!validationResult.ok) {
-              return { errors: validationResult.errors }
-            }
-
-            const localTimestamp = Date.now()
-
-            const auditInfoComplete: AuditInfo = {
-              ...auditInfo,
-              version: entity.version,
-              localTimestamp
-            }
-
-            let affectedPointers: Pointer[] | undefined
-
-            if (!isEntityAlreadyDeployed) {
-              // IF THIS POINT WAS REACHED, THEN THE DEPLOYMENT WILL BE COMMITTED
-
-              // Calculate overwrites
-              const { overwrote, overwrittenBy } = await this.pointerManager.calculateOverwrites(
-                transaction.pointerHistory,
-                entity
-              )
-
-              // Store the deployment
-              const deploymentId = await this.deploymentManager.saveDeployment(
-                transaction.deployments,
-                transaction.migrationData,
-                transaction.content,
-                entity,
-                auditInfoComplete,
-                overwrittenBy
-              )
-
-              // Modify active pointers
-              const result = await this.pointerManager.referenceEntityFromPointers(
-                transaction.lastDeployedPointers,
-                deploymentId,
-                entity
-              )
-              affectedPointers = Array.from(result.keys())
-
-              // Save deployment pointer changes
-              await this.deploymentManager.savePointerChanges(
-                transaction.deploymentPointerChanges,
-                deploymentId,
-                result
-              )
-
-              // Add to pointer history
-              await this.pointerManager.addToHistory(transaction.pointerHistory, deploymentId, entity)
-
-              // Set who overwrote who
-              await this.deploymentManager.setEntitiesAsOverwritten(transaction.deployments, overwrote, deploymentId)
-
-              // Store the entity's content
-              await this.storeEntityContent(hashes, alreadyStoredContent)
-            }
-
-            // Mark deployment as successful (this does nothing it if hadn't failed on the first place)
-            await this.failedDeploymentsManager.reportSuccessfulDeployment(
-              transaction.failedDeployments,
-              entity.type,
-              entity.id
-            )
-
-            return { auditInfoComplete, wasEntityDeployed: !isEntityAlreadyDeployed, affectedPointers }
-          }),
-        { priority: DB_REQUEST_PRIORITY.HIGH }
+        entityId,
+        entity,
+        auditInfo,
+        hashes,
+        context,
+        alreadyStoredContent
       )
 
-      if (!('auditInfoComplete' in response)) {
-        return response
-      } else if (response.wasEntityDeployed) {
+      if (!('auditInfoComplete' in storeResult)) {
+        return storeResult
+      } else if (storeResult.wasEntityDeployed) {
         // Report deployment to listeners
-        await Promise.all(this.listeners.map((listener) => listener({ entity, auditInfo: response.auditInfoComplete })))
+        await Promise.all(
+          this.listeners.map((listener) => listener({ entity, auditInfo: storeResult.auditInfoComplete }))
+        )
 
         // Since we are still reporting the history size, add one to it
         this.historySize++
         metricsComponent.increment('total_deployments_count', { entity_type: entity.type }, 1)
 
-        // Invalidate cache
-        response.affectedPointers?.forEach((pointer) => this.cache.invalidate(entity.type, pointer))
+        // Invalidate cache for retrieving entities by id
+        storeResult.affectedPointers?.forEach((pointer) => this.cache.invalidate(entity.type, pointer))
 
         // Insert in cache the updated entities
         // TODO
       }
-      return response.auditInfoComplete.localTimestamp
+      return storeResult.auditInfoComplete.localTimestamp
     } catch (error) {
       throw error
     } finally {
-      // Update the current list of pointers being deployed
+      // Remove the updated pointer from the list of current being deployed
       const pointersCurrentlyBeingDeployed = this.pointersBeingDeployed.get(entity.type)!
       entity.pointers.forEach((pointer) => pointersCurrentlyBeingDeployed.delete(pointer))
     }
+  }
+
+  private async storeDeploymentInDatabase(
+    task: Database | undefined,
+    entityId: string,
+    entity: Entity,
+    auditInfo: LocalDeploymentAuditInfo,
+    hashes: Map<string, Buffer>,
+    context: DeploymentContext,
+    alreadyStoredContent: Map<string, boolean>
+  ): Promise<
+    | InvalidResult
+    | { auditInfoComplete: AuditInfo; wasEntityDeployed: boolean; affectedPointers: Pointer[] | undefined }
+  > {
+    return await this.repository.reuseIfPresent(
+      task,
+      (db) =>
+        db.txIf(async (transaction) => {
+          const isEntityAlreadyDeployed = await this.isEntityAlreadyDeployed(entityId, transaction)
+
+          // Prepare validation functions that need context
+          const validationResult = await this.validator.validate({ entity, auditInfo, files: hashes }, context, {
+            fetchDeployments: (filters) => this.getDeployments({ filters }, transaction),
+            areThereNewerEntities: (entity) => this.areThereNewerEntitiesOnPointers(entity, transaction),
+            fetchDeploymentStatus: (type, id) =>
+              this.failedDeploymentsManager.getDeploymentStatus(transaction.failedDeployments, type, id),
+            isContentStoredAlready: () => Promise.resolve(alreadyStoredContent),
+            isEntityDeployedAlready: (entityIdToCheck: EntityId) =>
+              Promise.resolve(isEntityAlreadyDeployed && entityId === entityIdToCheck),
+            isEntityRateLimited: (entity) => Promise.resolve(this.isEntityRateLimited(entity))
+          })
+
+          if (!validationResult.ok) {
+            return { errors: validationResult.errors }
+          }
+
+          const auditInfoComplete: AuditInfo = {
+            ...auditInfo,
+            version: entity.version,
+            localTimestamp: Date.now()
+          }
+
+          let affectedPointers: Pointer[] | undefined
+
+          if (!isEntityAlreadyDeployed) {
+            // IF THIS POINT WAS REACHED, THEN THE DEPLOYMENT WILL BE COMMITTED
+            // Calculate overwrites
+            const { overwrote, overwrittenBy } = await this.pointerManager.calculateOverwrites(
+              transaction.pointerHistory,
+              entity
+            )
+
+            // Store the deployment
+            const deploymentId = await this.deploymentManager.saveDeployment(
+              transaction.deployments,
+              transaction.migrationData,
+              transaction.content,
+              entity,
+              auditInfoComplete,
+              overwrittenBy
+            )
+
+            // Modify active pointers
+            const pointersFromEntity = await this.pointerManager.referenceEntityFromPointers(
+              transaction.lastDeployedPointers,
+              deploymentId,
+              entity
+            )
+            affectedPointers = Array.from(pointersFromEntity.keys())
+
+            // Save deployment pointer changes
+            await this.deploymentManager.savePointerChanges(
+              transaction.deploymentPointerChanges,
+              deploymentId,
+              pointersFromEntity
+            )
+
+            // Add to pointer history
+            await this.pointerManager.addToHistory(transaction.pointerHistory, deploymentId, entity)
+
+            // Set who overwrote who
+            await this.deploymentManager.setEntitiesAsOverwritten(transaction.deployments, overwrote, deploymentId)
+
+            // Store the entity's content
+            await this.storeEntityContent(hashes, alreadyStoredContent)
+          }
+
+          // Mark deployment as successful (this does nothing it if hadn't failed on the first place)
+          await this.failedDeploymentsManager.reportSuccessfulDeployment(
+            transaction.failedDeployments,
+            entity.type,
+            entity.id
+          )
+
+          return { auditInfoComplete, wasEntityDeployed: !isEntityAlreadyDeployed, affectedPointers }
+        }),
+      { priority: DB_REQUEST_PRIORITY.HIGH }
+    )
   }
 
   reportErrorDuringSync(
@@ -300,8 +323,10 @@ export class ServiceImpl implements MetaverseContentService, ClusterDeploymentsS
     return false
   }
 
-  /** Check if    */
-  private isEntityRateLimited() {}
+  /** Check if the entity should be rate limit   */
+  private isEntityRateLimited(entity: Entity): boolean {
+    return false
+  }
 
   private storeEntityContent(
     hashes: Map<ContentFileHash, Buffer>,
@@ -331,7 +356,7 @@ export class ServiceImpl implements MetaverseContentService, ClusterDeploymentsS
     }
   }
 
-  static isIPFSHash(hash: string) {
+  static isIPFSHash(hash: string): boolean {
     return IPFSv2.validate(hash)
   }
 
@@ -420,7 +445,7 @@ export class ServiceImpl implements MetaverseContentService, ClusterDeploymentsS
     )
   }
 
-  getAllFailedDeployments() {
+  getAllFailedDeployments(): Promise<FailedDeployment[]> {
     return this.repository.run((db) => this.failedDeploymentsManager.getAllFailedDeployments(db.failedDeployments), {
       priority: DB_REQUEST_PRIORITY.LOW
     })

--- a/content/src/service/ServiceImpl.ts
+++ b/content/src/service/ServiceImpl.ts
@@ -135,7 +135,7 @@ export class ServiceImpl implements MetaverseContentService, ClusterDeploymentsS
         // Invalidate cache for retrieving entities by id
         storeResult.affectedPointers?.forEach((pointer) => this.cache.invalidate(entity.type, pointer))
 
-        // Insert in cache the updated entities
+        // Insert in deployments cache the updated entities
         if (entity.type == EntityType.PROFILE) {
           // Currently we are only checking profile deployments, in the future this may be refactored
           entity.pointers.forEach((address) => {

--- a/content/src/service/caching/CacheManager.ts
+++ b/content/src/service/caching/CacheManager.ts
@@ -1,7 +1,7 @@
 import { EntityType } from 'dcl-catalyst-commons'
 import { CacheByType } from './Cache'
 
-/** This manger is used to create cache instances, based on some pre-configured defaults */
+/** This manager is used to create cache instances, based on some pre-configured defaults */
 export class CacheManager {
   private readonly cacheSizes: Map<string, number>
 

--- a/content/src/service/synchronization/EventDeployer.ts
+++ b/content/src/service/synchronization/EventDeployer.ts
@@ -32,7 +32,7 @@ export class EventDeployer {
     deployments: Readable[],
     options?: HistoryDeploymentOptions,
     shouldIgnoreTimeout = false
-  ) {
+  ): Promise<void> {
     // Process history and deploy it
     return this.eventProcessor.processDeployments(deployments, options, shouldIgnoreTimeout)
   }

--- a/content/src/service/synchronization/EventDeployer.ts
+++ b/content/src/service/synchronization/EventDeployer.ts
@@ -57,7 +57,7 @@ export class EventDeployer {
       const isLegacyEntity = !!auditInfo.migrationData
       if (auditInfo.overwrittenBy) {
         metricsComponent.increment('dcl_content_downloaded_total', { overwritten: 'true' })
-        // Deploy the entity as overwritten and only download entity file
+        // Deploy the entity as overwritten and only download entity file to avoid storing content files for deployments that are no pointed at
         return this.buildDeploymentExecution(deployment, () =>
           this.service.deployEntity(
             [entityFile],
@@ -68,7 +68,7 @@ export class EventDeployer {
         )
       } else {
         metricsComponent.increment('dcl_content_downloaded_total', { overwritten: 'false' })
-        // Build entity
+        // Parse as JSON the entity and create an object
         const entity: Entity = EntityFactory.fromBufferWithId(entityFile, deployment.entityId)
 
         // Download all entity's files as we need all content
@@ -196,7 +196,7 @@ export class EventDeployer {
 
   /** Wrap the deployment, so if it fails, we can take action */
   private async wrapDeployment(deploymentPreparation: Promise<DeploymentExecution>): Promise<() => Promise<void>> {
-    const deploymentExecution = await deploymentPreparation
+    const deploymentExecution: DeploymentExecution = await deploymentPreparation
     return async () => {
       try {
         const deploymentResult: DeploymentResult = await deploymentExecution.execution()

--- a/content/src/service/synchronization/SynchronizationManager.ts
+++ b/content/src/service/synchronization/SynchronizationManager.ts
@@ -97,8 +97,9 @@ export class ClusterSynchronizationManager implements SynchronizationManager {
     }
   }
 
+  // This is the method that is called recursive to sync with other catalysts
   private async syncWithServers(): Promise<void> {
-    // Update flag
+    // Update flag: if it's not bootstrapping, then that means that it was synced and needs to get new deployments
     if (this.synchronizationState !== SynchronizationState.BOOTSTRAPPING) {
       this.synchronizationState = SynchronizationState.SYNCING
     }
@@ -135,7 +136,7 @@ export class ClusterSynchronizationManager implements SynchronizationManager {
         ClusterSynchronizationManager.LOGGER.debug(
           `Updating content server timestamps: ` + client.getAddress() + ' is ' + newTimestamp
         )
-        // Update the map, so we can store in on the database
+        // Update the map, so we can store it on the database
         this.lastKnownDeployments.set(client.getAddress(), newTimestamp)
       })
 

--- a/content/src/service/validations/Validations.ts
+++ b/content/src/service/validations/Validations.ts
@@ -192,6 +192,13 @@ export class Validations {
       return [`The metadata for this entity type (${deployment.entity.type}) is not valid.`]
   }
 
+  /** Validate the deployment is not rate limited */
+  static readonly RATE_LIMIT: Validation = async ({ deployment, externalCalls }) => {
+    if (!(await externalCalls.isEntityRateLimited(deployment.entity))) {
+      return [`The entity with id (${deployment.entity.id}) has been rate limited.`]
+    }
+  }
+
   private static correspondsToASnapshot(fileName: string, hash: string, metadata: Profile) {
     const fileNameWithoutExtension = fileName.replace(/.[^/.]+$/, '')
 

--- a/content/src/service/validations/Validations.ts
+++ b/content/src/service/validations/Validations.ts
@@ -2,10 +2,11 @@ import { Avatar, Profile, Scene, Wearable } from '@dcl/schemas'
 import { EntityType, EntityVersion } from 'dcl-catalyst-commons'
 import { Authenticator } from 'dcl-crypto'
 import ms from 'ms'
+import { Entity } from '../Entity'
 import { DeploymentStatus, NoFailure } from '../errors/FailedDeploymentsManager'
 import { ServiceImpl } from '../ServiceImpl'
 import { happenedBefore } from '../time/TimeSorting'
-import { Validation } from './Validator'
+import { ExternalCalls, Validation } from './Validator'
 
 export class Validations {
   /** Validate that the signature belongs to the Ethereum address */
@@ -124,8 +125,17 @@ export class Validations {
   /** Validate that uploaded and reported hashes are corrects */
   static readonly CONTENT_V3: Validation = async ({ deployment, externalCalls }) => {
     const { entity, files } = deployment
+    const errors: string[] = await this.validate_content_v3(entity, files, externalCalls)
+    return errors.length > 0 ? errors : undefined
+  }
+
+  private static async validate_content_v3(
+    entity: Entity,
+    files: Map<string, Buffer>,
+    externalCalls: ExternalCalls
+  ): Promise<string[]> {
+    const errors: string[] = []
     if (entity.content) {
-      const errors: string[] = []
       const alreadyStoredHashes = await externalCalls.isContentStoredAlready(Array.from(files.keys()))
 
       for (const [, hash] of entity.content) {
@@ -142,24 +152,17 @@ export class Validations {
           errors.push(`This hash was uploaded but is not referenced in the entity: ${hash}`)
         }
       }
-
-      return errors.length > 0 ? errors : undefined
     }
+    return errors
   }
 
   /** Validate that uploaded and reported hashes are corrects and files corresponds to snapshots */
   static readonly CONTENT_V4: Validation = async ({ deployment, externalCalls }) => {
     const { entity, files } = deployment
-    const errors: string[] = []
+    const errors: string[] = await this.validate_content_v3(entity, files, externalCalls)
+
     if (entity.content) {
-      const alreadyStoredHashes = await externalCalls.isContentStoredAlready(Array.from(files.keys()))
-
       for (const [fileName, hash] of entity.content) {
-        // Validate that all hashes in entity were uploaded, or were already stored on the service
-        if (!(files.has(hash) || alreadyStoredHashes.get(hash))) {
-          errors.push(`This hash is referenced in the entity but was not uploaded or previously available: ${hash}`)
-        }
-
         // Validate all content files correspond to at least one avatar snapshot
         if (entity.type === EntityType.PROFILE) {
           if (!Validations.correspondsToASnapshot(fileName, hash, entity.metadata)) {
@@ -167,14 +170,6 @@ export class Validations {
               `This file is not expected: '${fileName}' or its hash is invalid: '${hash}'. Please, include only valid snapshot files.`
             )
           }
-        }
-      }
-
-      // Validate that all hashes that belong to uploaded files are actually reported on the entity
-      const entityHashes = new Set(entity.content.values())
-      for (const [hash] of files) {
-        if (!entityHashes.has(hash) && hash !== entity.id) {
-          errors.push(`This hash was uploaded but is not referenced in the entity: ${hash}`)
         }
       }
     } else if (files) {

--- a/content/src/service/validations/Validations.ts
+++ b/content/src/service/validations/Validations.ts
@@ -24,6 +24,7 @@ export class Validations {
     }
     const maxSizeInBytes = maxSizeInMB * 1024 * 1024
     let totalSize = 0
+    deployment.entity.content
     deployment.files.forEach((file) => (totalSize += file.byteLength))
     const sizePerPointer = totalSize / entity.pointers.length
     if (sizePerPointer > maxSizeInBytes) {
@@ -203,7 +204,7 @@ export class Validations {
     const fileNameWithoutExtension = fileName.replace(/.[^/.]+$/, '')
 
     return metadata.avatars.some((avatar: Avatar) => {
-      console.log(
+      console.debug(
         `Snapshot file: ${fileNameWithoutExtension} - hash: ${avatar.avatar.snapshots[fileNameWithoutExtension]}`
       )
       return avatar.avatar.snapshots[fileNameWithoutExtension] === hash

--- a/content/src/service/validations/Validations.ts
+++ b/content/src/service/validations/Validations.ts
@@ -194,7 +194,7 @@ export class Validations {
 
   /** Validate the deployment is not rate limited */
   static readonly RATE_LIMIT: Validation = async ({ deployment, externalCalls }) => {
-    if (!(await externalCalls.isEntityRateLimited(deployment.entity))) {
+    if (await externalCalls.isEntityRateLimited(deployment.entity)) {
       return [`The entity with id (${deployment.entity.id}) has been rate limited.`]
     }
   }

--- a/content/src/service/validations/Validations.ts
+++ b/content/src/service/validations/Validations.ts
@@ -122,10 +122,36 @@ export class Validations {
   }
 
   /** Validate that uploaded and reported hashes are corrects */
-  static readonly CONTENT: Validation = async ({ deployment, externalCalls }) => {
+  static readonly CONTENT_V3: Validation = async ({ deployment, externalCalls }) => {
     const { entity, files } = deployment
     if (entity.content) {
       const errors: string[] = []
+      const alreadyStoredHashes = await externalCalls.isContentStoredAlready(Array.from(files.keys()))
+
+      for (const [, hash] of entity.content) {
+        // Validate that all hashes in entity were uploaded, or were already stored on the service
+        if (!(files.has(hash) || alreadyStoredHashes.get(hash))) {
+          errors.push(`This hash is referenced in the entity but was not uploaded or previously available: ${hash}`)
+        }
+      }
+
+      // Validate that all hashes that belong to uploaded files are actually reported on the entity
+      const entityHashes = new Set(entity.content.values())
+      for (const [hash] of files) {
+        if (!entityHashes.has(hash) && hash !== entity.id) {
+          errors.push(`This hash was uploaded but is not referenced in the entity: ${hash}`)
+        }
+      }
+
+      return errors.length > 0 ? errors : undefined
+    }
+  }
+
+  /** Validate that uploaded and reported hashes are corrects and files corresponds to snapshots */
+  static readonly CONTENT_V4: Validation = async ({ deployment, externalCalls }) => {
+    const { entity, files } = deployment
+    const errors: string[] = []
+    if (entity.content) {
       const alreadyStoredHashes = await externalCalls.isContentStoredAlready(Array.from(files.keys()))
 
       for (const [fileName, hash] of entity.content) {
@@ -151,9 +177,12 @@ export class Validations {
           errors.push(`This hash was uploaded but is not referenced in the entity: ${hash}`)
         }
       }
-
-      return errors.length > 0 ? errors : undefined
+    } else if (files) {
+      for (const [hash] of files) {
+        errors.push(`This hash was uploaded but is not referenced in the entity: ${hash}`)
+      }
     }
+    return errors.length > 0 ? errors : undefined
   }
 
   /** Validate that the address used was owned by Decentraland */

--- a/content/src/service/validations/Validator.ts
+++ b/content/src/service/validations/Validator.ts
@@ -77,9 +77,10 @@ export type ExternalCalls = {
   fetchDeploymentStatus: (entityType: EntityType, entityId: EntityId) => Promise<DeploymentStatus>
   isContentStoredAlready: (hashes: ContentFileHash[]) => Promise<Map<ContentFileHash, boolean>>
   isEntityDeployedAlready: (entityId: EntityId) => Promise<boolean>
+  isEntityRateLimited: (entity: Entity) => Promise<boolean>
 }
 
-// Will return undefined if there deployment is valid
+// Will return undefined if the deployment is valid
 export type Validation = (args: ValidationArgs) => undefined | Errors | Promise<undefined | Errors>
 
 export type ValidationArgs = {

--- a/content/src/service/validations/validations/ValidationsV3.ts
+++ b/content/src/service/validations/validations/ValidationsV3.ts
@@ -2,8 +2,6 @@ import { DeploymentContext } from '../../Service'
 import { Validations } from '../Validations'
 import { ValidationsForContext } from '../Validator'
 
-// TODO: Check if it's okay to add rate limit validation for all contexts
-
 export const VALIDATIONS_V3: ValidationsForContext = {
   // This is the context used when deploying an entity to the Catalyst directly
   [DeploymentContext.LOCAL]: [

--- a/content/src/service/validations/validations/ValidationsV3.ts
+++ b/content/src/service/validations/validations/ValidationsV3.ts
@@ -13,7 +13,7 @@ export const VALIDATIONS_V3: ValidationsForContext = {
     Validations.NO_NEWER,
     Validations.RECENT,
     Validations.NO_REDEPLOYS,
-    Validations.CONTENT,
+    Validations.CONTENT_V3,
     Validations.RATE_LIMIT
   ],
   [DeploymentContext.LOCAL_LEGACY_ENTITY]: [
@@ -24,7 +24,7 @@ export const VALIDATIONS_V3: ValidationsForContext = {
     Validations.RECENT,
     Validations.NO_REDEPLOYS,
     Validations.LEGACY_ENTITY,
-    Validations.CONTENT,
+    Validations.CONTENT_V3,
     Validations.DECENTRALAND_ADDRESS,
     Validations.RATE_LIMIT
   ],
@@ -35,7 +35,7 @@ export const VALIDATIONS_V3: ValidationsForContext = {
     Validations.SIGNATURE,
     Validations.ACCESS,
     Validations.ENTITY_STRUCTURE,
-    Validations.CONTENT,
+    Validations.CONTENT_V3,
     Validations.RATE_LIMIT
   ],
   [DeploymentContext.SYNCED_LEGACY_ENTITY]: [
@@ -43,7 +43,7 @@ export const VALIDATIONS_V3: ValidationsForContext = {
     Validations.SIGNATURE,
     Validations.ENTITY_STRUCTURE,
     Validations.LEGACY_ENTITY,
-    Validations.CONTENT,
+    Validations.CONTENT_V3,
     Validations.DECENTRALAND_ADDRESS,
     Validations.RATE_LIMIT
   ],
@@ -71,7 +71,7 @@ export const VALIDATIONS_V3: ValidationsForContext = {
     Validations.ACCESS,
     Validations.ENTITY_STRUCTURE,
     Validations.MUST_HAVE_FAILED_BEFORE,
-    Validations.CONTENT,
+    Validations.CONTENT_V3,
     Validations.RATE_LIMIT
   ]
 }

--- a/content/src/service/validations/validations/ValidationsV3.ts
+++ b/content/src/service/validations/validations/ValidationsV3.ts
@@ -2,6 +2,8 @@ import { DeploymentContext } from '../../Service'
 import { Validations } from '../Validations'
 import { ValidationsForContext } from '../Validator'
 
+// TODO: Check if it's okay to add rate limit validation for all contexts
+
 export const VALIDATIONS_V3: ValidationsForContext = {
   // This is the context used when deploying an entity to the Catalyst directly
   [DeploymentContext.LOCAL]: [
@@ -13,7 +15,8 @@ export const VALIDATIONS_V3: ValidationsForContext = {
     Validations.NO_NEWER,
     Validations.RECENT,
     Validations.NO_REDEPLOYS,
-    Validations.CONTENT
+    Validations.CONTENT,
+    Validations.RATE_LIMIT
   ],
   [DeploymentContext.LOCAL_LEGACY_ENTITY]: [
     // TODO: Add limit so that v3 entities can only be deployed up to a certain date
@@ -24,7 +27,8 @@ export const VALIDATIONS_V3: ValidationsForContext = {
     Validations.NO_REDEPLOYS,
     Validations.LEGACY_ENTITY,
     Validations.CONTENT,
-    Validations.DECENTRALAND_ADDRESS
+    Validations.DECENTRALAND_ADDRESS,
+    Validations.RATE_LIMIT
   ],
   // This is a context during synchronization: when the deployment is already deployed.
   // That's why here it's not present NO_REDEPLOY, during sync you can receive the same deployment from different catalysts.
@@ -33,7 +37,8 @@ export const VALIDATIONS_V3: ValidationsForContext = {
     Validations.SIGNATURE,
     Validations.ACCESS,
     Validations.ENTITY_STRUCTURE,
-    Validations.CONTENT
+    Validations.CONTENT,
+    Validations.RATE_LIMIT
   ],
   [DeploymentContext.SYNCED_LEGACY_ENTITY]: [
     // TODO: Add limit so that v3 entities can only be deployed up to a certain date
@@ -41,22 +46,25 @@ export const VALIDATIONS_V3: ValidationsForContext = {
     Validations.ENTITY_STRUCTURE,
     Validations.LEGACY_ENTITY,
     Validations.CONTENT,
-    Validations.DECENTRALAND_ADDRESS
+    Validations.DECENTRALAND_ADDRESS,
+    Validations.RATE_LIMIT
   ],
   // This is during synchronization when a deployment needs to  be done, but you already have a newer which overwrites it.
-  // So, at this momento the files from the entity of the overwritten deployment are not download.
+  // So, at this moment the files from the entity of the overwritten deployment are not download.
   [DeploymentContext.OVERWRITTEN]: [
     // TODO: Add limit so that v3 entities can only be deployed up to a certain date
     Validations.SIGNATURE,
     Validations.ACCESS,
-    Validations.ENTITY_STRUCTURE
+    Validations.ENTITY_STRUCTURE,
+    Validations.RATE_LIMIT
   ],
   [DeploymentContext.OVERWRITTEN_LEGACY_ENTITY]: [
     // TODO: Add limit so that v3 entities can only be deployed up to a certain date
     Validations.SIGNATURE,
     Validations.ENTITY_STRUCTURE,
     Validations.LEGACY_ENTITY,
-    Validations.DECENTRALAND_ADDRESS
+    Validations.DECENTRALAND_ADDRESS,
+    Validations.RATE_LIMIT
   ],
   // This context is used only when running the fix deployments script
   [DeploymentContext.FIX_ATTEMPT]: [
@@ -65,6 +73,7 @@ export const VALIDATIONS_V3: ValidationsForContext = {
     Validations.ACCESS,
     Validations.ENTITY_STRUCTURE,
     Validations.MUST_HAVE_FAILED_BEFORE,
-    Validations.CONTENT
+    Validations.CONTENT,
+    Validations.RATE_LIMIT
   ]
 }

--- a/content/src/service/validations/validations/ValidationsV4.ts
+++ b/content/src/service/validations/validations/ValidationsV4.ts
@@ -13,7 +13,8 @@ export const VALIDATIONS_V4: ValidationsForContext = {
     Validations.CONTENT,
     Validations.NO_NEWER,
     Validations.RECENT,
-    Validations.NO_REDEPLOYS
+    Validations.NO_REDEPLOYS,
+    Validations.RATE_LIMIT
   ],
   [DeploymentContext.SYNCED]: [
     Validations.IPFS_HASHING,
@@ -22,15 +23,19 @@ export const VALIDATIONS_V4: ValidationsForContext = {
     Validations.SIGNATURE,
     Validations.ACCESS,
     Validations.ENTITY_STRUCTURE,
-    Validations.CONTENT
+    Validations.CONTENT,
+    Validations.RATE_LIMIT
   ],
+  // This is during synchronization when a deployment needs to  be done, but you already have a newer which overwrites it.
+  // So, at this moment the files from the entity of the overwritten deployment are not download.
   [DeploymentContext.OVERWRITTEN]: [
     Validations.IPFS_HASHING,
     // TODO: Validations.REQUEST_SIZE_V4
     Validations.METADATA_SCHEMA,
     Validations.SIGNATURE,
     Validations.ACCESS,
-    Validations.ENTITY_STRUCTURE
+    Validations.ENTITY_STRUCTURE,
+    Validations.RATE_LIMIT
   ],
   [DeploymentContext.FIX_ATTEMPT]: [
     Validations.IPFS_HASHING,
@@ -40,7 +45,8 @@ export const VALIDATIONS_V4: ValidationsForContext = {
     Validations.ACCESS,
     Validations.ENTITY_STRUCTURE,
     Validations.CONTENT,
-    Validations.MUST_HAVE_FAILED_BEFORE
+    Validations.MUST_HAVE_FAILED_BEFORE,
+    Validations.RATE_LIMIT
   ],
   // Note: there is no need for legacy entities anymore, so we won't allow then in v4
   [DeploymentContext.SYNCED_LEGACY_ENTITY]: [Validations.FAIL_ALWAYS],

--- a/content/src/service/validations/validations/ValidationsV4.ts
+++ b/content/src/service/validations/validations/ValidationsV4.ts
@@ -4,49 +4,53 @@ import { ValidationsForContext } from '../Validator'
 
 export const VALIDATIONS_V4: ValidationsForContext = {
   [DeploymentContext.LOCAL]: [
-    Validations.IPFS_HASHING,
-    // TODO: Validations.REQUEST_SIZE_V4
-    Validations.METADATA_SCHEMA,
-    Validations.SIGNATURE,
-    Validations.ACCESS,
-    Validations.ENTITY_STRUCTURE,
-    Validations.CONTENT,
-    Validations.NO_NEWER,
-    Validations.RECENT,
-    Validations.NO_REDEPLOYS,
-    Validations.RATE_LIMIT
+    Validations.FAIL_ALWAYS
+    // Validations.IPFS_HASHING,
+    // // TODO: Validations.REQUEST_SIZE_V4
+    // Validations.METADATA_SCHEMA,
+    // Validations.SIGNATURE,
+    // Validations.ACCESS,
+    // Validations.ENTITY_STRUCTURE,
+    // Validations.CONTENT_V4,
+    // Validations.NO_NEWER,
+    // Validations.RECENT,
+    // Validations.NO_REDEPLOYS,
+    // Validations.RATE_LIMIT
   ],
   [DeploymentContext.SYNCED]: [
-    Validations.IPFS_HASHING,
-    // TODO: Validations.REQUEST_SIZE_V4
-    Validations.METADATA_SCHEMA,
-    Validations.SIGNATURE,
-    Validations.ACCESS,
-    Validations.ENTITY_STRUCTURE,
-    Validations.CONTENT,
-    Validations.RATE_LIMIT
+    Validations.FAIL_ALWAYS
+    // Validations.IPFS_HASHING,
+    // // TODO: Validations.REQUEST_SIZE_V4
+    // Validations.METADATA_SCHEMA,
+    // Validations.SIGNATURE,
+    // Validations.ACCESS,
+    // Validations.ENTITY_STRUCTURE,
+    // Validations.CONTENT_V4,
+    // Validations.RATE_LIMIT
   ],
   // This is during synchronization when a deployment needs to  be done, but you already have a newer which overwrites it.
   // So, at this moment the files from the entity of the overwritten deployment are not download.
   [DeploymentContext.OVERWRITTEN]: [
-    Validations.IPFS_HASHING,
-    // TODO: Validations.REQUEST_SIZE_V4
-    Validations.METADATA_SCHEMA,
-    Validations.SIGNATURE,
-    Validations.ACCESS,
-    Validations.ENTITY_STRUCTURE,
-    Validations.RATE_LIMIT
+    Validations.FAIL_ALWAYS
+    // Validations.IPFS_HASHING,
+    // // TODO: Validations.REQUEST_SIZE_V4
+    // Validations.METADATA_SCHEMA,
+    // Validations.SIGNATURE,
+    // Validations.ACCESS,
+    // Validations.ENTITY_STRUCTURE,
+    // Validations.RATE_LIMIT
   ],
   [DeploymentContext.FIX_ATTEMPT]: [
-    Validations.IPFS_HASHING,
-    // TODO: Validations.REQUEST_SIZE_V4
-    Validations.METADATA_SCHEMA,
-    Validations.SIGNATURE,
-    Validations.ACCESS,
-    Validations.ENTITY_STRUCTURE,
-    Validations.CONTENT,
-    Validations.MUST_HAVE_FAILED_BEFORE,
-    Validations.RATE_LIMIT
+    Validations.FAIL_ALWAYS
+    // Validations.IPFS_HASHING,
+    // // TODO: Validations.REQUEST_SIZE_V4
+    // Validations.METADATA_SCHEMA,
+    // Validations.SIGNATURE,
+    // Validations.ACCESS,
+    // Validations.ENTITY_STRUCTURE,
+    // Validations.CONTENT_V4,
+    // Validations.MUST_HAVE_FAILED_BEFORE,
+    // Validations.RATE_LIMIT
   ],
   // Note: there is no need for legacy entities anymore, so we won't allow then in v4
   [DeploymentContext.SYNCED_LEGACY_ENTITY]: [Validations.FAIL_ALWAYS],

--- a/content/test/unit/service/validations/Validations.spec.ts
+++ b/content/test/unit/service/validations/Validations.spec.ts
@@ -448,7 +448,7 @@ describe('Validations', function () {
     })
   })
 
-  describe('IFPS hashing', () => {
+  describe('IPFS hashing', () => {
     it(`when an entity's id is not an ipfs hash, then it fails`, async () => {
       const entity = buildEntity({ id: 'QmTBPcZLFQf1rZpZg2T8nMDwWRoqeftRdvkaexgAECaqHp' })
       const args = buildArgs({ deployment: { entity } })
@@ -560,6 +560,32 @@ describe('Validations', function () {
       const validMetadata = wearable
       const invalidMetadata = {}
       testType(EntityType.WEARABLE, validMetadata, invalidMetadata)
+    })
+  })
+
+  describe('Rate limit for deployments', () => {
+    it(`when it should not be rate limit, then the entity is deployed`, async () => {
+      const args = buildArgs({
+        deployment: { entity: buildEntity() },
+        externalCalls: { isEntityRateLimited: async () => false }
+      })
+
+      const result = Validations.RATE_LIMIT(args)
+
+      await assertNoErrors(result)
+    })
+
+    it(`when it should be rate limit, then the entity is not deployed`, async () => {
+      const entity = buildEntity()
+
+      const args = buildArgs({
+        deployment: { entity: entity },
+        externalCalls: { isEntityRateLimited: async () => true }
+      })
+
+      const result = Validations.RATE_LIMIT(args)
+
+      await assertErrorsWere(result, `The entity with id (${entity.id}) has been rate limited.`)
     })
   })
 })

--- a/content/test/unit/service/validations/Validations.spec.ts
+++ b/content/test/unit/service/validations/Validations.spec.ts
@@ -665,6 +665,7 @@ function buildArgs(args: {
       fetchDeploymentStatus: () => Promise.resolve(NoFailure.NOT_MARKED_AS_FAILED),
       isContentStoredAlready: (hashes) => Promise.resolve(new Map(hashes.map((hash) => [hash, false]))),
       isEntityDeployedAlready: () => Promise.resolve(false),
+      isEntityRateLimited: () => Promise.resolve(false),
       ...args?.externalCalls
     }
   }

--- a/content/test/unit/service/validations/Validations.spec.ts
+++ b/content/test/unit/service/validations/Validations.spec.ts
@@ -225,7 +225,7 @@ describe('Validations', function () {
       })
       const args = buildArgs({ deployment: { entity, files: new Map() } })
 
-      const result = Validations.CONTENT(args)
+      const result = Validations.CONTENT_V4(args)
 
       await assertErrorsWere(result, notAvailableHashMessage('hash'))
     })
@@ -239,7 +239,7 @@ describe('Validations', function () {
         externalCalls: { isContentStoredAlready: () => Promise.resolve(new Map([['hash', true]])) }
       })
 
-      const result = Validations.CONTENT(args)
+      const result = Validations.CONTENT_V4(args)
 
       await assertNoErrors(result)
     })
@@ -252,7 +252,7 @@ describe('Validations', function () {
         deployment: { entity, files: new Map([['hash', Buffer.from([])]]) }
       })
 
-      const result = Validations.CONTENT(args)
+      const result = Validations.CONTENT_V4(args)
 
       await assertNoErrors(result)
     })
@@ -269,7 +269,7 @@ describe('Validations', function () {
         }
       })
 
-      const result = Validations.CONTENT(args)
+      const result = Validations.CONTENT_V4(args)
 
       await assertErrorsWere(result, notReferencedHashMessage('hash-2'))
     })
@@ -288,7 +288,7 @@ describe('Validations', function () {
         }
       })
 
-      const result = Validations.CONTENT(args)
+      const result = Validations.CONTENT_V4(args)
 
       await assertNoErrors(result)
     })
@@ -307,7 +307,7 @@ describe('Validations', function () {
         }
       })
 
-      const result = Validations.CONTENT(args)
+      const result = Validations.CONTENT_V4(args)
 
       await assertErrorsWere(
         result,
@@ -329,7 +329,7 @@ describe('Validations', function () {
         }
       })
 
-      const result = Validations.CONTENT(args)
+      const result = Validations.CONTENT_V4(args)
 
       await assertErrorsWere(
         result,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2431,6 +2431,11 @@ clone-response@^1.0.2:
   dependencies:
     mimic-response "^1.0.0"
 
+clone@2.x:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
+  integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
+
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
@@ -6056,6 +6061,13 @@ node-addon-api@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-4.1.0.tgz#f1722f1f60793584632ffffb79e12ca042c48bd0"
   integrity sha512-Zz1o1BDX2VtduiAt6kgiUl8jX1Vm3NMboljFYKQJ6ee8AGfiTvM2mlZFI3xPbqjs80rCQgiVJI/DjQ/1QJ0HwA==
+
+node-cache@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/node-cache/-/node-cache-5.1.2.tgz#f264dc2ccad0a780e76253a694e9fd0ed19c398d"
+  integrity sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==
+  dependencies:
+    clone "2.x"
 
 node-duration@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
Add a new validation for V3 and V4 entities which rate limits the number of deployments. It only allows making a deploy per pointer per TTL configured and a max amount of deployments too.