### PR TITLE
fix: prevent docker to cache stages that need to be run and cache dependencies stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,6 @@ FROM node:14-alpine as base
 WORKDIR /app
 RUN apk add --no-cache bash
 
-# get production dependencies
-FROM base as dependencies
-
 COPY package.json .
 COPY yarn.lock .
 COPY comms/lighthouse/package.json comms/lighthouse/
@@ -12,13 +9,16 @@ COPY commons/package.json commons/
 COPY contracts/package.json contracts/
 COPY content/package.json content/
 COPY lambdas/package.json lambdas/
+
+# get production dependencies
+FROM base as dependencies
 RUN yarn install --prod --frozen-lockfile
 
 # build sources
 FROM base as catalyst-builder
-COPY . .
 RUN yarn install --frozen-lockfile
 
+COPY . .
 FROM catalyst-builder as comms-builder
 RUN yarn workspace @catalyst/lighthouse-server build
 FROM catalyst-builder as content-builder


### PR DESCRIPTION
## Description

With this change dependencies will be cached when there are no changes in any `package.json` and code will always be rebuilt. 