### PR TITLE
feat: fetch third party integrations from subgraph endpoint

### DIFF
--- a/lambdas/src/Environment.ts
+++ b/lambdas/src/Environment.ts
@@ -22,6 +22,10 @@ export const DEFAULT_COLLECTIONS_SUBGRAPH_MATIC_MUMBAI =
   'https://api.thegraph.com/subgraphs/name/decentraland/collections-matic-mumbai'
 export const DEFAULT_COLLECTIONS_SUBGRAPH_MATIC_MAINNET =
   'https://api.thegraph.com/subgraphs/name/decentraland/collections-matic-mainnet'
+export const DEFAULT_THIRD_PARTY_REGISTRY_SUBGRAPH_MATIC_MUMBAI =
+  'https://api.thegraph.com/subgraphs/name/decentraland/tpr-matic-mumbai'
+export const DEFAULT_THIRD_PARTY_REGISTRY_SUBGRAPH_MATIC_MAINNET =
+  'https://api.thegraph.com/subgraphs/name/decentraland/tpr-matic-mainnet'
 
 const DEFAULT_MAX_SYNCHRONIZATION_TIME = '15m'
 const DEFAULT_MAX_DEPLOYMENT_OBTENTION_TIME = '3s'
@@ -81,6 +85,7 @@ export const enum EnvironmentConfig {
   ENS_OWNER_PROVIDER_URL,
   COLLECTIONS_L1_SUBGRAPH_URL,
   COLLECTIONS_L2_SUBGRAPH_URL,
+  THIRD_PARTY_REGISTRY_SUBGRAPH_URL,
   COMMIT_HASH,
   CATALYST_VERSION,
   USE_COMPRESSION_MIDDLEWARE,
@@ -167,6 +172,16 @@ export class EnvironmentBuilder {
         (process.env.ETH_NETWORK === 'mainnet'
           ? DEFAULT_COLLECTIONS_SUBGRAPH_MATIC_MAINNET
           : DEFAULT_COLLECTIONS_SUBGRAPH_MATIC_MUMBAI)
+    )
+
+    this.registerConfigIfNotAlreadySet(
+      env,
+      EnvironmentConfig.THIRD_PARTY_REGISTRY_SUBGRAPH_URL,
+      () =>
+        process.env.THIRD_PARTY_SUBGRAPH_URL ??
+        (process.env.ETH_NETWORK === 'mainnet'
+          ? DEFAULT_THIRD_PARTY_REGISTRY_SUBGRAPH_MATIC_MAINNET
+          : DEFAULT_THIRD_PARTY_REGISTRY_SUBGRAPH_MATIC_MUMBAI)
     )
 
     this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.COMMIT_HASH, () => process.env.COMMIT_HASH ?? 'Unknown')

--- a/lambdas/src/Server.ts
+++ b/lambdas/src/Server.ts
@@ -1,5 +1,5 @@
-import { initializeMetricsServer } from '@dcl/catalyst-node-commons'
 import { LAMBDAS_API } from '@dcl/catalyst-api-specs'
+import { initializeMetricsServer } from '@dcl/catalyst-node-commons'
 import compression from 'compression'
 import cors from 'cors'
 import express from 'express'
@@ -18,6 +18,7 @@ import { EnsOwnership } from './apis/profiles/EnsOwnership'
 import { initializeIndividualProfileRoutes, initializeProfilesRoutes } from './apis/profiles/routes'
 import { WearablesOwnership } from './apis/profiles/WearablesOwnership'
 import statusRouter from './apis/status/routes'
+import { initializeThirdPartyIntegrationsRoutes } from './apis/third-party/routes'
 import { Bean, Environment, EnvironmentConfig } from './Environment'
 import { metricsComponent } from './metrics'
 import { SmartContentClient } from './utils/SmartContentClient'
@@ -120,6 +121,8 @@ export class Server {
 
     // Functionality for Explore use case
     this.app.use('/explore', initializeExploreRoutes(express.Router(), env.getBean(Bean.DAO), contentClient))
+
+    this.app.use('/third-party-integrations', initializeThirdPartyIntegrationsRoutes(theGraphClient, express.Router()))
   }
 
   async start(): Promise<void> {

--- a/lambdas/src/apis/collections/types.ts
+++ b/lambdas/src/apis/collections/types.ts
@@ -75,3 +75,8 @@ export type ERC721StandardTrait = {
   trait_type: string
   value: string
 }
+
+export type ThirdPartyIntegration = {
+  urn: string
+  description: string
+}

--- a/lambdas/src/apis/third-party/controllers/third-party.ts
+++ b/lambdas/src/apis/third-party/controllers/third-party.ts
@@ -1,0 +1,22 @@
+import { Response } from 'express'
+import { TheGraphClient } from '../../../utils/TheGraphClient'
+import { TimeRefreshedDataHolder } from '../../../utils/TimeRefreshedDataHolder'
+import { ThirdPartyIntegration } from '../../collections/types'
+
+let thirdPartyIntegrationsCache: TimeRefreshedDataHolder<ThirdPartyIntegration[]>
+
+export function initCache(theGraphClient: TheGraphClient): void {
+  thirdPartyIntegrationsCache = new TimeRefreshedDataHolder(() => fetchThirdPartyIntegrations(theGraphClient), '1m')
+}
+
+export async function retrieveThirdPartyIntegrations(res: Response): Promise<void> {
+  const thirdPartyIntegrations = await thirdPartyIntegrationsCache.get()
+  const lastUpdate = thirdPartyIntegrationsCache.lastUpdate()
+
+  res.setHeader('Last-Modified', lastUpdate.toUTCString())
+  res.status(200).send({ data: thirdPartyIntegrations })
+}
+
+async function fetchThirdPartyIntegrations(theGraphClient: TheGraphClient): Promise<ThirdPartyIntegration[]> {
+  return await theGraphClient.getThirdPartyIntegrations()
+}

--- a/lambdas/src/apis/third-party/routes.ts
+++ b/lambdas/src/apis/third-party/routes.ts
@@ -1,0 +1,8 @@
+import { Router } from 'express'
+import { TheGraphClient } from '../../utils/TheGraphClient'
+import { initCache, retrieveThirdPartyIntegrations } from './controllers/third-party'
+
+export function initializeThirdPartyIntegrationsRoutes(theGraphClient: TheGraphClient, router: Router): Router {
+  initCache(theGraphClient)
+  return router.get('/', (_, res) => retrieveThirdPartyIntegrations(res))
+}

--- a/lambdas/src/utils/TheGraphClient.ts
+++ b/lambdas/src/utils/TheGraphClient.ts
@@ -2,7 +2,7 @@ import { parseUrn } from '@dcl/urn-resolver'
 import { Fetcher } from 'dcl-catalyst-commons'
 import { EthAddress } from 'dcl-crypto'
 import log4js from 'log4js'
-import { WearableId, WearablesFilters } from '../apis/collections/types'
+import { ThirdPartyIntegration, WearableId, WearablesFilters } from '../apis/collections/types'
 
 export class TheGraphClient {
   public static readonly MAX_PAGE_SIZE = 1000
@@ -119,6 +119,23 @@ export class TheGraphClient {
       TheGraphClient.LOGGER.error(error)
       return []
     }
+  }
+
+  /**
+   * This method returns the list of third party integrations as well as collections
+   */
+  public async getThirdPartyIntegrations(): Promise<ThirdPartyIntegration[]> {
+    const query: Query<
+      { thirdParties: { id: string; metadata: { thirdParty: { description: string } } }[] },
+      ThirdPartyIntegration[]
+    > = {
+      description: 'fetch third parties',
+      subgraph: 'thirdPartyRegistrySubgraph',
+      query: QUERY_THIRD_PARTIES,
+      mapper: (response) =>
+        response.thirdParties.map((tp) => ({ urn: tp.id, description: tp.metadata.thirdParty.description }))
+    }
+    return this.runQuery(query, { thirdPartyType: 'third_party_v1' })
   }
 
   private getOwnersByWearable(
@@ -348,6 +365,20 @@ export class TheGraphClient {
   }
 }
 
+const QUERY_THIRD_PARTIES = `
+query ThirdParties() {
+  thirdParties {
+    id
+		metadata {
+      thirdParty {
+        id
+        description
+      }
+    }
+  }
+}
+`
+
 const QUERY_WEARABLES_BY_OWNER: string = `
   query WearablesByOwner($owner: String, $first: Int, $skip: Int) {
     nfts(where: {owner: $owner, searchItemType_in: ["wearable_v1", "wearable_v2", "smart_wearable_v1", "emote_v1"]}, first: $first, skip: $skip) {
@@ -393,4 +424,5 @@ type URLs = {
   ensSubgraph: string
   collectionsSubgraph: string
   maticCollectionsSubgraph: string
+  thirdPartyRegistrySubgraph: string
 }

--- a/lambdas/src/utils/TheGraphClientFactory.ts
+++ b/lambdas/src/utils/TheGraphClientFactory.ts
@@ -6,8 +6,9 @@ export class TheGraphClientFactory {
     const collectionsSubgraph: string = env.getConfig(EnvironmentConfig.COLLECTIONS_L1_SUBGRAPH_URL)
     const maticCollectionsSubgraph: string = env.getConfig(EnvironmentConfig.COLLECTIONS_L2_SUBGRAPH_URL)
     const ensSubgraph: string = env.getConfig(EnvironmentConfig.ENS_OWNER_PROVIDER_URL)
+    const thirdPartyRegistrySubgraph: string = env.getConfig(EnvironmentConfig.THIRD_PARTY_REGISTRY_SUBGRAPH_URL)
     return new TheGraphClient(
-      { collectionsSubgraph, maticCollectionsSubgraph, ensSubgraph },
+      { collectionsSubgraph, maticCollectionsSubgraph, ensSubgraph, thirdPartyRegistrySubgraph },
       env.getBean(Bean.SMART_CONTENT_SERVER_FETCHER)
     )
   }


### PR DESCRIPTION
## Description

Adds `/third-party-integrations` endpoint.

It will query The Graph third party registry subgraph and return the list of integrations. 