### PR TITLE
chore: reduce off chain refresh time

### DIFF
--- a/lambdas/src/Environment.ts
+++ b/lambdas/src/Environment.ts
@@ -221,7 +221,7 @@ export class EnvironmentBuilder {
     this.registerConfigIfNotAlreadySet(
       env,
       EnvironmentConfig.OFF_CHAIN_WEARABLES_REFRESH_TIME,
-      () => process.env.OFF_CHAIN_WEARABLES_REFRESH_TIME ?? '1d'
+      () => process.env.OFF_CHAIN_WEARABLES_REFRESH_TIME ?? '15m'
     )
     this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.VALIDATE_API, () => process.env.VALIDATE_API == 'true')
 

--- a/lambdas/src/apis/collections/off-chain/OffChainWearablesManager.ts
+++ b/lambdas/src/apis/collections/off-chain/OffChainWearablesManager.ts
@@ -23,7 +23,7 @@ export class OffChainWearablesManager {
   }) {
     this.definitions = new TimeRefreshedDataHolder(
       () => OffChainWearablesManager.fetchOffChain(client, collections ?? DEFAULT_COLLECTIONS),
-      refreshTime ?? '1d'
+      refreshTime ?? '15m'
     )
   }
 

--- a/lambdas/src/apis/collections/off-chain/OffChainWearablesManager.ts
+++ b/lambdas/src/apis/collections/off-chain/OffChainWearablesManager.ts
@@ -19,11 +19,11 @@ export class OffChainWearablesManager {
   }: {
     client: SmartContentClient
     collections?: OffChainCollections
-    refreshTime?: string
+    refreshTime: string
   }) {
     this.definitions = new TimeRefreshedDataHolder(
       () => OffChainWearablesManager.fetchOffChain(client, collections ?? DEFAULT_COLLECTIONS),
-      refreshTime ?? '15m'
+      refreshTime
     )
   }
 

--- a/lambdas/test/apis/collections/off-chain/OffChainWearablesManager.spec.ts
+++ b/lambdas/test/apis/collections/off-chain/OffChainWearablesManager.spec.ts
@@ -22,7 +22,7 @@ describe('OffChainWearablesManager', () => {
 
   it(`When definitions are loaded for the first time, then content server is queried`, async () => {
     const { instance: contentClient, mock: contentClientMock } = contentServer()
-    const manager = new OffChainWearablesManager({ client: contentClient, collections: COLLECTIONS })
+    const manager = new OffChainWearablesManager({ client: contentClient, collections: COLLECTIONS, refreshTime: '2s' })
 
     await manager.find({ collectionIds: [COLLECTION_ID_1] })
 
@@ -77,7 +77,7 @@ describe('OffChainWearablesManager', () => {
 
   it(`When multiple requests happen concurrently, then definition is only calculated once`, async () => {
     const { instance: contentClient, mock: contentClientMock } = contentServer()
-    const manager = new OffChainWearablesManager({ client: contentClient, collections: COLLECTIONS })
+    const manager = new OffChainWearablesManager({ client: contentClient, collections: COLLECTIONS, refreshTime: '2s' })
 
     await Promise.all([
       manager.find({ collectionIds: [COLLECTION_ID_1] }),
@@ -90,7 +90,7 @@ describe('OffChainWearablesManager', () => {
 
   it(`When the collection id filter is used, then wearables are filtered correctly`, async () => {
     const { instance: contentClient } = contentServer()
-    const manager = new OffChainWearablesManager({ client: contentClient, collections: COLLECTIONS })
+    const manager = new OffChainWearablesManager({ client: contentClient, collections: COLLECTIONS, refreshTime: '2s' })
 
     const wearables = await manager.find({ collectionIds: [COLLECTION_ID_1] })
 
@@ -99,7 +99,7 @@ describe('OffChainWearablesManager', () => {
 
   it(`When the wearable id filter is used, then wearables are filtered correctly`, async () => {
     const { instance: contentClient } = contentServer()
-    const manager = new OffChainWearablesManager({ client: contentClient, collections: COLLECTIONS })
+    const manager = new OffChainWearablesManager({ client: contentClient, collections: COLLECTIONS, refreshTime: '2s' })
 
     const wearables = await manager.find({ wearableIds: [WEARABLE_ID_2, WEARABLE_ID_3] })
 
@@ -108,7 +108,7 @@ describe('OffChainWearablesManager', () => {
 
   it(`When the text search filter is used, then wearables are filtered correctly`, async () => {
     const { instance: contentClient } = contentServer()
-    const manager = new OffChainWearablesManager({ client: contentClient, collections: COLLECTIONS })
+    const manager = new OffChainWearablesManager({ client: contentClient, collections: COLLECTIONS, refreshTime: '2s' })
 
     const wearables = await manager.find({ textSearch: 'other' })
 
@@ -117,7 +117,7 @@ describe('OffChainWearablesManager', () => {
 
   it(`When multiple filters are used, then wearables are filtered correctly`, async () => {
     const { instance: contentClient } = contentServer()
-    const manager = new OffChainWearablesManager({ client: contentClient, collections: COLLECTIONS })
+    const manager = new OffChainWearablesManager({ client: contentClient, collections: COLLECTIONS, refreshTime: '2s' })
 
     const wearables = await manager.find({ textSearch: 'other', collectionIds: [COLLECTION_ID_1] })
 


### PR DESCRIPTION
## Description

Deploying changes for the off chain wearables is taking a long time because results are cached for one day, making it difficult to check if what was deployed is correct, and also for testing and iterating. The goal of this PR is to reduce that time to a number that helps with these issues, while not impacting the catalyst performance.

## Changes

- Reduce the default time for off chain wearables cache refresh from `1 day` to `15 minutes`