### PR TITLE
feat: update error when failed deployment retry fails

### DIFF
--- a/content/src/components.ts
+++ b/content/src/components.ts
@@ -70,9 +70,9 @@ export async function initComponentsWithEnv(env: Environment): Promise<AppCompon
   // TODO: this should be in the src/logic folder. It is not a component
   const pointerManager = new PointerManager()
 
-  const validator = createValidator({ storage, authenticator, catalystFetcher, env })
-  const serverValidator = createServerValidator()
   const failedDeploymentsCache = createFailedDeploymentsCache()
+  const validator = createValidator({ storage, authenticator, catalystFetcher, env })
+  const serverValidator = createServerValidator({ failedDeploymentsCache })
 
   const deployedEntitiesFilter = createBloomFilterComponent({
     sizeInBytes: 512

--- a/content/src/components.ts
+++ b/content/src/components.ts
@@ -177,7 +177,8 @@ export async function initComponentsWithEnv(env: Environment): Promise<AppCompon
     metrics,
     staticConfigs,
     logs,
-    contentCluster
+    contentCluster,
+    failedDeploymentsCache
   })
 
   const ethNetwork: string = env.getConfig(EnvironmentConfig.ETH_NETWORK)

--- a/content/src/logic/deployments.ts
+++ b/content/src/logic/deployments.ts
@@ -18,7 +18,14 @@ export async function isEntityDeployed(
 export async function retryFailedDeploymentExecution(
   components: Pick<
     AppComponents,
-    'metrics' | 'staticConfigs' | 'fetcher' | 'downloadQueue' | 'logs' | 'deployer' | 'contentCluster'
+    | 'metrics'
+    | 'staticConfigs'
+    | 'fetcher'
+    | 'downloadQueue'
+    | 'logs'
+    | 'deployer'
+    | 'contentCluster'
+    | 'failedDeploymentsCache'
   >,
   logger: ILoggerComponent.ILogger
 ): Promise<void> {
@@ -44,6 +51,10 @@ export async function retryFailedDeploymentExecution(
           DeploymentContext.FIX_ATTEMPT
         )
       } catch (error) {
+        // it failed again, override failed deployment error description
+        const errorDescription = error.message
+        components.failedDeploymentsCache.reportFailure({ ...failedDeployment, errorDescription })
+
         logger.info(`Failed to fix deployment of entity`, { entityId, entityType })
         logger.error(error)
       }

--- a/content/src/ports/failedDeploymentsCache.ts
+++ b/content/src/ports/failedDeploymentsCache.ts
@@ -23,7 +23,7 @@ export type FailedDeployment = {
 export type IFailedDeploymentsCacheComponent = {
   getAllFailedDeployments(): FailedDeployment[]
   findFailedDeployment(entityId: EntityId): FailedDeployment | undefined
-  reportSuccessfulDeployment(entityId: EntityId): boolean
+  removeFailedDeployment(entityId: EntityId): boolean
   reportFailure(failedDeployment: FailedDeployment): void
   getDeploymentStatus(entityId: EntityId): DeploymentStatus
 }
@@ -37,7 +37,7 @@ export function createFailedDeploymentsCache(): IFailedDeploymentsCacheComponent
     findFailedDeployment(entityId: EntityId) {
       return failedDeployments.get(entityId)
     },
-    reportSuccessfulDeployment(entityId: EntityId) {
+    removeFailedDeployment(entityId: EntityId) {
       return failedDeployments.delete(entityId)
     },
     reportFailure(failedDeployment: FailedDeployment) {

--- a/content/src/service/ServiceImpl.ts
+++ b/content/src/service/ServiceImpl.ts
@@ -277,7 +277,7 @@ export class ServiceImpl implements MetaverseContentService {
           }
 
           // Mark deployment as successful (this does nothing it if hadn't failed on the first place)
-          this.components.failedDeploymentsCache.reportSuccessfulDeployment(entity.id)
+          this.components.failedDeploymentsCache.removeFailedDeployment(entity.id)
 
           return { auditInfoComplete, wasEntityDeployed: !isEntityAlreadyDeployed, affectedPointers }
         }),

--- a/content/src/service/synchronization/SynchronizationManager.ts
+++ b/content/src/service/synchronization/SynchronizationManager.ts
@@ -14,6 +14,7 @@ type ContentSyncComponents = Pick<
   | 'synchronizationJobManager'
   | 'deployer'
   | 'contentCluster'
+  | 'failedDeploymentsCache'
 >
 
 export enum SynchronizationState {


### PR DESCRIPTION
## Description

Update failed deployment error description when retry task fails to fix it.

Fixing a failed deployment will be ignored when there are newer entities with same pointer and it will be removed from the cache.