### PR TITLE
Remove deprecated CamelCase endpoints

### DIFF
--- a/content/src/service/Server.ts
+++ b/content/src/service/Server.ts
@@ -88,12 +88,10 @@ export class Server implements IBaseComponent {
     this.registerRoute('/denylist/:type/:id', controller, controller.addToDenylist, HttpMethod.PUT)
     this.registerRoute('/denylist/:type/:id', controller, controller.removeFromDenylist, HttpMethod.DELETE)
     this.registerRoute('/denylist/:type/:id', controller, controller.isTargetDenylisted, HttpMethod.HEAD)
-    this.registerRoute('/failedDeployments', controller, controller.getFailedDeployments) // TODO: Deprecate
     this.registerRoute('/failed-deployments', controller, controller.getFailedDeployments)
     this.registerRoute('/challenge', controller, controller.getChallenge)
-    this.registerRoute('/pointerChanges', controller, controller.getPointerChanges) // TODO: Deprecate
     this.registerRoute('/pointer-changes', controller, controller.getPointerChanges)
-    this.registerRoute('/snapshot/:type', controller, controller.getSnapshot)
+    this.registerRoute('/snapshot/:type', controller, controller.getSnapshot) // TODO: Deprecate
     this.registerRoute('/snapshot', controller, controller.getAllSnapshots)
   }
 

--- a/content/test/unit/service/Service.spec.ts
+++ b/content/test/unit/service/Service.spec.ts
@@ -91,7 +91,7 @@ describe('Service', function () {
     } else {
       const deltaMilliseconds = Date.now() - deploymentResult
       expect(deltaMilliseconds).toBeGreaterThanOrEqual(0)
-      expect(deltaMilliseconds).toBeLessThanOrEqual(10)
+      expect(deltaMilliseconds).toBeLessThanOrEqual(1000)
       expect(storageSpy).toHaveBeenCalledWith(entity.id, entityFile)
       expect(storageSpy).toHaveBeenCalledWith(randomFileHash, randomFile)
     }


### PR DESCRIPTION
Remove deprecated CamelCase endpoints:
- `/pointerChanges` => `/pointer-changes`
- `/failedDeployments` => `/failed-deployments`