### PR TITLE
Increase rate limit for deploying profiles

### DIFF
--- a/content/src/Environment.ts
+++ b/content/src/Environment.ts
@@ -261,7 +261,7 @@ export class EnvironmentBuilder {
     this.registerConfigIfNotAlreadySet(
       env,
       EnvironmentConfig.DEPLOYMENTS_RATE_LIMIT_MAX,
-      () => process.env.DEPLOYMENTS_RATE_LIMIT_MAX ?? 100
+      () => process.env.DEPLOYMENTS_RATE_LIMIT_MAX ?? 300
     )
     this.registerConfigIfNotAlreadySet(
       env,


### PR DESCRIPTION
With this change, we are allowed to deploy 300 profiles per minute per Catalyst.