### PR TITLE
feat: add wearables size validation with new limits

### DIFF
--- a/content/src/service/validations/Validations.ts
+++ b/content/src/service/validations/Validations.ts
@@ -25,7 +25,7 @@ export class Validations {
     if (!maxSizeInMB) {
       return [`Type ${entity.type} is not supported yet`]
     }
-    const maxSizeInBytes = maxSizeInMB * 1024 * 1024
+    const maxSizeInBytes = maxSizeInMB.max * 1024 * 1024
     let totalSize = 0
 
     deployment.files.forEach((file) => (totalSize += file.byteLength))
@@ -228,7 +228,7 @@ export class Validations {
     if (!maxSizeInMB) {
       return [`Type ${entity.type} is not supported yet`]
     }
-    const maxSizeInBytes = maxSizeInMB * 1024 * 1024
+    const maxSizeInBytes = maxSizeInMB.max * 1024 * 1024
 
     let totalSize = 0
 
@@ -246,10 +246,27 @@ export class Validations {
     const sizePerPointer = totalSize / entity.pointers.length
     if (sizePerPointer > maxSizeInBytes) {
       return [
-        `The deployment is too big. The maximum allowed size per pointer is ${maxSizeInMB} MB for ${
+        `The deployment is too big. The maximum allowed size per pointer is ${maxSizeInMB.max} MB for ${
           entity.type
         }. You can upload up to ${entity.pointers.length * maxSizeInBytes} bytes but you tried to upload ${totalSize}.`
       ]
+    }
+
+    if (entity.type === EntityType.WEARABLE) {
+      if (!maxSizeInMB.model) return [`Model size limit not defined for wearables`]
+      const wearableMetadata = entity.metadata as Wearable
+      const thumbnailHash = entity.content?.get(wearableMetadata.thumbnail)
+      if (thumbnailHash) {
+        const thumbnailSize = deployment.files.get(thumbnailHash)?.byteLength
+        const modelSize = maxSizeInMB.max * 1024 * 1024 - (thumbnailSize ?? 0)
+        if (modelSize > maxSizeInMB.model) {
+          return [
+            `The deployment is too big. The maximum allowed size for wearable model files is ${
+              maxSizeInMB.model
+            } MB. You can upload up to ${maxSizeInMB.model * 1024 * 1024} bytes but you tried to upload ${modelSize}.`
+          ]
+        }
+      }
     }
   }
 

--- a/content/src/service/validations/Validations.ts
+++ b/content/src/service/validations/Validations.ts
@@ -19,13 +19,14 @@ export class Validations {
   }
 
   /** Validate that the full request size is within limits */
-  static readonly REQUEST_SIZE_V3: Validation = ({ deployment, env }) => {
+  static readonly REQUEST_SIZE_V3: Validation = (args) => {
+    const { deployment, env } = args
     const { entity } = deployment
     const maxSizeInMB = env.maxUploadSizePerTypeInMB.get(entity.type)
     if (!maxSizeInMB) {
       return [`Type ${entity.type} is not supported yet`]
     }
-    const maxSizeInBytes = maxSizeInMB.total * 1024 * 1024
+    const maxSizeInBytes = maxSizeInMB * 1024 * 1024
     let totalSize = 0
 
     deployment.files.forEach((file) => (totalSize += file.byteLength))
@@ -37,7 +38,7 @@ export class Validations {
         }. You can upload up to ${entity.pointers.length * maxSizeInBytes} bytes but you tried to upload ${totalSize}.`
       ]
     }
-    return this.validateWearableSize(deployment, entity, maxSizeInMB)
+    return this.WEARABLE_SIZE(args)
   }
 
   /** Validate that the pointers are valid, and that the Ethereum address has write access to them */
@@ -205,6 +206,7 @@ export class Validations {
     return ['This deployment is invalid. What are you doing?']
   }
 
+  /** Validate entities metadata against its corresponding schema */
   static readonly METADATA_SCHEMA: Validation = async ({ deployment }) => {
     const validate = {
       [EntityType.PROFILE]: Profile.validate,
@@ -223,58 +225,31 @@ export class Validations {
     }
   }
 
+  /** Validate size of deployment result including previous deployments */
   static readonly REQUEST_SIZE_V4: Validation = async ({ deployment, env, externalCalls }) => {
     const { entity } = deployment
     const maxSizeInMB = env.maxUploadSizePerTypeInMB.get(entity.type)
     if (!maxSizeInMB) {
       return [`Type ${entity.type} is not supported yet`]
     }
-    const maxSizeInBytes = maxSizeInMB.total * 1024 * 1024
+    const maxSizeInBytes = maxSizeInMB * 1024 * 1024
 
     let totalSize = 0
 
-    for (const [, hash] of entity.content ?? []) {
-      const uploadedFile = deployment.files.get(hash)
-      if (uploadedFile) {
-        totalSize += uploadedFile.byteLength
-      } else {
-        const contentSize = await externalCalls.fetchContentFileSize(hash)
-        if (!contentSize) return [`Couldn't fetch content file with hash: ${hash}`]
-        totalSize += contentSize
-      }
+    try {
+      totalSize = await this.calculateDeploymentSize(deployment, externalCalls)
+    } catch (e) {
+      return [e.message ?? `Couldn't calculate deployment size`]
     }
 
     const sizePerPointer = totalSize / entity.pointers.length
     if (sizePerPointer > maxSizeInBytes) {
       return [
-        `The deployment is too big. The maximum allowed size per pointer is ${maxSizeInMB.total} MB for ${
+        `The deployment is too big. The maximum allowed size per pointer is ${maxSizeInMB} MB for ${
           entity.type
         }. You can upload up to ${entity.pointers.length * maxSizeInBytes} bytes but you tried to upload ${totalSize}.`
       ]
     }
-    return this.validateWearableSize(deployment, entity, maxSizeInMB)
-  }
-
-  private static readonly validateWearableSize = (
-    deployment: DeploymentToValidate,
-    entity: Entity,
-    maxSizeInMB: { total: number; model?: number }
-  ): undefined | string[] => {
-    if (entity.type !== EntityType.WEARABLE) return
-    if (!maxSizeInMB.model) return [`Model size limit not defined for wearables`]
-
-    const wearableMetadata = entity.metadata as Wearable
-    const thumbnailHash = entity.content?.get(wearableMetadata.thumbnail)
-    if (!thumbnailHash) return
-
-    const thumbnailSize = deployment.files.get(thumbnailHash)?.byteLength
-    const modelSize = maxSizeInMB.total * 1024 * 1024 - (thumbnailSize ?? 0)
-    if (modelSize > maxSizeInMB.model)
-      return [
-        `The deployment is too big. The maximum allowed size for wearable model files is ${
-          maxSizeInMB.model
-        } MB. You can upload up to ${maxSizeInMB.model * 1024 * 1024} bytes but you tried to upload ${modelSize}.`
-      ]
   }
 
   private static correspondsToASnapshot(fileName: string, hash: string, metadata: Profile) {
@@ -288,27 +263,83 @@ export class Validations {
     })
   }
 
-  static readonly WEARABLE_THUMBNAIL: Validation = async ({ deployment }) => {
-    // only validate wearables
-    if (deployment.entity.type !== EntityType.WEARABLE) return
+  private static async calculateDeploymentSize(
+    deployment: DeploymentToValidate,
+    externalCalls: ExternalCalls
+  ): Promise<number> {
+    let totalSize = 0
+    for (const [, hash] of deployment.entity.content ?? []) {
+      const uploadedFile = deployment.files.get(hash)
+      if (uploadedFile) {
+        totalSize += uploadedFile.byteLength
+      } else {
+        const contentSize = await externalCalls.fetchContentFileSize(hash)
+        if (!contentSize) throw new Error(`Couldn't fetch content file with hash: ${hash}`)
+        totalSize += contentSize
+      }
+    }
+    return totalSize
+  }
 
+  /** Validate that given wearable deployment includes a thumbnail with valid format and size */
+  static readonly WEARABLE_CUSTOM: Validation = async (args) => {
+    if (args.deployment.entity.type !== EntityType.WEARABLE) return
+
+    let errors: string[] = []
+    errors = [...((await this.WEARABLE_THUMBNAIL(args)) ?? []), ...((await this.WEARABLE_SIZE(args)) ?? [])]
+    return errors.length > 0 ? errors : undefined
+  }
+
+  static readonly WEARABLE_THUMBNAIL: Validation = async ({ deployment }) => {
     // read thumbnail field from metadata
     const metadata = deployment.entity.metadata as Wearable
 
     const hash = deployment.entity.content?.get(metadata.thumbnail)
     if (!hash) return [`Couldn't find hash for thumbnail file with name: ${metadata.thumbnail}`]
 
+    const errors: string[] = []
     // check size
     const thumbnailBuffer = deployment.files.get(hash)
     if (!thumbnailBuffer) return [`Couldn't find thumbnail file with hash: ${hash}`]
     try {
       const { width, height, format } = await sharp(thumbnailBuffer).metadata()
-      if (!width || !height) return [`Couldn't validate thumbnail size for file ${metadata.thumbnail}`]
-      if (!format || format !== 'png') return [`Invalid or unknown image format. Only 'PNG' format is accepted.`]
-      if (width !== DEFAULT_THUMBNAIL_SIZE || height !== DEFAULT_THUMBNAIL_SIZE)
-        return [`Invalid thumbnail image size (width = ${width} / height = ${height})`]
+      if (!format || format !== 'png') errors.push(`Invalid or unknown image format. Only 'PNG' format is accepted.`)
+      if (!width || !height) {
+        errors.push(`Couldn't validate thumbnail size for file ${metadata.thumbnail}`)
+      } else if (width !== DEFAULT_THUMBNAIL_SIZE || height !== DEFAULT_THUMBNAIL_SIZE) {
+        errors.push(`Invalid thumbnail image size (width = ${width} / height = ${height})`)
+      }
     } catch (e) {
       return [`Couldn't parse thumbnail, please check image format.`]
+    }
+    return errors.length > 0 ? errors : undefined
+  }
+
+  /** Validate wearable files size, excluding thumbnail, is less than expected */
+  static readonly WEARABLE_SIZE: Validation = async ({ deployment, env, externalCalls }) => {
+    const entity = deployment.entity
+    const maxSizeInMB = env.maxUploadSizePerTypeInMB.get(EntityType.WEARABLE)
+    if (!maxSizeInMB) return
+
+    // hardcoded value to be used just in this validation
+    const modelSizeInMB = 2
+
+    const wearableMetadata = entity.metadata as Wearable
+    const thumbnailHash = entity.content?.get(wearableMetadata.thumbnail)
+    if (!thumbnailHash) return
+
+    try {
+      const totalDeploymentSize = await this.calculateDeploymentSize(deployment, externalCalls)
+      const thumbnailSize = deployment.files.get(thumbnailHash)?.byteLength ?? 0
+      const modelSize = totalDeploymentSize - thumbnailSize
+      if (modelSize > modelSizeInMB * 1024 * 1024)
+        return [
+          `The deployment is too big. The maximum allowed size for wearable model files is 2 MB. You can upload up to ${
+            modelSizeInMB * 1024 * 1024
+          } bytes but you tried to upload ${modelSize}.`
+        ]
+    } catch (e) {
+      return [e.message ?? `Couldn't validate wearable size`]
     }
   }
 }

--- a/content/src/service/validations/Validations.ts
+++ b/content/src/service/validations/Validations.ts
@@ -25,7 +25,7 @@ export class Validations {
     if (!maxSizeInMB) {
       return [`Type ${entity.type} is not supported yet`]
     }
-    const maxSizeInBytes = maxSizeInMB.max * 1024 * 1024
+    const maxSizeInBytes = maxSizeInMB.total * 1024 * 1024
     let totalSize = 0
 
     deployment.files.forEach((file) => (totalSize += file.byteLength))
@@ -228,7 +228,7 @@ export class Validations {
     if (!maxSizeInMB) {
       return [`Type ${entity.type} is not supported yet`]
     }
-    const maxSizeInBytes = maxSizeInMB.max * 1024 * 1024
+    const maxSizeInBytes = maxSizeInMB.total * 1024 * 1024
 
     let totalSize = 0
 
@@ -246,7 +246,7 @@ export class Validations {
     const sizePerPointer = totalSize / entity.pointers.length
     if (sizePerPointer > maxSizeInBytes) {
       return [
-        `The deployment is too big. The maximum allowed size per pointer is ${maxSizeInMB.max} MB for ${
+        `The deployment is too big. The maximum allowed size per pointer is ${maxSizeInMB.total} MB for ${
           entity.type
         }. You can upload up to ${entity.pointers.length * maxSizeInBytes} bytes but you tried to upload ${totalSize}.`
       ]
@@ -258,7 +258,7 @@ export class Validations {
       const thumbnailHash = entity.content?.get(wearableMetadata.thumbnail)
       if (thumbnailHash) {
         const thumbnailSize = deployment.files.get(thumbnailHash)?.byteLength
-        const modelSize = maxSizeInMB.max * 1024 * 1024 - (thumbnailSize ?? 0)
+        const modelSize = maxSizeInMB.total * 1024 * 1024 - (thumbnailSize ?? 0)
         if (modelSize > maxSizeInMB.model) {
           return [
             `The deployment is too big. The maximum allowed size for wearable model files is ${

--- a/content/src/service/validations/Validator.ts
+++ b/content/src/service/validations/Validator.ts
@@ -68,7 +68,7 @@ export type ServerEnvironment = {
   accessChecker: AccessChecker
   authenticator: ContentAuthenticator
   requestTtlBackwards: number
-  maxUploadSizePerTypeInMB: Map<EntityType, { model?: number; max: number }>
+  maxUploadSizePerTypeInMB: Map<EntityType, { model?: number; total: number }>
 }
 
 export type ExternalCalls = {

--- a/content/src/service/validations/Validator.ts
+++ b/content/src/service/validations/Validator.ts
@@ -68,7 +68,7 @@ export type ServerEnvironment = {
   accessChecker: AccessChecker
   authenticator: ContentAuthenticator
   requestTtlBackwards: number
-  maxUploadSizePerTypeInMB: Map<EntityType, number>
+  maxUploadSizePerTypeInMB: Map<EntityType, { model?: number; max: number }>
 }
 
 export type ExternalCalls = {

--- a/content/src/service/validations/Validator.ts
+++ b/content/src/service/validations/Validator.ts
@@ -68,7 +68,7 @@ export type ServerEnvironment = {
   accessChecker: AccessChecker
   authenticator: ContentAuthenticator
   requestTtlBackwards: number
-  maxUploadSizePerTypeInMB: Map<EntityType, { model?: number; total: number }>
+  maxUploadSizePerTypeInMB: Map<EntityType, number>
 }
 
 export type ExternalCalls = {

--- a/content/src/service/validations/ValidatorFactory.ts
+++ b/content/src/service/validations/ValidatorFactory.ts
@@ -9,9 +9,9 @@ export class ValidatorFactory {
       authenticator: env.getBean(Bean.AUTHENTICATOR),
       requestTtlBackwards: env.getConfig(EnvironmentConfig.REQUEST_TTL_BACKWARDS),
       maxUploadSizePerTypeInMB: new Map([
-        [EntityType.SCENE, { max: 15 }],
-        [EntityType.PROFILE, { max: 15 }],
-        [EntityType.WEARABLE, { max: 3, model: 2 }]
+        [EntityType.SCENE, { total: 15 }],
+        [EntityType.PROFILE, { total: 15 }],
+        [EntityType.WEARABLE, { total: 3, model: 2 }]
       ])
     })
   }

--- a/content/src/service/validations/ValidatorFactory.ts
+++ b/content/src/service/validations/ValidatorFactory.ts
@@ -9,9 +9,9 @@ export class ValidatorFactory {
       authenticator: env.getBean(Bean.AUTHENTICATOR),
       requestTtlBackwards: env.getConfig(EnvironmentConfig.REQUEST_TTL_BACKWARDS),
       maxUploadSizePerTypeInMB: new Map([
-        [EntityType.SCENE, 15],
-        [EntityType.PROFILE, 15],
-        [EntityType.WEARABLE, 2]
+        [EntityType.SCENE, { max: 15 }],
+        [EntityType.PROFILE, { max: 15 }],
+        [EntityType.WEARABLE, { max: 3, model: 2 }]
       ])
     })
   }

--- a/content/src/service/validations/ValidatorFactory.ts
+++ b/content/src/service/validations/ValidatorFactory.ts
@@ -9,9 +9,9 @@ export class ValidatorFactory {
       authenticator: env.getBean(Bean.AUTHENTICATOR),
       requestTtlBackwards: env.getConfig(EnvironmentConfig.REQUEST_TTL_BACKWARDS),
       maxUploadSizePerTypeInMB: new Map([
-        [EntityType.SCENE, { total: 15 }],
-        [EntityType.PROFILE, { total: 15 }],
-        [EntityType.WEARABLE, { total: 3, model: 2 }]
+        [EntityType.SCENE, 15],
+        [EntityType.PROFILE, 15],
+        [EntityType.WEARABLE, 3]
       ])
     })
   }

--- a/content/src/service/validations/validations/ValidationsV4.ts
+++ b/content/src/service/validations/validations/ValidationsV4.ts
@@ -11,7 +11,7 @@ export const VALIDATIONS_V4: ValidationsForContext = {
     Validations.ENTITY_STRUCTURE,
     Validations.CONTENT_V4,
     Validations.REQUEST_SIZE_V4,
-    Validations.WEARABLE_THUMBNAIL,
+    Validations.WEARABLE_CUSTOM,
     Validations.NO_NEWER,
     Validations.RECENT,
     Validations.NO_REDEPLOYS
@@ -24,20 +24,20 @@ export const VALIDATIONS_V4: ValidationsForContext = {
     Validations.ENTITY_STRUCTURE,
     Validations.CONTENT_V4,
     Validations.REQUEST_SIZE_V4,
-    Validations.WEARABLE_THUMBNAIL
+    Validations.WEARABLE_CUSTOM
   ],
   // This is during synchronization when a deployment needs to  be done, but you already have a newer which overwrites it.
   // So, at this moment the files from the entity of the overwritten deployment are not download.
   [DeploymentContext.OVERWRITTEN]: [
     Validations.IPFS_HASHING,
-    Validations.REQUEST_SIZE_V4,
     Validations.METADATA_SCHEMA,
-    Validations.WEARABLE_THUMBNAIL,
+    Validations.REQUEST_SIZE_V4,
     Validations.SIGNATURE,
     Validations.ACCESS,
     Validations.ENTITY_STRUCTURE
   ],
   [DeploymentContext.FIX_ATTEMPT]: [
+    Validations.MUST_HAVE_FAILED_BEFORE,
     Validations.IPFS_HASHING,
     Validations.METADATA_SCHEMA,
     Validations.SIGNATURE,
@@ -45,8 +45,7 @@ export const VALIDATIONS_V4: ValidationsForContext = {
     Validations.ENTITY_STRUCTURE,
     Validations.CONTENT_V4,
     Validations.REQUEST_SIZE_V4,
-    Validations.WEARABLE_THUMBNAIL,
-    Validations.MUST_HAVE_FAILED_BEFORE
+    Validations.WEARABLE_CUSTOM
   ],
   // Note: there is no need for legacy entities anymore, so we won't allow then in v4
   [DeploymentContext.SYNCED_LEGACY_ENTITY]: [Validations.FAIL_ALWAYS],

--- a/content/test/unit/service/validations/Validations.spec.ts
+++ b/content/test/unit/service/validations/Validations.spec.ts
@@ -571,7 +571,7 @@ describe('Validations', function () {
       const entity = buildEntity()
       const args = buildArgs({
         deployment: { entity, files: getFileWithSize(3) },
-        env: { maxUploadSizePerTypeInMB: new Map([[EntityType.SCENE, { max: 2 }]]) }
+        env: { maxUploadSizePerTypeInMB: new Map([[EntityType.SCENE, { total: 2 }]]) }
       })
 
       const result = Validations.REQUEST_SIZE_V3(args)
@@ -586,7 +586,7 @@ describe('Validations', function () {
       const entity = buildEntity({ pointers: ['P1', 'P2'] })
       const args = buildArgs({
         deployment: { entity, files: getFileWithSize(3) },
-        env: { maxUploadSizePerTypeInMB: new Map([[EntityType.SCENE, { max: 2 }]]) }
+        env: { maxUploadSizePerTypeInMB: new Map([[EntityType.SCENE, { total: 2 }]]) }
       })
 
       const result = Validations.REQUEST_SIZE_V3(args)
@@ -602,7 +602,7 @@ describe('Validations', function () {
       const entity = buildEntity({ content })
       const args = buildArgs({
         deployment: { entity, files: getFileWithSize(3, 'C') },
-        env: { maxUploadSizePerTypeInMB: new Map([[EntityType.SCENE, { max: 2 }]]) }
+        env: { maxUploadSizePerTypeInMB: new Map([[EntityType.SCENE, { total: 2 }]]) }
       })
 
       const result = Validations.REQUEST_SIZE_V4(args)
@@ -627,7 +627,7 @@ describe('Validations', function () {
       const entity = buildEntity({ content })
       const args = buildArgs({
         deployment: { entity, files: getFileWithSize(3, 'C') },
-        env: { maxUploadSizePerTypeInMB: new Map([[EntityType.SCENE, { max: 10 }]]) },
+        env: { maxUploadSizePerTypeInMB: new Map([[EntityType.SCENE, { total: 10 }]]) },
         externalCalls: {
           fetchContentFileSize: (hash) => Promise.resolve(contentSizes.get(hash))
         }
@@ -650,7 +650,7 @@ describe('Validations', function () {
       const entity = buildEntity({ content })
       const args = buildArgs({
         deployment: { entity, files: getFileWithSize(3, 'C') },
-        env: { maxUploadSizePerTypeInMB: new Map([[EntityType.SCENE, { max: 10 }]]) },
+        env: { maxUploadSizePerTypeInMB: new Map([[EntityType.SCENE, { total: 10 }]]) },
         externalCalls: {
           fetchContentFileSize: () => Promise.resolve(undefined)
         }
@@ -668,7 +668,7 @@ describe('Validations', function () {
       const entity = buildEntity({ pointers: ['P1', 'P2'], content: new Map([]) })
       const args = buildArgs({
         deployment: { entity, files: getFileWithSize(3) },
-        env: { maxUploadSizePerTypeInMB: new Map([[EntityType.SCENE, { max: 2 }]]) }
+        env: { maxUploadSizePerTypeInMB: new Map([[EntityType.SCENE, { total: 2 }]]) }
       })
 
       const result = Validations.REQUEST_SIZE_V4(args)
@@ -691,7 +691,7 @@ describe('Validations', function () {
       const entity = { ...buildEntityV4(EntityType.WEARABLE, { thumbnail: 'thumbnail.png' }), content }
       const args = buildArgs({
         deployment: { entity, files },
-        env: { maxUploadSizePerTypeInMB: new Map([[EntityType.WEARABLE, { max: 3, model: 2 }]]) }
+        env: { maxUploadSizePerTypeInMB: new Map([[EntityType.WEARABLE, { total: 3, model: 2 }]]) }
       })
 
       const result = Validations.REQUEST_SIZE_V4(args)
@@ -719,7 +719,7 @@ describe('Validations', function () {
       const entity = { ...buildEntityV4(EntityType.WEARABLE, { thumbnail: 'thumbnail.png' }), content }
       const args = buildArgs({
         deployment: { entity, files },
-        env: { maxUploadSizePerTypeInMB: new Map([[EntityType.WEARABLE, { max: 3, model: 2 }]]) }
+        env: { maxUploadSizePerTypeInMB: new Map([[EntityType.WEARABLE, { total: 3, model: 2 }]]) }
       })
 
       const result = Validations.REQUEST_SIZE_V4(args)

--- a/content/test/unit/service/validations/Validations.spec.ts
+++ b/content/test/unit/service/validations/Validations.spec.ts
@@ -571,7 +571,7 @@ describe('Validations', function () {
       const entity = buildEntity()
       const args = buildArgs({
         deployment: { entity, files: getFileWithSize(3) },
-        env: { maxUploadSizePerTypeInMB: new Map([[EntityType.SCENE, 2]]) }
+        env: { maxUploadSizePerTypeInMB: new Map([[EntityType.SCENE, { max: 2 }]]) }
       })
 
       const result = Validations.REQUEST_SIZE_V3(args)
@@ -586,7 +586,7 @@ describe('Validations', function () {
       const entity = buildEntity({ pointers: ['P1', 'P2'] })
       const args = buildArgs({
         deployment: { entity, files: getFileWithSize(3) },
-        env: { maxUploadSizePerTypeInMB: new Map([[EntityType.SCENE, 2]]) }
+        env: { maxUploadSizePerTypeInMB: new Map([[EntityType.SCENE, { max: 2 }]]) }
       })
 
       const result = Validations.REQUEST_SIZE_V3(args)
@@ -602,7 +602,7 @@ describe('Validations', function () {
       const entity = buildEntity({ content })
       const args = buildArgs({
         deployment: { entity, files: getFileWithSize(3, 'C') },
-        env: { maxUploadSizePerTypeInMB: new Map([[EntityType.SCENE, 2]]) }
+        env: { maxUploadSizePerTypeInMB: new Map([[EntityType.SCENE, { max: 2 }]]) }
       })
 
       const result = Validations.REQUEST_SIZE_V4(args)
@@ -627,7 +627,7 @@ describe('Validations', function () {
       const entity = buildEntity({ content })
       const args = buildArgs({
         deployment: { entity, files: getFileWithSize(3, 'C') },
-        env: { maxUploadSizePerTypeInMB: new Map([[EntityType.SCENE, 10]]) },
+        env: { maxUploadSizePerTypeInMB: new Map([[EntityType.SCENE, { max: 10 }]]) },
         externalCalls: {
           fetchContentFileSize: (hash) => Promise.resolve(contentSizes.get(hash))
         }
@@ -650,7 +650,7 @@ describe('Validations', function () {
       const entity = buildEntity({ content })
       const args = buildArgs({
         deployment: { entity, files: getFileWithSize(3, 'C') },
-        env: { maxUploadSizePerTypeInMB: new Map([[EntityType.SCENE, 10]]) },
+        env: { maxUploadSizePerTypeInMB: new Map([[EntityType.SCENE, { max: 10 }]]) },
         externalCalls: {
           fetchContentFileSize: () => Promise.resolve(undefined)
         }
@@ -668,12 +668,66 @@ describe('Validations', function () {
       const entity = buildEntity({ pointers: ['P1', 'P2'], content: new Map([]) })
       const args = buildArgs({
         deployment: { entity, files: getFileWithSize(3) },
-        env: { maxUploadSizePerTypeInMB: new Map([[EntityType.SCENE, 2]]) }
+        env: { maxUploadSizePerTypeInMB: new Map([[EntityType.SCENE, { max: 2 }]]) }
       })
 
       const result = Validations.REQUEST_SIZE_V4(args)
 
       await assertNoErrors(result)
+    })
+
+    it(`when a wearable is deployed and model is too big, then it fails`, async () => {
+      const withSize = (size: number) => Buffer.alloc(size * 1024 * 1024)
+      const content = new Map([
+        ['A', 'A'],
+        ['C', 'C'],
+        ['thumbnail.png', 'thumbnail']
+      ])
+      const files = new Map([
+        ['A', withSize(1)],
+        ['C', withSize(1.5)],
+        ['thumbnail', Buffer.alloc(1)]
+      ])
+      const entity = { ...buildEntityV4(EntityType.WEARABLE, { thumbnail: 'thumbnail.png' }), content }
+      const args = buildArgs({
+        deployment: { entity, files },
+        env: { maxUploadSizePerTypeInMB: new Map([[EntityType.WEARABLE, { max: 3, model: 2 }]]) }
+      })
+
+      const result = Validations.REQUEST_SIZE_V4(args)
+
+      const actualErrors = await result
+      expect(actualErrors).toBeDefined()
+      expect(actualErrors?.length).toBe(1)
+      expect(actualErrors?.[0]).toMatch(
+        'The deployment is too big. The maximum allowed size for wearable model files *'
+      )
+    })
+
+    it(`when a wearable is deployed and thumbnail is too big, then it fails`, async () => {
+      const withSize = (size: number) => Buffer.alloc(size * 1024 * 1024)
+      const content = new Map([
+        ['A', 'A'],
+        ['C', 'C'],
+        ['thumbnail.png', 'thumbnail']
+      ])
+      const files = new Map([
+        ['A', withSize(1)],
+        ['C', withSize(1)],
+        ['thumbnail', withSize(2)]
+      ])
+      const entity = { ...buildEntityV4(EntityType.WEARABLE, { thumbnail: 'thumbnail.png' }), content }
+      const args = buildArgs({
+        deployment: { entity, files },
+        env: { maxUploadSizePerTypeInMB: new Map([[EntityType.WEARABLE, { max: 3, model: 2 }]]) }
+      })
+
+      const result = Validations.REQUEST_SIZE_V4(args)
+
+      const actualErrors = await result
+      expect(actualErrors).toBeDefined()
+      expect(actualErrors?.length).toBe(1)
+      expect(actualErrors?.[0]).toMatch('The deployment is too big. The maximum allowed size per pointer is *')
     })
   })
 

--- a/content/test/unit/service/validations/Validations.spec.ts
+++ b/content/test/unit/service/validations/Validations.spec.ts
@@ -571,7 +571,7 @@ describe('Validations', function () {
       const entity = buildEntity()
       const args = buildArgs({
         deployment: { entity, files: getFileWithSize(3) },
-        env: { maxUploadSizePerTypeInMB: new Map([[EntityType.SCENE, { total: 2 }]]) }
+        env: { maxUploadSizePerTypeInMB: new Map([[EntityType.SCENE, 2]]) }
       })
 
       const result = Validations.REQUEST_SIZE_V3(args)
@@ -586,7 +586,7 @@ describe('Validations', function () {
       const entity = buildEntity({ pointers: ['P1', 'P2'] })
       const args = buildArgs({
         deployment: { entity, files: getFileWithSize(3) },
-        env: { maxUploadSizePerTypeInMB: new Map([[EntityType.SCENE, { total: 2 }]]) }
+        env: { maxUploadSizePerTypeInMB: new Map([[EntityType.SCENE, 2]]) }
       })
 
       const result = Validations.REQUEST_SIZE_V3(args)
@@ -602,7 +602,7 @@ describe('Validations', function () {
       const entity = buildEntity({ content })
       const args = buildArgs({
         deployment: { entity, files: getFileWithSize(3, 'C') },
-        env: { maxUploadSizePerTypeInMB: new Map([[EntityType.SCENE, { total: 2 }]]) }
+        env: { maxUploadSizePerTypeInMB: new Map([[EntityType.SCENE, 2]]) }
       })
 
       const result = Validations.REQUEST_SIZE_V4(args)
@@ -627,7 +627,7 @@ describe('Validations', function () {
       const entity = buildEntity({ content })
       const args = buildArgs({
         deployment: { entity, files: getFileWithSize(3, 'C') },
-        env: { maxUploadSizePerTypeInMB: new Map([[EntityType.SCENE, { total: 10 }]]) },
+        env: { maxUploadSizePerTypeInMB: new Map([[EntityType.SCENE, 10]]) },
         externalCalls: {
           fetchContentFileSize: (hash) => Promise.resolve(contentSizes.get(hash))
         }
@@ -650,7 +650,7 @@ describe('Validations', function () {
       const entity = buildEntity({ content })
       const args = buildArgs({
         deployment: { entity, files: getFileWithSize(3, 'C') },
-        env: { maxUploadSizePerTypeInMB: new Map([[EntityType.SCENE, { total: 10 }]]) },
+        env: { maxUploadSizePerTypeInMB: new Map([[EntityType.SCENE, 10]]) },
         externalCalls: {
           fetchContentFileSize: () => Promise.resolve(undefined)
         }
@@ -668,66 +668,12 @@ describe('Validations', function () {
       const entity = buildEntity({ pointers: ['P1', 'P2'], content: new Map([]) })
       const args = buildArgs({
         deployment: { entity, files: getFileWithSize(3) },
-        env: { maxUploadSizePerTypeInMB: new Map([[EntityType.SCENE, { total: 2 }]]) }
+        env: { maxUploadSizePerTypeInMB: new Map([[EntityType.SCENE, 2]]) }
       })
 
       const result = Validations.REQUEST_SIZE_V4(args)
 
       await assertNoErrors(result)
-    })
-
-    it(`when a wearable is deployed and model is too big, then it fails`, async () => {
-      const withSize = (size: number) => Buffer.alloc(size * 1024 * 1024)
-      const content = new Map([
-        ['A', 'A'],
-        ['C', 'C'],
-        ['thumbnail.png', 'thumbnail']
-      ])
-      const files = new Map([
-        ['A', withSize(1)],
-        ['C', withSize(1.5)],
-        ['thumbnail', Buffer.alloc(1)]
-      ])
-      const entity = { ...buildEntityV4(EntityType.WEARABLE, { thumbnail: 'thumbnail.png' }), content }
-      const args = buildArgs({
-        deployment: { entity, files },
-        env: { maxUploadSizePerTypeInMB: new Map([[EntityType.WEARABLE, { total: 3, model: 2 }]]) }
-      })
-
-      const result = Validations.REQUEST_SIZE_V4(args)
-
-      const actualErrors = await result
-      expect(actualErrors).toBeDefined()
-      expect(actualErrors?.length).toBe(1)
-      expect(actualErrors?.[0]).toMatch(
-        'The deployment is too big. The maximum allowed size for wearable model files *'
-      )
-    })
-
-    it(`when a wearable is deployed and thumbnail is too big, then it fails`, async () => {
-      const withSize = (size: number) => Buffer.alloc(size * 1024 * 1024)
-      const content = new Map([
-        ['A', 'A'],
-        ['C', 'C'],
-        ['thumbnail.png', 'thumbnail']
-      ])
-      const files = new Map([
-        ['A', withSize(1)],
-        ['C', withSize(1)],
-        ['thumbnail', withSize(2)]
-      ])
-      const entity = { ...buildEntityV4(EntityType.WEARABLE, { thumbnail: 'thumbnail.png' }), content }
-      const args = buildArgs({
-        deployment: { entity, files },
-        env: { maxUploadSizePerTypeInMB: new Map([[EntityType.WEARABLE, { total: 3, model: 2 }]]) }
-      })
-
-      const result = Validations.REQUEST_SIZE_V4(args)
-
-      const actualErrors = await result
-      expect(actualErrors).toBeDefined()
-      expect(actualErrors?.length).toBe(1)
-      expect(actualErrors?.[0]).toMatch('The deployment is too big. The maximum allowed size per pointer is *')
     })
   })
 
@@ -834,7 +780,7 @@ describe('Validations', function () {
     })
   })
 
-  describe('Wearable Thumbnail:', () => {
+  describe('Wearable custom validation: ', () => {
     let validThumbnailBuffer: Buffer
     let invalidThumbnailBuffer: Buffer
     const fileName = 'thumbnail.png'
@@ -860,67 +806,147 @@ describe('Validations', function () {
       invalidThumbnailBuffer = await createImage(1)
     })
 
-    it('when there is no hash for given thumbnail file name, it should return an error', async () => {
-      const content = new Map<string, string>([])
-      const files = new Map([[hash, validThumbnailBuffer]])
-      const entity = { ...buildEntityV4(EntityType.WEARABLE, wearable), content }
-      const args = buildArgs({ deployment: { entity, files } })
+    describe('Thumbnail:', () => {
+      it('when there is no hash for given thumbnail file name, it should return an error', async () => {
+        const content = new Map<string, string>([])
+        const files = new Map([[hash, validThumbnailBuffer]])
+        const entity = { ...buildEntityV4(EntityType.WEARABLE, wearable), content }
+        const args = buildArgs({ deployment: { entity, files } })
 
-      const result = Validations.WEARABLE_THUMBNAIL(args)
-      await assertErrorsWere(result, `Couldn't find hash for thumbnail file with name: ${fileName}`)
+        const result = Validations.WEARABLE_THUMBNAIL(args)
+        await assertErrorsWere(result, `Couldn't find hash for thumbnail file with name: ${fileName}`)
+      })
+
+      it('when there is no file for given thumbnail file hash, it should return an error', async () => {
+        const content = new Map<string, string>([[fileName, hash]])
+        const files = new Map([['notSame' + hash, validThumbnailBuffer]])
+        const entity = { ...buildEntityV4(EntityType.WEARABLE, wearable), content }
+        const args = buildArgs({ deployment: { entity, files } })
+
+        const result = Validations.WEARABLE_THUMBNAIL(args)
+        await assertErrorsWere(result, `Couldn't find thumbnail file with hash: ${hash}`)
+      })
+
+      it('when thumbnail image format is not valid, it should return an error', async () => {
+        const content = new Map<string, string>([[fileName, hash]])
+        const files = new Map([[hash, Buffer.alloc(1)]])
+        const entity = { ...buildEntityV4(EntityType.WEARABLE, wearable), content }
+        const args = buildArgs({ deployment: { entity, files } })
+
+        const result = Validations.WEARABLE_THUMBNAIL(args)
+        await assertErrorsWere(result, `Couldn't parse thumbnail, please check image format.`)
+      })
+
+      it('when thumbnail image size is invalid, it should return an error', async () => {
+        const content = new Map<string, string>([[fileName, hash]])
+        const files = new Map([[hash, invalidThumbnailBuffer]])
+        const entity = { ...buildEntityV4(EntityType.WEARABLE, wearable), content }
+        const args = buildArgs({ deployment: { entity, files } })
+
+        const result = Validations.WEARABLE_THUMBNAIL(args)
+        await assertErrorsWere(result, `Invalid thumbnail image size (width = 1 / height = 1)`)
+      })
+
+      it('when thumbnail image format is not png, it should return an error', async () => {
+        const jpgImage = await createImage(DEFAULT_THUMBNAIL_SIZE, 'jpg')
+        const content = new Map<string, string>([[fileName, hash]])
+        const files = new Map([[hash, jpgImage]])
+        const entity = { ...buildEntityV4(EntityType.WEARABLE, wearable), content }
+        const args = buildArgs({ deployment: { entity, files } })
+
+        const result = Validations.WEARABLE_THUMBNAIL(args)
+
+        await assertErrorsWere(result, `Invalid or unknown image format. Only 'PNG' format is accepted.`)
+      })
+
+      it('when thumbnail image size is valid, should not return any error', async () => {
+        const content = new Map<string, string>([[fileName, hash]])
+        const files = new Map([[hash, validThumbnailBuffer]])
+        const entity = { ...buildEntityV4(EntityType.WEARABLE, wearable), content }
+        const args = buildArgs({ deployment: { entity, files } })
+
+        const result = Validations.WEARABLE_THUMBNAIL(args)
+
+        await assertNoErrors(result)
+      })
     })
 
-    it('when there is no file for given thumbnail file hash, it should return an error', async () => {
-      const content = new Map<string, string>([[fileName, hash]])
-      const files = new Map([['notSame' + hash, validThumbnailBuffer]])
-      const entity = { ...buildEntityV4(EntityType.WEARABLE, wearable), content }
-      const args = buildArgs({ deployment: { entity, files } })
+    describe('Size:', () => {
+      it(`when a wearable is deployed and model is too big, then it fails`, async () => {
+        const withSize = (size: number) => Buffer.alloc(size * 1024 * 1024)
+        const content = new Map([
+          ['A', 'A'],
+          ['C', 'C'],
+          ['thumbnail.png', 'thumbnail']
+        ])
+        const files = new Map([
+          ['A', withSize(1)],
+          ['C', withSize(1.5)],
+          ['thumbnail', Buffer.alloc(1)]
+        ])
+        const entity = { ...buildEntityV4(EntityType.WEARABLE, { thumbnail: 'thumbnail.png' }), content }
+        const args = buildArgs({
+          deployment: { entity, files },
+          env: { maxUploadSizePerTypeInMB: new Map([[EntityType.WEARABLE, 3]]) }
+        })
 
-      const result = Validations.WEARABLE_THUMBNAIL(args)
-      await assertErrorsWere(result, `Couldn't find thumbnail file with hash: ${hash}`)
-    })
+        const result = Validations.WEARABLE_SIZE(args)
 
-    it('when thumbnail image format is not valid, it should return an error', async () => {
-      const content = new Map<string, string>([[fileName, hash]])
-      const files = new Map([[hash, Buffer.alloc(1)]])
-      const entity = { ...buildEntityV4(EntityType.WEARABLE, wearable), content }
-      const args = buildArgs({ deployment: { entity, files } })
+        const actualErrors = await result
+        expect(actualErrors).toBeDefined()
+        expect(actualErrors?.length).toBe(1)
+        expect(actualErrors?.[0]).toMatch(
+          'The deployment is too big. The maximum allowed size for wearable model files *'
+        )
+      })
 
-      const result = Validations.WEARABLE_THUMBNAIL(args)
-      await assertErrorsWere(result, `Couldn't parse thumbnail, please check image format.`)
-    })
+      it(`when a wearable is deployed and thumbnail is too big, then it fails`, async () => {
+        const withSize = (size: number) => Buffer.alloc(size * 1024 * 1024)
+        const content = new Map([
+          ['A', 'A'],
+          ['C', 'C'],
+          ['thumbnail.png', 'thumbnail']
+        ])
+        const files = new Map([
+          ['A', withSize(1)],
+          ['C', withSize(1)],
+          ['thumbnail', withSize(2)]
+        ])
+        const entity = { ...buildEntityV4(EntityType.WEARABLE, { thumbnail: 'thumbnail.png' }), content }
+        const args = buildArgs({
+          deployment: { entity, files },
+          env: { maxUploadSizePerTypeInMB: new Map([[EntityType.WEARABLE, 3]]) }
+        })
 
-    it('when thumbnail image size is invalid, it should return an error', async () => {
-      const content = new Map<string, string>([[fileName, hash]])
-      const files = new Map([[hash, invalidThumbnailBuffer]])
-      const entity = { ...buildEntityV4(EntityType.WEARABLE, wearable), content }
-      const args = buildArgs({ deployment: { entity, files } })
+        const result = Validations.REQUEST_SIZE_V4(args)
 
-      const result = Validations.WEARABLE_THUMBNAIL(args)
-      await assertErrorsWere(result, `Invalid thumbnail image size (width = 1 / height = 1)`)
-    })
+        const actualErrors = await result
+        expect(actualErrors).toBeDefined()
+        expect(actualErrors?.length).toBe(1)
+        expect(actualErrors?.[0]).toMatch('The deployment is too big. *')
+      })
 
-    it('when thumbnail image format is not png, it should return an error', async () => {
-      const jpgImage = await createImage(DEFAULT_THUMBNAIL_SIZE, 'jpg')
-      const content = new Map<string, string>([[fileName, hash]])
-      const files = new Map([[hash, jpgImage]])
-      const entity = { ...buildEntityV4(EntityType.WEARABLE, wearable), content }
-      const args = buildArgs({ deployment: { entity, files } })
+      it(`when a wearable is deployed and sizes are correct, then it is ok`, async () => {
+        const withSize = (sizeInMB: number) => Buffer.alloc(sizeInMB * 1024 * 1024)
+        const content = new Map([
+          ['A', 'A'],
+          ['C', 'C'],
+          ['thumbnail.png', 'thumbnail']
+        ])
+        const files = new Map([
+          ['A', withSize(1)],
+          ['C', withSize(1)],
+          ['thumbnail', withSize(0.9)]
+        ])
+        const entity = { ...buildEntityV4(EntityType.WEARABLE, { thumbnail: 'thumbnail.png' }), content }
+        const args = buildArgs({
+          deployment: { entity, files },
+          env: { maxUploadSizePerTypeInMB: new Map([[EntityType.WEARABLE, 3]]) }
+        })
 
-      const result = Validations.WEARABLE_THUMBNAIL(args)
-
-      await assertErrorsWere(result, `Invalid or unknown image format. Only 'PNG' format is accepted.`)
-    })
-
-    it('when thumbnail image size is valid, should not return any error', async () => {
-      const content = new Map<string, string>([[fileName, hash]])
-      const files = new Map([[hash, validThumbnailBuffer]])
-      const entity = { ...buildEntityV4(EntityType.WEARABLE, wearable), content }
-      const args = buildArgs({ deployment: { entity, files } })
-
-      const result = Validations.WEARABLE_THUMBNAIL(args)
-
-      await assertNoErrors(result)
+        const result = Validations.WEARABLE_SIZE(args)
+        await assertNoErrors(result)
+      })
     })
   })
 })


### PR DESCRIPTION
# Description

- Increase total size limit for wearables to 3 MB.
- Set model size limit for wearables to 2MB (without taking into account the thumbnail image).