### PR TITLE
Fix server killed when fails

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,7 +16,6 @@
     120
   ],
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true,
     "source.organizeImports": true
   },
   "eslint.validate": [

--- a/commons/servers/metrics.ts
+++ b/commons/servers/metrics.ts
@@ -29,7 +29,7 @@ export function initializeMetricsServer<T extends string>(
 
   return {
     async start(port?: number) {
-      const usedPort = port === undefined ? parseInt(process.env.METRICS_PORT ?? '9090') : port
+      const usedPort = port === undefined ? parseInt(process.env.METRICS_PORT ?? '9092') : port
       if (isNaN(usedPort)) {
         throw new Error('Invalid non-numeric METRICS_PORT')
       }

--- a/lambdas/.gitignore
+++ b/lambdas/.gitignore
@@ -1,0 +1,1 @@
+lambdas-storage

--- a/lambdas/README.md
+++ b/lambdas/README.md
@@ -24,7 +24,8 @@ yarn test
 
 - Start the content server
 
-  `yarn start`
+- Start lambdas server
+  `CONTENT_SERVER_ADDRESS=localhost:6969 SERVER_PORT=9091 yarn start`
 
 ## Configuration
 

--- a/lambdas/src/apis/images/controllers/images.ts
+++ b/lambdas/src/apis/images/controllers/images.ts
@@ -95,7 +95,7 @@ export async function getResizedImage(
           downloadFuture.resolve()
           if (existingDownloadsFutures[filePath] === downloadFuture) delete existingDownloadsFutures[filePath]
         } catch (error) {
-          LOGGER.error(`Error while trying to conver image of ${cid} to size ${size}`, error)
+          LOGGER.error(`Error while trying to convert image of ${cid} to size ${size}`, error)
           throw new ServiceError("Couldn't resize content. Is content a valid image?", 400)
         }
       } else if (contentServerResponse.status === 404) {
@@ -107,8 +107,8 @@ export async function getResizedImage(
     } catch (e) {
       downloadFuture.reject(e)
       if (existingDownloadsFutures[filePath] === downloadFuture) delete existingDownloadsFutures[filePath]
-      throw e
     }
+    return downloadFuture
   }
 
   async function getStreamFor(cid: string, size: string) {


### PR DESCRIPTION
## Description

Lambdas server was killed when asked for content that was not present, for example: `/lambdas/images/abcde/256`

