### PR TITLE
fix: check rate limit only for profiles

### DIFF
--- a/content/src/service/ServiceImpl.ts
+++ b/content/src/service/ServiceImpl.ts
@@ -333,6 +333,10 @@ export class ServiceImpl implements MetaverseContentService, ClusterDeploymentsS
   /** Check if the entity should be rate limit: no deployment has been made for the same pointer in the last ttl
    * and no more than max size of deployments were made either   */
   private isEntityRateLimited(entity: Entity): boolean {
+    // Currently only for profiles
+    if (entity.type != EntityType.PROFILE) {
+      return false
+    }
     return (
       entity.pointers.some((p) => !!this.deploymentsCache.cache.get(p)) ||
       this.deploymentsCache.cache.stats.keys > this.deploymentsCache.maxSize


### PR DESCRIPTION
We were only storing profiles, so this is not a functionality change, but it's a performance improvement.