### PR TITLE
feat: fetch wearables from third party resolver API

### DIFF
--- a/lambdas/src/apis/collections/controllers/wearables.ts
+++ b/lambdas/src/apis/collections/controllers/wearables.ts
@@ -2,9 +2,11 @@ import { toQueryParams } from '@dcl/catalyst-node-commons'
 import { EntityType } from 'dcl-catalyst-commons'
 import { EthAddress } from 'dcl-crypto'
 import { Request, Response } from 'express'
+import log4js from 'log4js'
 import { asArray, asInt } from '../../../utils/ControllerUtils'
 import { SmartContentClient } from '../../../utils/SmartContentClient'
 import { TheGraphClient } from '../../../utils/TheGraphClient'
+import { createThirdPartyFetcher, createThirdPartyResolver } from '../../../utils/third-party'
 import { BASE_AVATARS_COLLECTION_ID, OffChainWearablesManager } from '../off-chain/OffChainWearablesManager'
 import { Wearable, WearableId, WearablesFilters, WearablesPagination } from '../types'
 import { isBaseAvatar, translateEntityIntoWearable } from '../Utils'
@@ -17,34 +19,48 @@ const INCLUDE_DEFINITION_VERSIONS = [
   'includedefinitions'
 ]
 
+const LOGGER = log4js.getLogger('TheGraphClient')
+
 export async function getWearablesByOwnerEndpoint(
   client: SmartContentClient,
   theGraphClient: TheGraphClient,
   req: Request,
   res: Response
-) {
+): Promise<void> {
   // Method: GET
-  // Path: /wearables-by-owner/:owner
+  // Path: /wearables-by-owner/:owner?collectionId={string}
 
   const { owner } = req.params
+  const { collectionId } = req.query
   const includeDefinition = INCLUDE_DEFINITION_VERSIONS.some((version) => version in req.query)
 
   try {
-    const result = await getWearablesByOwner(owner, includeDefinition, client, theGraphClient)
-    res.send(result)
+    const wearablesByOwner = await getWearablesByOwner(
+      owner,
+      includeDefinition,
+      client,
+      collectionId
+        ? await createThirdPartyResolver(theGraphClient, createThirdPartyFetcher(), collectionId as string)
+        : theGraphClient
+    )
+    res.send(wearablesByOwner)
   } catch (e) {
-    res.status(500).send(`Failed to fetch wearables by owner. Reason was ${e}`)
+    LOGGER.debug(e)
+    res.status(500).send(`Failed to fetch wearables by owner.`)
   }
+}
+export interface FindWearablesByOwner {
+  findWearablesByOwner: (owner: EthAddress) => Promise<WearableId[]>
 }
 
 export async function getWearablesByOwner(
   owner: EthAddress,
   includeDefinition: boolean,
   client: SmartContentClient,
-  theGraphClient: TheGraphClient
+  wearablesResolver: FindWearablesByOwner
 ): Promise<{ urn: WearableId; amount: number; definition?: Wearable | undefined }[]> {
   // Fetch wearables & definitions (if needed)
-  const wearablesByOwner = await theGraphClient.findWearablesByOwner(owner)
+  const wearablesByOwner = await wearablesResolver.findWearablesByOwner(owner)
   const definitions: Map<WearableId, Wearable> = includeDefinition
     ? await fetchDefinitions(wearablesByOwner, client)
     : new Map()
@@ -72,7 +88,7 @@ export async function getWearablesEndpoint(
   offChainManager: OffChainWearablesManager,
   req: Request,
   res: Response
-) {
+): Promise<unknown> {
   // Method: GET
   // Path: /wearables/?filters&limit={number}&lastId={string}
 

--- a/lambdas/src/apis/collections/types.ts
+++ b/lambdas/src/apis/collections/types.ts
@@ -80,3 +80,18 @@ export type ThirdPartyIntegration = {
   urn: string
   description: string
 }
+
+export type ThirdPartyAsset = {
+  id: string
+  amount: number
+  urn: {
+    decentraland: string
+  }
+}
+
+export type ThirdPartyAssets = {
+  address: EthAddress
+  total: number
+  page: number
+  assets: ThirdPartyAsset[]
+}

--- a/lambdas/src/utils/TheGraphClient.ts
+++ b/lambdas/src/utils/TheGraphClient.ts
@@ -138,6 +138,20 @@ export class TheGraphClient {
     return this.runQuery(query, { thirdPartyType: 'third_party_v1' })
   }
 
+  /**
+   * This method returns the third party resolver API to be used to query assets from any collection
+   * of given third party integration
+   */
+  public async findThirdPartyResolver(subgraph: keyof URLs, id: string): Promise<string | undefined> {
+    const query: Query<{ thirdParties: [{ resolver: string }] }, string | undefined> = {
+      description: 'fetch third party resolver',
+      subgraph: subgraph,
+      query: QUERY_THIRD_PARTY_RESOLVER,
+      mapper: (response) => response.thirdParties[0]?.resolver
+    }
+    return await this.runQuery(query, { id })
+  }
+
   private getOwnersByWearable(
     wearableIdsToCheck: [string, string[]][],
     subgraph: keyof URLs
@@ -375,6 +389,15 @@ query ThirdParties() {
         description
       }
     }
+  }
+}
+`
+
+const QUERY_THIRD_PARTY_RESOLVER = `
+query ThirdPartyResolver($id: String!) {
+  thirdParties(where: {id: $id}) {
+    id
+    resolver
   }
 }
 `

--- a/lambdas/src/utils/third-party.ts
+++ b/lambdas/src/utils/third-party.ts
@@ -1,0 +1,45 @@
+import { fetchJson } from 'dcl-catalyst-commons'
+import { EthAddress } from 'dcl-crypto'
+import log4js from 'log4js'
+import { FindWearablesByOwner } from '../apis/collections/controllers/wearables'
+import { ThirdPartyAsset, ThirdPartyAssets } from '../apis/collections/types'
+import { TheGraphClient } from './TheGraphClient'
+
+const LOGGER = log4js.getLogger('ThirdPartyResolver')
+
+export interface ThirdPartyFetcher {
+  fetchAssets: (url: string, collectionId: string, owner: EthAddress) => Promise<ThirdPartyAsset[] | undefined>
+}
+
+export const createThirdPartyFetcher = (): ThirdPartyFetcher => ({
+  fetchAssets: async (url: string, collectionId: string, owner: EthAddress): Promise<ThirdPartyAsset[]> => {
+    try {
+      const assetsByOnwer = (await fetchJson(`${url}/registry/${collectionId}/address/${owner}/assets`, {
+        timeout: '5000'
+      })) as ThirdPartyAssets
+
+      if (!assetsByOnwer)
+        LOGGER.debug(`No assets found with owner: ${owner}, url: ${url} and registryId: ${collectionId}`)
+      return assetsByOnwer?.assets ?? []
+    } catch (e) {
+      throw new Error(`Error fetching assets with owner: ${owner}, url: ${url} and registryId: ${collectionId}`)
+    }
+  }
+})
+
+export const createThirdPartyResolver = async (
+  theGraphClient: TheGraphClient,
+  thirdPartyFetcher: ThirdPartyFetcher,
+  collectionId: string
+): Promise<FindWearablesByOwner> => {
+  const thirdPartyResolverAPI = await theGraphClient.findThirdPartyResolver('thirdPartyRegistrySubgraph', collectionId)
+  if (!thirdPartyResolverAPI) throw new Error(`Could not find third party resolver for collectionId: ${collectionId}`)
+
+  return {
+    findWearablesByOwner: async (owner) => {
+      const assetsByOwner = await thirdPartyFetcher.fetchAssets(thirdPartyResolverAPI, collectionId, owner)
+      if (!assetsByOwner) throw new Error(`Could not fetch assets for owner: ${owner}`)
+      return assetsByOwner?.map((asset) => asset.urn.decentraland) ?? []
+    }
+  }
+}

--- a/lambdas/test/apis/collections/controller/wearables/wearables-by-owner.spec.ts
+++ b/lambdas/test/apis/collections/controller/wearables/wearables-by-owner.spec.ts
@@ -1,9 +1,10 @@
 import { EntityType, EntityVersion } from 'dcl-catalyst-commons'
 import { anything, instance, mock, verify, when } from 'ts-mockito'
-import { getWearablesByOwner } from '../../../../../src/apis/collections/controllers/wearables'
-import { WearableId } from '../../../../../src/apis/collections/types'
+import { FindWearablesByOwner, getWearablesByOwner } from '../../../../../src/apis/collections/controllers/wearables'
+import { ThirdPartyAsset, WearableId } from '../../../../../src/apis/collections/types'
 import { SmartContentClient } from '../../../../../src/utils/SmartContentClient'
 import { TheGraphClient } from '../../../../../src/utils/TheGraphClient'
+import { createThirdPartyResolver, ThirdPartyFetcher } from '../../../../../src/utils/third-party'
 
 const SOME_ADDRESS = '0x079bed9c31cb772c4c156f86e1cff15bf751add0'
 const WEARABLE_ID_1 = 'someCollection-someWearable'
@@ -71,6 +72,57 @@ describe('wearables by owner', () => {
     expect(wearable.definition).toBeUndefined()
     verify(contentClientMock.fetchEntitiesByPointers(anything(), anything())).once()
   })
+
+  it(`When third party wearable collectionId is present, it should return the corresponding one`, async () => {
+    const { instance: thirdPartyFetcherInstance, mock: thirdPartyFetcherMock } = thirdPartyFetcher([
+      {
+        id: WEARABLE_ID_1,
+        amount: 1,
+        urn: { decentraland: WEARABLE_ID_1 }
+      }
+    ])
+    const { instance: thirdPartyGraphClientInstance, mock: thirdPartyGraphClientMock } = thirdPartyGraphClient()
+
+    const resolver = await thirdPartyResolver(
+      thirdPartyGraphClientInstance,
+      thirdPartyFetcherInstance,
+      'someCollection'
+    )
+    const { instance: contentClient, mock: contentClientMock } = contentServerThatReturns(WEARABLE_ID_1)
+
+    const wearables = await getWearablesByOwner(SOME_ADDRESS, true, contentClient, resolver)
+
+    expect(wearables.length).toEqual(1)
+    const [wearable] = wearables
+    expect(wearable.urn).toBe(WEARABLE_ID_1)
+    expect(wearable.amount).toBe(1)
+    expect(wearable.definition).toEqual({ ...WEARABLE_METADATA, id: WEARABLE_ID_1 })
+    verify(contentClientMock.fetchEntitiesByPointers(anything(), anything())).once()
+    verify(thirdPartyFetcherMock.fetchAssets(anything(), anything(), anything())).once()
+    verify(thirdPartyGraphClientMock.findThirdPartyResolver(anything(), anything())).once()
+  })
+
+  it(`When there is no third party registered for a collectionId, it should return an error`, async () => {
+    const collectionId = 'someCollection'
+    const { instance } = noThirdPartyRegistered()
+    const { instance: thirdPartyFetcherInstance } = thirdPartyFetcher([])
+    await expect(thirdPartyResolver(instance, thirdPartyFetcherInstance, collectionId)).rejects.toThrowError(
+      `Could not find third party resolver for collectionId: ${collectionId}`
+    )
+  })
+
+  it(`When there a third party resolver doesn't respond, it should return an error`, async () => {
+    const { instance: thirdPartyFetcher } = undefinedThirdPartyFetcher()
+    const { instance: thirdPartyGraphClientInstance } = thirdPartyGraphClient()
+
+    const resolver = await thirdPartyResolver(thirdPartyGraphClientInstance, thirdPartyFetcher, 'someCollection')
+
+    const { instance: contentClient } = contentServerThatReturns(WEARABLE_ID_1)
+
+    await expect(getWearablesByOwner(SOME_ADDRESS, true, contentClient, resolver)).rejects.toThrowError(
+      `Could not fetch assets for owner: ${SOME_ADDRESS}`
+    )
+  })
 })
 
 function emptyContentServer() {
@@ -94,6 +146,38 @@ function contentServerThatReturns(id?: WearableId) {
   }
   const mockedClient = mock(SmartContentClient)
   when(mockedClient.fetchEntitiesByPointers(anything(), anything())).thenResolve(id ? [entity] : [])
+  return { instance: instance(mockedClient), mock: mockedClient }
+}
+
+async function thirdPartyResolver(
+  graphClient: TheGraphClient,
+  thirdPartyFetcher: ThirdPartyFetcher,
+  collectionId: string
+): Promise<FindWearablesByOwner> {
+  return await createThirdPartyResolver(graphClient, thirdPartyFetcher, collectionId)
+}
+
+function thirdPartyFetcher(assets: ThirdPartyAsset[]): { instance: ThirdPartyFetcher; mock: ThirdPartyFetcher } {
+  const resolver = mock<ThirdPartyFetcher>()
+  when(resolver.fetchAssets(anything(), anything(), anything())).thenResolve(assets)
+  return { instance: instance(resolver), mock: resolver }
+}
+
+function undefinedThirdPartyFetcher(): { instance: ThirdPartyFetcher; mock: ThirdPartyFetcher } {
+  const resolver = mock<ThirdPartyFetcher>()
+  when(resolver.fetchAssets(anything(), anything(), anything())).thenResolve(undefined)
+  return { instance: instance(resolver), mock: resolver }
+}
+
+function noThirdPartyRegistered() {
+  const mockedClient = mock(TheGraphClient)
+  when(mockedClient.findThirdPartyResolver(anything(), anything())).thenResolve(undefined)
+  return { instance: instance(mockedClient), mock: mockedClient }
+}
+
+function thirdPartyGraphClient(url: string = 'someUrl'): { instance: TheGraphClient; mock: TheGraphClient } {
+  const mockedClient = mock(TheGraphClient)
+  when(mockedClient.findThirdPartyResolver(anything(), anything())).thenResolve(url)
   return { instance: instance(mockedClient), mock: mockedClient }
 }
 


### PR DESCRIPTION
## Description

Adding TPW support to `GET /lambdas/collections/wearables-by-owner/:address?collectionId=THIRD_PARTY_URN` endpoint. 

Added behaviour: 
- When a `collectionId` is present.
- Query The Graph for a TPR (third party resolver).
- Fetch wearables from that TPR API (using same `collectionId` and given user `address`)