### PR TITLE
fix: snapshot indexes

### DIFF
--- a/content/src/logic/snapshots-queries.ts
+++ b/content/src/logic/snapshots-queries.ts
@@ -25,9 +25,9 @@ export async function* streamActiveDeployments(
         entity_pointers,
         auth_chain,
         date_part('epoch', local_timestamp) * 1000 AS local_timestamp
-      FROM deployments
-      WHERE deleter_deployment IS NULL
-      ORDER BY local_timestamp ASC
+      FROM deployments d
+      WHERE d.deleter_deployment IS NULL
+      ORDER BY d.local_timestamp ASC
     `,
     options
   )) {
@@ -57,9 +57,9 @@ export async function* streamActiveDeploymentsEntityType(
         entity_pointers,
         auth_chain,
         date_part('epoch', local_timestamp) * 1000 AS local_timestamp
-      FROM deployments
-      WHERE deleter_deployment IS NULL AND entity_type = ${entityType}
-      ORDER BY local_timestamp ASC
+      FROM deployments d
+      WHERE d.deleter_deployment IS NULL AND d.entity_type = ${entityType}
+      ORDER BY d.local_timestamp ASC
     `,
     options
   )) {

--- a/content/src/migrations/scripts/1620152961576_add_deleter_indexes.ts
+++ b/content/src/migrations/scripts/1620152961576_add_deleter_indexes.ts
@@ -1,6 +1,7 @@
 import { MigrationBuilder } from 'node-pg-migrate'
 
 export async function up(pgm: MigrationBuilder): Promise<void> {
+  // deprecated by 1639480263808_snapshot_index.ts
   pgm.addIndex('deployments', 'deleter_deployment')
 }
 

--- a/content/src/migrations/scripts/1639480263808_snapshot_index.ts
+++ b/content/src/migrations/scripts/1639480263808_snapshot_index.ts
@@ -1,0 +1,23 @@
+import { MigrationBuilder } from 'node-pg-migrate'
+
+/*
+ * Add an auth_chain field to failed deployments to prevent hitting other catalysts during synchronization.
+ */
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.sql(`
+    CREATE INDEX IF NOT EXISTS
+      deployments_full_snapshots_ix
+    ON deployments (
+      deleter_deployment DESC NULLS FIRST,
+      local_timestamp ASC NULLS LAST
+    )
+    INCLUDE (entity_type)
+  `)
+  pgm.dropIndex('deployments', 'deleter_deployment')
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.sql('DROP INDEX IF EXISTS deployments_full_snapshots_ix')
+  pgm.addIndex('deployments', 'deleter_deployment')
+}


### PR DESCRIPTION
```
content=> EXPLAIN ANALYZE SELECT entity_id, entity_pointers, date_part('epoch', local_timestamp) * 1000 AS local_timestamp FROM deployments d WHERE d.deleter_deployment IS NULL AND entity_type = 'wearable' ORDER BY d.local_timestamp DESC;
                                                                          QUERY PLAN
--------------------------------------------------------------------------------------------------------------------------------------------------------------
 Sort  (cost=1622.02..1624.85 rows=1133 width=131) (actual time=3.608..4.607 rows=1244 loops=1)
   Sort Key: local_timestamp DESC
   Sort Method: quicksort  Memory: 379kB
   ->  Index Scan using deployments_entity_type_index on deployments d  (cost=0.42..1564.55 rows=1133 width=131) (actual time=0.042..2.179 rows=1244 loops=1)
         Index Cond: (entity_type = 'wearable'::text)
         Filter: (deleter_deployment IS NULL)
 Planning Time: 0.145 ms
 Execution Time: 5.642 ms
```