### PR TITLE
feat: validate v4 entities size including previous deployments

### DIFF
--- a/content/.gitignore
+++ b/content/.gitignore
@@ -1,1 +1,1 @@
-storage*
+storage/*

--- a/content/src/service/ServiceImpl.ts
+++ b/content/src/service/ServiceImpl.ts
@@ -181,7 +181,7 @@ export class ServiceImpl implements MetaverseContentService, ClusterDeploymentsS
             isEntityDeployedAlready: (entityIdToCheck: EntityId) =>
               Promise.resolve(isEntityAlreadyDeployed && entityId === entityIdToCheck),
             isEntityRateLimited: (entity) => Promise.resolve(this.isEntityRateLimited(entity)),
-            fetchContentFileSize: async (hash) => (await this.getContent(hash))?.getLength() ?? 0
+            fetchContentFileSize: async (hash) => (await this.getSize(hash)) ?? 0
           })
 
           if (!validationResult.ok) {

--- a/content/src/service/ServiceImpl.ts
+++ b/content/src/service/ServiceImpl.ts
@@ -181,7 +181,7 @@ export class ServiceImpl implements MetaverseContentService, ClusterDeploymentsS
             isEntityDeployedAlready: (entityIdToCheck: EntityId) =>
               Promise.resolve(isEntityAlreadyDeployed && entityId === entityIdToCheck),
             isEntityRateLimited: (entity) => Promise.resolve(this.isEntityRateLimited(entity)),
-            fetchContentFileSize: async (hash) => (await this.getSize(hash)) ?? 0
+            fetchContentFileSize: async (hash) => await this.getSize(hash)
           })
 
           if (!validationResult.ok) {

--- a/content/src/service/ServiceImpl.ts
+++ b/content/src/service/ServiceImpl.ts
@@ -11,12 +11,12 @@ import {
 } from 'dcl-catalyst-commons'
 import log4js from 'log4js'
 import NodeCache from 'node-cache'
-import { ContentItem } from 'src/storage/ContentStorage'
 import { CURRENT_CONTENT_VERSION } from '../Environment'
 import { metricsComponent } from '../metrics'
 import { Database } from '../repository/Database'
 import { Repository } from '../repository/Repository'
 import { DB_REQUEST_PRIORITY } from '../repository/RepositoryQueue'
+import { ContentItem } from '../storage/ContentStorage'
 import { CacheByType } from './caching/Cache'
 import {
   Deployment,
@@ -370,6 +370,10 @@ export class ServiceImpl implements MetaverseContentService, ClusterDeploymentsS
 
   static isIPFSHash(hash: string): boolean {
     return IPFSv2.validate(hash)
+  }
+
+  getSize(fileHash: ContentFileHash): Promise<number | undefined> {
+    return this.storage.getSize(fileHash)
   }
 
   getContent(fileHash: ContentFileHash): Promise<ContentItem | undefined> {

--- a/content/src/service/ServiceImpl.ts
+++ b/content/src/service/ServiceImpl.ts
@@ -11,12 +11,12 @@ import {
 } from 'dcl-catalyst-commons'
 import log4js from 'log4js'
 import NodeCache from 'node-cache'
+import { ContentItem } from 'src/storage/ContentStorage'
 import { CURRENT_CONTENT_VERSION } from '../Environment'
 import { metricsComponent } from '../metrics'
 import { Database } from '../repository/Database'
 import { Repository } from '../repository/Repository'
 import { DB_REQUEST_PRIORITY } from '../repository/RepositoryQueue'
-import { ContentItem } from '../storage/ContentStorage'
 import { CacheByType } from './caching/Cache'
 import {
   Deployment,
@@ -180,7 +180,8 @@ export class ServiceImpl implements MetaverseContentService, ClusterDeploymentsS
             isContentStoredAlready: () => Promise.resolve(alreadyStoredContent),
             isEntityDeployedAlready: (entityIdToCheck: EntityId) =>
               Promise.resolve(isEntityAlreadyDeployed && entityId === entityIdToCheck),
-            isEntityRateLimited: (entity) => Promise.resolve(this.isEntityRateLimited(entity))
+            isEntityRateLimited: (entity) => Promise.resolve(this.isEntityRateLimited(entity)),
+            fetchContentFileSize: async (hash) => (await this.getContent(hash))?.getLength() ?? 0
           })
 
           if (!validationResult.ok) {

--- a/content/src/service/ServiceStorage.ts
+++ b/content/src/service/ServiceStorage.ts
@@ -19,4 +19,8 @@ export class ServiceStorage {
   async isContentAvailable(fileHashes: ContentFileHash[]): Promise<Map<ContentFileHash, boolean>> {
     return this.storage.exist(fileHashes)
   }
+
+  async getSize(fileHash: ContentFileHash): Promise<number | undefined> {
+    return (await this.storage.stats(fileHash))?.size
+  }
 }

--- a/content/src/service/validations/Validations.ts
+++ b/content/src/service/validations/Validations.ts
@@ -25,7 +25,7 @@ export class Validations {
     }
     const maxSizeInBytes = maxSizeInMB * 1024 * 1024
     let totalSize = 0
-    deployment.entity.content
+
     deployment.files.forEach((file) => (totalSize += file.byteLength))
     const sizePerPointer = totalSize / entity.pointers.length
     if (sizePerPointer > maxSizeInBytes) {

--- a/content/src/service/validations/Validations.ts
+++ b/content/src/service/validations/Validations.ts
@@ -232,7 +232,13 @@ export class Validations {
 
     for (const [, hash] of entity.content ?? []) {
       const uploadedFile = deployment.files.get(hash)
-      totalSize += uploadedFile?.byteLength ?? (await externalCalls.fetchContentFileSize(hash))
+      if (uploadedFile) {
+        totalSize += uploadedFile.byteLength
+      } else {
+        const contentSize = await externalCalls.fetchContentFileSize(hash)
+        if (!contentSize) return [`Couldn't fetch content file with hash: ${hash}`]
+        totalSize += contentSize
+      }
     }
 
     const sizePerPointer = totalSize / entity.pointers.length

--- a/content/src/service/validations/Validator.ts
+++ b/content/src/service/validations/Validator.ts
@@ -78,7 +78,7 @@ export type ExternalCalls = {
   isContentStoredAlready: (hashes: ContentFileHash[]) => Promise<Map<ContentFileHash, boolean>>
   isEntityDeployedAlready: (entityId: EntityId) => Promise<boolean>
   isEntityRateLimited: (entity: Entity) => Promise<boolean>
-  fetchContentFileSize: (hash: string) => Promise<number>
+  fetchContentFileSize: (hash: string) => Promise<number | undefined>
 }
 
 // Will return undefined if the deployment is valid

--- a/content/src/service/validations/Validator.ts
+++ b/content/src/service/validations/Validator.ts
@@ -78,6 +78,7 @@ export type ExternalCalls = {
   isContentStoredAlready: (hashes: ContentFileHash[]) => Promise<Map<ContentFileHash, boolean>>
   isEntityDeployedAlready: (entityId: EntityId) => Promise<boolean>
   isEntityRateLimited: (entity: Entity) => Promise<boolean>
+  fetchContentFileSize: (hash: string) => Promise<number>
 }
 
 // Will return undefined if the deployment is valid

--- a/content/src/service/validations/validations/ValidationsV4.ts
+++ b/content/src/service/validations/validations/ValidationsV4.ts
@@ -4,53 +4,45 @@ import { ValidationsForContext } from '../Validator'
 
 export const VALIDATIONS_V4: ValidationsForContext = {
   [DeploymentContext.LOCAL]: [
-    Validations.FAIL_ALWAYS
-    // Validations.IPFS_HASHING,
-    // // TODO: Validations.REQUEST_SIZE_V4
-    // Validations.METADATA_SCHEMA,
-    // Validations.SIGNATURE,
-    // Validations.ACCESS,
-    // Validations.ENTITY_STRUCTURE,
-    // Validations.CONTENT_V4,
-    // Validations.NO_NEWER,
-    // Validations.RECENT,
-    // Validations.NO_REDEPLOYS,
-    // Validations.RATE_LIMIT
+    Validations.IPFS_HASHING,
+    Validations.METADATA_SCHEMA,
+    Validations.SIGNATURE,
+    Validations.ACCESS,
+    Validations.ENTITY_STRUCTURE,
+    Validations.CONTENT_V4,
+    Validations.REQUEST_SIZE_V4,
+    Validations.NO_NEWER,
+    Validations.RECENT,
+    Validations.NO_REDEPLOYS
   ],
   [DeploymentContext.SYNCED]: [
-    Validations.FAIL_ALWAYS
-    // Validations.IPFS_HASHING,
-    // // TODO: Validations.REQUEST_SIZE_V4
-    // Validations.METADATA_SCHEMA,
-    // Validations.SIGNATURE,
-    // Validations.ACCESS,
-    // Validations.ENTITY_STRUCTURE,
-    // Validations.CONTENT_V4,
-    // Validations.RATE_LIMIT
+    Validations.IPFS_HASHING,
+    Validations.METADATA_SCHEMA,
+    Validations.SIGNATURE,
+    Validations.ACCESS,
+    Validations.ENTITY_STRUCTURE,
+    Validations.CONTENT_V4,
+    Validations.REQUEST_SIZE_V4
   ],
   // This is during synchronization when a deployment needs to  be done, but you already have a newer which overwrites it.
   // So, at this moment the files from the entity of the overwritten deployment are not download.
   [DeploymentContext.OVERWRITTEN]: [
-    Validations.FAIL_ALWAYS
-    // Validations.IPFS_HASHING,
-    // // TODO: Validations.REQUEST_SIZE_V4
-    // Validations.METADATA_SCHEMA,
-    // Validations.SIGNATURE,
-    // Validations.ACCESS,
-    // Validations.ENTITY_STRUCTURE,
-    // Validations.RATE_LIMIT
+    Validations.IPFS_HASHING,
+    Validations.REQUEST_SIZE_V4,
+    Validations.METADATA_SCHEMA,
+    Validations.SIGNATURE,
+    Validations.ACCESS,
+    Validations.ENTITY_STRUCTURE
   ],
   [DeploymentContext.FIX_ATTEMPT]: [
-    Validations.FAIL_ALWAYS
-    // Validations.IPFS_HASHING,
-    // // TODO: Validations.REQUEST_SIZE_V4
-    // Validations.METADATA_SCHEMA,
-    // Validations.SIGNATURE,
-    // Validations.ACCESS,
-    // Validations.ENTITY_STRUCTURE,
-    // Validations.CONTENT_V4,
-    // Validations.MUST_HAVE_FAILED_BEFORE,
-    // Validations.RATE_LIMIT
+    Validations.IPFS_HASHING,
+    Validations.METADATA_SCHEMA,
+    Validations.SIGNATURE,
+    Validations.ACCESS,
+    Validations.ENTITY_STRUCTURE,
+    Validations.CONTENT_V4,
+    Validations.REQUEST_SIZE_V4,
+    Validations.MUST_HAVE_FAILED_BEFORE
   ],
   // Note: there is no need for legacy entities anymore, so we won't allow then in v4
   [DeploymentContext.SYNCED_LEGACY_ENTITY]: [Validations.FAIL_ALWAYS],

--- a/content/src/storage/ContentStorage.ts
+++ b/content/src/storage/ContentStorage.ts
@@ -5,6 +5,7 @@ export interface ContentStorage {
   delete(ids: string[]): Promise<void>
   retrieve(id: string): Promise<ContentItem | undefined>
   exist(ids: string[]): Promise<Map<string, boolean>>
+  stats(id: string): Promise<{ size: number } | undefined>
 }
 
 export interface ContentItem {

--- a/content/src/storage/FileSystemContentStorage.ts
+++ b/content/src/storage/FileSystemContentStorage.ts
@@ -40,6 +40,15 @@ export class FileSystemContentStorage implements ContentStorage {
     return undefined
   }
 
+  async stats(id: string): Promise<{ size: number } | undefined> {
+    const filePath = this.getFilePath(id)
+    if (await existPath(filePath)) {
+      try {
+        return await fs.promises.stat(filePath)
+      } catch (e) {}
+    }
+  }
+
   async exist(ids: string[]): Promise<Map<string, boolean>> {
     const checks = await Promise.all(
       ids.map<Promise<[string, boolean]>>(async (id) => [id, await existPath(this.getFilePath(id))])

--- a/content/src/storage/S3ContentStorage.ts
+++ b/content/src/storage/S3ContentStorage.ts
@@ -102,6 +102,10 @@ export class S3ContentStorage implements ContentStorage {
     //     })
     // })
   }
+
+  stats(id: string): Promise<{ size: number } | undefined> {
+    throw new Error('Not implemented')
+  }
 }
 
 class S3ContentItem implements ContentItem {

--- a/content/test/unit/storage/MockedStorage.ts
+++ b/content/test/unit/storage/MockedStorage.ts
@@ -18,4 +18,8 @@ export class MockedStorage implements ContentStorage {
   exist(ids: string[]): Promise<Map<string, boolean>> {
     return Promise.resolve(new Map(ids.map((id) => [id, this.storage.has(id)])))
   }
+  stats(id: string): Promise<{ size: number } | undefined> {
+    const content = this.storage.get(id)
+    return Promise.resolve(content ? { size: content.byteLength } : undefined)
+  }
 }


### PR DESCRIPTION
## Description

Introduces entity v4 deployment size validation.
Takes into account all content files and not just the uploaded files in current deployment.

Resolves #198 