### PR TITLE
Rate limit when deploying any entity type

### DIFF
--- a/content/src/components.ts
+++ b/content/src/components.ts
@@ -79,12 +79,17 @@ export async function initComponentsWithEnv(env: Environment): Promise<AppCompon
 
   const failedDeploymentsCache = createFailedDeploymentsCache()
 
-  const rateLimitDeploymentCacheMap = createRateLimitDeploymentCacheMap({
-    defaultTtl: env.getConfig(EnvironmentConfig.DEPLOYMENTS_DEFAULT_RATE_LIMIT_TTL) ?? ms('1m'),
-    defaultMax: env.getConfig(EnvironmentConfig.DEPLOYMENTS_DEFAULT_RATE_LIMIT_MAX) ?? 300,
-    entitiesConfigTtl: env.getConfig<Map<EntityType, number>>(EnvironmentConfig.DEPLOYMENT_RATE_LIMIT_TTL) ?? new Map(),
-    entitiesConfigMax: env.getConfig<Map<EntityType, number>>(EnvironmentConfig.DEPLOYMENT_RATE_LIMIT_MAX) ?? new Map()
-  })
+  const rateLimitDeploymentCacheMap = createRateLimitDeploymentCacheMap(
+    { logs },
+    {
+      defaultTtl: env.getConfig(EnvironmentConfig.DEPLOYMENTS_DEFAULT_RATE_LIMIT_TTL) ?? ms('1m'),
+      defaultMax: env.getConfig(EnvironmentConfig.DEPLOYMENTS_DEFAULT_RATE_LIMIT_MAX) ?? 300,
+      entitiesConfigTtl:
+        env.getConfig<Map<EntityType, number>>(EnvironmentConfig.DEPLOYMENT_RATE_LIMIT_TTL) ?? new Map(),
+      entitiesConfigMax:
+        env.getConfig<Map<EntityType, number>>(EnvironmentConfig.DEPLOYMENT_RATE_LIMIT_MAX) ?? new Map()
+    }
+  )
 
   const validator = createValidator({ storage, authenticator, catalystFetcher, env, logs })
   const serverValidator = createServerValidator({ failedDeploymentsCache })

--- a/content/src/components.ts
+++ b/content/src/components.ts
@@ -13,11 +13,11 @@ import { metricsDeclaration } from './metrics'
 import { MigrationManagerFactory } from './migrations/MigrationManagerFactory'
 import { createDenylistComponent } from './ports/denylist'
 import { createDeploymentListComponent } from './ports/deploymentListComponent'
+import { createDeployRateLimiter } from './ports/deployRateLimiterComponent'
 import { createFailedDeploymentsCache } from './ports/failedDeploymentsCache'
 import { createFetchComponent } from './ports/fetcher'
 import { createFsComponent } from './ports/fs'
 import { createDatabaseComponent } from './ports/postgres'
-import { createRateLimitDeploymentCacheMap } from './ports/rateLimitDeploymentCacheMap'
 import { createSequentialTaskExecutor } from './ports/sequecuentialTaskExecutor'
 import { RepositoryFactory } from './repository/RepositoryFactory'
 import { AuthenticatorFactory } from './service/auth/AuthenticatorFactory'
@@ -85,7 +85,7 @@ export async function initComponentsWithEnv(env: Environment): Promise<AppCompon
 
   const failedDeploymentsCache = createFailedDeploymentsCache()
 
-  const rateLimitDeploymentCacheMap = createRateLimitDeploymentCacheMap(
+  const deployRateLimiter = createDeployRateLimiter(
     { logs },
     {
       defaultTtl: env.getConfig(EnvironmentConfig.DEPLOYMENTS_DEFAULT_RATE_LIMIT_TTL) ?? ms('1m'),
@@ -107,7 +107,7 @@ export async function initComponentsWithEnv(env: Environment): Promise<AppCompon
     storage,
     deploymentManager,
     failedDeploymentsCache,
-    rateLimitDeploymentCacheMap,
+    deployRateLimiter,
     pointerManager,
     repository,
     validator,
@@ -245,7 +245,7 @@ export async function initComponentsWithEnv(env: Environment): Promise<AppCompon
     contentCluster,
     deploymentManager,
     failedDeploymentsCache,
-    rateLimitDeploymentCacheMap,
+    deployRateLimiter,
     pointerManager,
     storage,
     authenticator,

--- a/content/src/components.ts
+++ b/content/src/components.ts
@@ -10,7 +10,6 @@ import path from 'path'
 import { Controller } from './controller/Controller'
 import { Environment, EnvironmentConfig } from './Environment'
 import { FetcherFactory } from './helpers/FetcherFactory'
-import { createSequentialTaskExecutor } from './ports/sequecuentialTaskExecutor'
 import { metricsDeclaration } from './metrics'
 import { MigrationManagerFactory } from './migrations/MigrationManagerFactory'
 import { createDeploymentListComponent } from './ports/deploymentListComponent'
@@ -18,6 +17,7 @@ import { createFailedDeploymentsCache } from './ports/failedDeploymentsCache'
 import { createFetchComponent } from './ports/fetcher'
 import { createDatabaseComponent } from './ports/postgres'
 import { createRateLimitDeploymentCacheMap } from './ports/rateLimitDeploymentCacheMap'
+import { createSequentialTaskExecutor } from './ports/sequecuentialTaskExecutor'
 import { RepositoryFactory } from './repository/RepositoryFactory'
 import { AuthenticatorFactory } from './service/auth/AuthenticatorFactory'
 import { DeploymentManager } from './service/deployments/DeploymentManager'
@@ -95,7 +95,7 @@ export async function initComponentsWithEnv(env: Environment): Promise<AppCompon
   )
 
   const validator = createValidator({ storage, authenticator, catalystFetcher, env, logs })
-  const serverValidator = createServerValidator({ failedDeploymentsCache })
+  const serverValidator = createServerValidator({ failedDeploymentsCache, metrics })
 
   const deployedEntitiesFilter = createDeploymentListComponent({ database, logs })
 

--- a/content/src/components.ts
+++ b/content/src/components.ts
@@ -3,7 +3,9 @@ import { createJobLifecycleManagerComponent } from '@dcl/snapshots-fetcher/dist/
 import { createJobQueue } from '@dcl/snapshots-fetcher/dist/job-queue-port'
 import { createLogComponent } from '@well-known-components/logger'
 import { createTestMetricsComponent } from '@well-known-components/metrics'
+import { EntityType } from 'dcl-catalyst-commons'
 import fs from 'fs'
+import ms from 'ms'
 import path from 'path'
 import { Controller } from './controller/Controller'
 import { Environment, EnvironmentConfig } from './Environment'
@@ -76,7 +78,14 @@ export async function initComponentsWithEnv(env: Environment): Promise<AppCompon
   const pointerManager = new PointerManager()
 
   const failedDeploymentsCache = createFailedDeploymentsCache()
-  const rateLimitDeploymentCacheMap = createRateLimitDeploymentCacheMap(env)
+
+  const rateLimitDeploymentCacheMap = createRateLimitDeploymentCacheMap({
+    defaultTtl: env.getConfig(EnvironmentConfig.DEPLOYMENTS_DEFAULT_RATE_LIMIT_TTL) ?? ms('1m'),
+    defaultMax: env.getConfig(EnvironmentConfig.DEPLOYMENTS_DEFAULT_RATE_LIMIT_MAX) ?? 300,
+    entitiesConfigTtl: env.getConfig<Map<EntityType, number>>(EnvironmentConfig.DEPLOYMENT_RATE_LIMIT_TTL) ?? new Map(),
+    entitiesConfigMax: env.getConfig<Map<EntityType, number>>(EnvironmentConfig.DEPLOYMENT_RATE_LIMIT_MAX) ?? new Map()
+  })
+
   const validator = createValidator({ storage, authenticator, catalystFetcher, env, logs })
   const serverValidator = createServerValidator({ failedDeploymentsCache })
 

--- a/content/src/components.ts
+++ b/content/src/components.ts
@@ -14,6 +14,7 @@ import { createDeploymentListComponent } from './ports/deploymentListComponent'
 import { createFailedDeploymentsCache } from './ports/failedDeploymentsCache'
 import { createFetchComponent } from './ports/fetcher'
 import { createDatabaseComponent } from './ports/postgres'
+import { createRateLimitDeploymentCacheMap } from './ports/rateLimitDeploymentCacheMap'
 import { RepositoryFactory } from './repository/RepositoryFactory'
 import { AuthenticatorFactory } from './service/auth/AuthenticatorFactory'
 import { DeploymentManager } from './service/deployments/DeploymentManager'
@@ -75,6 +76,7 @@ export async function initComponentsWithEnv(env: Environment): Promise<AppCompon
   const pointerManager = new PointerManager()
 
   const failedDeploymentsCache = createFailedDeploymentsCache()
+  const rateLimitDeploymentCacheMap = createRateLimitDeploymentCacheMap(env)
   const validator = createValidator({ storage, authenticator, catalystFetcher, env, logs })
   const serverValidator = createServerValidator({ failedDeploymentsCache })
 
@@ -85,6 +87,7 @@ export async function initComponentsWithEnv(env: Environment): Promise<AppCompon
     storage,
     deploymentManager,
     failedDeploymentsCache,
+    rateLimitDeploymentCacheMap,
     pointerManager,
     repository,
     validator,
@@ -219,6 +222,7 @@ export async function initComponentsWithEnv(env: Environment): Promise<AppCompon
     contentCluster,
     deploymentManager,
     failedDeploymentsCache,
+    rateLimitDeploymentCacheMap,
     pointerManager,
     storage,
     authenticator,

--- a/content/src/controller/Controller.ts
+++ b/content/src/controller/Controller.ts
@@ -29,7 +29,7 @@ import {
   LocalDeploymentAuditInfo
 } from '../service/Service'
 import { ContentItem, RawContent } from '../storage/ContentStorage'
-import { AppComponents } from '../types'
+import { AppComponents, parseEntityType } from '../types'
 import { ControllerDeploymentFactory } from './ControllerDeploymentFactory'
 import { ControllerEntityFactory } from './ControllerEntityFactory'
 
@@ -56,7 +56,7 @@ export class Controller {
     // Method: GET
     // Path: /entities/:type
     // Query String: ?{filter}&fields={fieldList}
-    const type: EntityType = this.parseEntityType(req.params.type)
+    const type: EntityType = parseEntityType(req.params.type)
     const pointers: Pointer[] = this.asArray<Pointer>(req.query.pointer as string)?.map((p) => p.toLowerCase()) ?? []
     const ids: EntityId[] = this.asArray<EntityId>(req.query.id as string) ?? []
     const fields: string = req.query.fields as string
@@ -88,15 +88,6 @@ export class Controller {
     }
     const maskedEntities: Entity[] = entities.map((entity) => ControllerEntityFactory.maskEntity(entity, enumFields))
     res.send(maskedEntities)
-  }
-
-  private parseEntityType(strType: string): EntityType {
-    if (strType.endsWith('s')) {
-      strType = strType.slice(0, -1)
-    }
-    strType = strType.toUpperCase().trim()
-    const type = EntityType[strType]
-    return type
   }
 
   private asArray<T>(elements: any | T | T[]): T[] | undefined {
@@ -252,7 +243,7 @@ export class Controller {
   async getAudit(req: express.Request, res: express.Response) {
     // Method: GET
     // Path: /audit/:type/:entityId
-    const type = this.parseEntityType(req.params.type)
+    const type = parseEntityType(req.params.type)
     const entityId = req.params.entityId
 
     // Validate type is valid
@@ -290,7 +281,7 @@ export class Controller {
     // Query String: ?from={timestamp}&to={timestamp}&offset={number}&limit={number}&entityType={entityType}&includeAuthChain={boolean}
     const stringEntityTypes = this.asArray<string>(req.query.entityType)
     const entityTypes: (EntityType | undefined)[] | undefined = stringEntityTypes
-      ? stringEntityTypes.map((type) => this.parseEntityType(type))
+      ? stringEntityTypes.map((type) => parseEntityType(type))
       : undefined
     // deprecated
     const fromLocalTimestamp: Timestamp | undefined = this.asInt(req.query.fromLocalTimestamp)
@@ -419,7 +410,7 @@ export class Controller {
 
     const stringEntityTypes = this.asArray<string>(req.query.entityType as string | string[])
     const entityTypes: (EntityType | undefined)[] | undefined = stringEntityTypes
-      ? stringEntityTypes.map((type) => this.parseEntityType(type))
+      ? stringEntityTypes.map((type) => parseEntityType(type))
       : undefined
     const entityIds: EntityId[] | undefined = this.asArray<EntityId>(req.query.entityId)
     const onlyCurrentlyPointed: boolean | undefined = this.asBoolean(req.query.onlyCurrentlyPointed)
@@ -614,7 +605,7 @@ export class Controller {
     // Method: GET
     // Path: /snapshot/:type
 
-    const type = this.parseEntityType(req.params.type)
+    const type = parseEntityType(req.params.type)
 
     // Validate type is valid
     if (!type) {

--- a/content/src/metrics.ts
+++ b/content/src/metrics.ts
@@ -55,10 +55,18 @@ export const metricsDeclaration = validateMetricsDeclaration({
     labelNames: []
   },
 
+  // TODO: Unify this metrics
+
   dcl_content_failed_deployments_total: {
     help: 'Total failed deployments',
     type: 'counter',
     labelNames: []
+  },
+
+  dcl_content_rate_limited_deployments_total: {
+    help: 'Total failed deployments due rate limit',
+    type: 'counter',
+    labelNames: ['entity_type']
   },
 
   dcl_deployments_endpoint_counter: {

--- a/content/src/ports/fetcher.ts
+++ b/content/src/ports/fetcher.ts
@@ -1,7 +1,7 @@
 import { IFetchComponent } from '@well-known-components/http-server'
 import * as nodeFetch from 'node-fetch'
 
-export function createFetchComponent() {
+export function createFetchComponent(): IFetchComponent {
   const fetch: IFetchComponent = {
     async fetch(url: nodeFetch.RequestInfo, init?: nodeFetch.RequestInit): Promise<nodeFetch.Response> {
       return nodeFetch.default(url, init)

--- a/content/src/ports/rateLimitDeploymentCacheMap.ts
+++ b/content/src/ports/rateLimitDeploymentCacheMap.ts
@@ -1,0 +1,86 @@
+import { EntityType, Pointer, Timestamp } from 'dcl-catalyst-commons'
+import ms from 'ms'
+import NodeCache from 'node-cache'
+import { Environment, EnvironmentConfig } from '../Environment'
+
+export type IRateLimitDeploymentCacheMapComponent = {
+  newDeployment(entityType: EntityType, pointers: Pointer[], localTimestamp: Timestamp): void
+  isRateLimited(entityType: EntityType, pointers: Pointer[]): boolean
+}
+
+export function createRateLimitDeploymentCacheMap(env: Environment): IRateLimitDeploymentCacheMapComponent {
+  const deploymentCacheMap: Map<EntityType, { cache: NodeCache; maxSize: number }> = generateDeploymentCacheMap(env)
+
+  function getFromCache(entityType: EntityType): { cache: NodeCache; maxSize: number } {
+    const cache = deploymentCacheMap.get(entityType)
+    if (!cache) {
+      throw new Error(`Invalid Entity Type: ${entityType}`)
+    }
+    return cache
+  }
+
+  return {
+    newDeployment(entityType: EntityType, pointers: Pointer[], localTimestamp: Timestamp): void {
+      const cacheByEntityType = getFromCache(entityType)
+      for (const pointer in pointers) {
+        cacheByEntityType.cache.set(pointer, localTimestamp)
+      }
+    },
+
+    /** Check if the entity should be rate limit: no deployment has been made for the same pointer in the last ttl
+     * and no more than max size of deployments were made either   */
+    isRateLimited(entityType: EntityType, pointers: Pointer[]): boolean {
+      const cacheByEntityType = getFromCache(entityType)
+      return (
+        pointers.some((p) => !!cacheByEntityType.cache.get(p)) ||
+        cacheByEntityType.cache.stats.keys > cacheByEntityType.maxSize
+      )
+    }
+  }
+}
+
+function generateDeploymentCacheMap(env: Environment): Map<EntityType, { cache: NodeCache; maxSize: number }> {
+  const envMaxPerEntity: Map<EntityType, number> = getMaxPerEntityMapConfig(env)
+  const envTtlPerEntity: Map<EntityType, number> = getTtlPerEntityMapConfig(env)
+
+  const deploymentCacheMap: Map<EntityType, { cache: NodeCache; maxSize: number }> = new Map()
+
+  for (const entityType of Object.values(EntityType)) {
+    const ttl: number =
+      envTtlPerEntity.get(entityType) ?? env.getConfig(EnvironmentConfig.DEPLOYMENTS_DEFAULT_RATE_LIMIT_TTL)
+    const maxSize: number =
+      envMaxPerEntity.get(entityType) ?? env.getConfig(EnvironmentConfig.DEPLOYMENTS_DEFAULT_RATE_LIMIT_MAX)
+
+    deploymentCacheMap.set(entityType, {
+      cache: new NodeCache({ stdTTL: ttl, checkperiod: ttl }),
+      maxSize: maxSize
+    })
+  }
+  return deploymentCacheMap
+}
+
+function getTtlPerEntityMapConfig(env: Environment) {
+  const defaultTtlPerEntity: Map<EntityType, number> = new Map([
+    [EntityType.PROFILE, ms('1m')],
+    [EntityType.SCENE, ms('20s')],
+    [EntityType.WEARABLE, ms('20s')],
+    [EntityType.STORE, ms('1m')]
+  ])
+  const envTtlPerEntityOverrideConfig: Map<EntityType, number> =
+    env.getConfig<Map<EntityType, number>>(EnvironmentConfig.DEPLOYMENT_RATE_LIMIT_TTL) ?? new Map()
+  const envTtlPerEntity: Map<EntityType, number> = new Map([...defaultTtlPerEntity, ...envTtlPerEntityOverrideConfig])
+  return envTtlPerEntity
+}
+
+function getMaxPerEntityMapConfig(env: Environment) {
+  const defaultMaxPerEntity: Map<EntityType, number> = new Map([
+    [EntityType.PROFILE, 300],
+    [EntityType.SCENE, 100000],
+    [EntityType.WEARABLE, 100000],
+    [EntityType.STORE, 300]
+  ])
+  const envMaxPerEntityOverrideConfig: Map<EntityType, number> =
+    env.getConfig<Map<EntityType, number>>(EnvironmentConfig.DEPLOYMENT_RATE_LIMIT_MAX) ?? new Map()
+  const envMaxPerEntity: Map<EntityType, number> = new Map([...defaultMaxPerEntity, ...envMaxPerEntityOverrideConfig])
+  return envMaxPerEntity
+}

--- a/content/src/service/ServiceFactory.ts
+++ b/content/src/service/ServiceFactory.ts
@@ -10,7 +10,7 @@ export class ServiceFactory {
       AppComponents,
       | 'pointerManager'
       | 'failedDeploymentsCache'
-      | 'rateLimitDeploymentCacheMap'
+      | 'deployRateLimiter'
       | 'deploymentManager'
       | 'storage'
       | 'repository'

--- a/content/src/service/ServiceFactory.ts
+++ b/content/src/service/ServiceFactory.ts
@@ -1,6 +1,4 @@
 import { Entity, Pointer } from 'dcl-catalyst-commons'
-import NodeCache from 'node-cache'
-import { EnvironmentConfig } from '../Environment'
 import { AppComponents } from '../types'
 import { ENTITIES_BY_POINTERS_CACHE_CONFIG } from './caching/CacheManager'
 import { CacheManagerFactory } from './caching/CacheManagerFactory'
@@ -12,6 +10,7 @@ export class ServiceFactory {
       AppComponents,
       | 'pointerManager'
       | 'failedDeploymentsCache'
+      | 'rateLimitDeploymentCacheMap'
       | 'deploymentManager'
       | 'storage'
       | 'repository'
@@ -29,11 +28,6 @@ export class ServiceFactory {
     // TODO: move this inside ServiceImpl constructor
     const cacheManager = CacheManagerFactory.create(env)
     const cache = cacheManager.buildEntityTypedCache<Pointer, Entity>(ENTITIES_BY_POINTERS_CACHE_CONFIG)
-    const ttl = env.getConfig(EnvironmentConfig.DEPLOYMENTS_RATE_LIMIT_TTL) as number
-    const deploymentsCache = new NodeCache({ stdTTL: ttl, checkperiod: ttl })
-    return new ServiceImpl(components, cache, {
-      cache: deploymentsCache,
-      maxSize: env.getConfig(EnvironmentConfig.DEPLOYMENTS_RATE_LIMIT_MAX)
-    })
+    return new ServiceImpl(components, cache)
   }
 }

--- a/content/src/service/ServiceImpl.ts
+++ b/content/src/service/ServiceImpl.ts
@@ -46,7 +46,7 @@ export class ServiceImpl implements MetaverseContentService {
       | 'storage'
       | 'pointerManager'
       | 'failedDeploymentsCache'
-      | 'rateLimitDeploymentCacheMap'
+      | 'deployRateLimiter'
       | 'deploymentManager'
       | 'validator'
       | 'serverValidator'
@@ -175,7 +175,7 @@ export class ServiceImpl implements MetaverseContentService {
         storeResult.affectedPointers?.forEach((pointer) => this.cache.invalidate(entity.type, pointer))
 
         // Insert in deployments cache the updated entities
-        this.components.rateLimitDeploymentCacheMap.newDeployment(
+        this.components.deployRateLimiter.newDeployment(
           entity.type,
           entity.pointers,
           storeResult.auditInfoComplete.localTimestamp
@@ -472,8 +472,7 @@ export class ServiceImpl implements MetaverseContentService {
       isEntityDeployedAlready: () => isEntityDeployedAlready,
       isNotFailedDeployment: (entity) =>
         this.components.failedDeploymentsCache.findFailedDeployment(entity.id) === undefined,
-      isEntityRateLimited: (entity) =>
-        this.components.rateLimitDeploymentCacheMap.isRateLimited(entity.type, entity.pointers),
+      isEntityRateLimited: (entity) => this.components.deployRateLimiter.isRateLimited(entity.type, entity.pointers),
       isRequestTtlBackwards: (entity) =>
         Date.now() - entity.timestamp > this.components.env.getConfig<number>(EnvironmentConfig.REQUEST_TTL_BACKWARDS)
     })

--- a/content/src/types.ts
+++ b/content/src/types.ts
@@ -5,7 +5,7 @@ import { IJobQueue } from '@dcl/snapshots-fetcher/dist/job-queue-port'
 import { IDeployerComponent, RemoteEntityDeployment } from '@dcl/snapshots-fetcher/dist/types'
 import { IFetchComponent } from '@well-known-components/http-server'
 import { ILoggerComponent, IMetricsComponent } from '@well-known-components/interfaces'
-import { Fetcher } from 'dcl-catalyst-commons'
+import { EntityType, Fetcher } from 'dcl-catalyst-commons'
 import { Controller } from './controller/Controller'
 import { Environment } from './Environment'
 import { metricsDeclaration } from './metrics'
@@ -13,6 +13,7 @@ import { MigrationManager } from './migrations/MigrationManager'
 import { DeploymentListComponent } from './ports/deploymentListComponent'
 import { IFailedDeploymentsCacheComponent } from './ports/failedDeploymentsCache'
 import { IDatabaseComponent } from './ports/postgres'
+import { IRateLimitDeploymentCacheMapComponent } from './ports/rateLimitDeploymentCacheMap'
 import { Repository } from './repository/Repository'
 import { ContentAuthenticator } from './service/auth/Authenticator'
 import { DeploymentManager } from './service/deployments/DeploymentManager'
@@ -53,6 +54,7 @@ export type AppComponents = {
   contentCluster: ContentCluster
   pointerManager: PointerManager
   failedDeploymentsCache: IFailedDeploymentsCacheComponent
+  rateLimitDeploymentCacheMap: IRateLimitDeploymentCacheMapComponent
   deploymentManager: DeploymentManager
   storage: ContentStorage
   authenticator: ContentAuthenticator
@@ -89,4 +91,14 @@ export type StatusProbeResult = {
 
 export type IStatusCapableComponent = {
   getComponentStatus(): Promise<StatusProbeResult>
+}
+
+// TODO: Move this to catalyst-commons
+export function parseEntityType(strType: string): EntityType {
+  if (strType.endsWith('s')) {
+    strType = strType.slice(0, -1)
+  }
+  strType = strType.toUpperCase().trim()
+  const type = EntityType[strType]
+  return type
 }

--- a/content/src/types.ts
+++ b/content/src/types.ts
@@ -12,10 +12,10 @@ import { metricsDeclaration } from './metrics'
 import { MigrationManager } from './migrations/MigrationManager'
 import { DenylistComponent } from './ports/denylist'
 import { DeploymentListComponent } from './ports/deploymentListComponent'
+import { IDeployRateLimiterComponent } from './ports/deployRateLimiterComponent'
 import { IFailedDeploymentsCacheComponent } from './ports/failedDeploymentsCache'
 import { FSComponent } from './ports/fs'
 import { IDatabaseComponent } from './ports/postgres'
-import { IRateLimitDeploymentCacheMapComponent } from './ports/rateLimitDeploymentCacheMap'
 import { ISequentialTaskExecutorComponent } from './ports/sequecuentialTaskExecutor'
 import { Repository } from './repository/Repository'
 import { ContentAuthenticator } from './service/auth/Authenticator'
@@ -57,7 +57,7 @@ export type AppComponents = {
   contentCluster: ContentCluster
   pointerManager: PointerManager
   failedDeploymentsCache: IFailedDeploymentsCacheComponent
-  rateLimitDeploymentCacheMap: IRateLimitDeploymentCacheMapComponent
+  deployRateLimiter: IDeployRateLimiterComponent
   deploymentManager: DeploymentManager
   storage: ContentStorage
   authenticator: ContentAuthenticator

--- a/content/src/types.ts
+++ b/content/src/types.ts
@@ -8,13 +8,13 @@ import { ILoggerComponent, IMetricsComponent } from '@well-known-components/inte
 import { EntityType, Fetcher } from 'dcl-catalyst-commons'
 import { Controller } from './controller/Controller'
 import { Environment } from './Environment'
-import { ISequentialTaskExecutorComponent } from './ports/sequecuentialTaskExecutor'
 import { metricsDeclaration } from './metrics'
 import { MigrationManager } from './migrations/MigrationManager'
 import { DeploymentListComponent } from './ports/deploymentListComponent'
 import { IFailedDeploymentsCacheComponent } from './ports/failedDeploymentsCache'
 import { IDatabaseComponent } from './ports/postgres'
 import { IRateLimitDeploymentCacheMapComponent } from './ports/rateLimitDeploymentCacheMap'
+import { ISequentialTaskExecutorComponent } from './ports/sequecuentialTaskExecutor'
 import { Repository } from './repository/Repository'
 import { ContentAuthenticator } from './service/auth/Authenticator'
 import { DeploymentManager } from './service/deployments/DeploymentManager'
@@ -95,7 +95,7 @@ export type IStatusCapableComponent = {
   getComponentStatus(): Promise<StatusProbeResult>
 }
 
-// TODO: Move this to catalyst-commons
+// TODO: Move this to catalyst-commons and remove the check for trailing s?
 export function parseEntityType(strType: string): EntityType {
   if (strType.endsWith('s')) {
     strType = strType.slice(0, -1)

--- a/content/test/unit/service/Service.spec.ts
+++ b/content/test/unit/service/Service.spec.ts
@@ -9,10 +9,10 @@ import { Environment, EnvironmentConfig } from '../../../src/Environment'
 import { metricsDeclaration } from '../../../src/metrics'
 import { createDenylistComponent, DenylistComponent } from '../../../src/ports/denylist'
 import { createDeploymentListComponent } from '../../../src/ports/deploymentListComponent'
+import { createDeployRateLimiter } from '../../../src/ports/deployRateLimiterComponent'
 import { createFailedDeploymentsCache } from '../../../src/ports/failedDeploymentsCache'
 import { createFsComponent } from '../../../src/ports/fs'
 import { createDatabaseComponent } from '../../../src/ports/postgres'
-import { createRateLimitDeploymentCacheMap } from '../../../src/ports/rateLimitDeploymentCacheMap'
 import { ContentAuthenticator } from '../../../src/service/auth/Authenticator'
 import { DeploymentManager } from '../../../src/service/deployments/DeploymentManager'
 import * as deployments from '../../../src/service/deployments/deployments'
@@ -248,7 +248,7 @@ describe('Service', function () {
     const deploymentManager = new DeploymentManager()
     const failedDeploymentsCache = createFailedDeploymentsCache()
     const logs = createLogComponent()
-    const rateLimitDeploymentCacheMap = createRateLimitDeploymentCacheMap({ logs },
+    const deployRateLimiter = createDeployRateLimiter({ logs },
       { defaultMax: 300, defaultTtl: ms('1m'), entitiesConfigMax: new Map(), entitiesConfigTtl: new Map() })
     const metrics = createTestMetricsComponent(metricsDeclaration)
     const storage = new MockedStorage()
@@ -263,7 +263,7 @@ describe('Service', function () {
       env,
       pointerManager,
       failedDeploymentsCache,
-      rateLimitDeploymentCacheMap,
+      deployRateLimiter,
       deploymentManager,
       storage,
       repository,

--- a/content/test/unit/service/Service.spec.ts
+++ b/content/test/unit/service/Service.spec.ts
@@ -242,10 +242,10 @@ describe('Service', function () {
     const serverValidator = new NoOpServerValidator()
     const deploymentManager = new DeploymentManager()
     const failedDeploymentsCache = createFailedDeploymentsCache()
-    const rateLimitDeploymentCacheMap = createRateLimitDeploymentCacheMap(
+    const logs = createLogComponent()
+    const rateLimitDeploymentCacheMap = createRateLimitDeploymentCacheMap({ logs },
       { defaultMax: 300, defaultTtl: ms('1m'), entitiesConfigMax: new Map(), entitiesConfigTtl: new Map() })
     const metrics = createTestMetricsComponent(metricsDeclaration)
-    const logs = createLogComponent()
     const storage = new MockedStorage()
     const pointerManager = NoOpPointerManager.build()
     const authenticator = new ContentAuthenticator('', DECENTRALAND_ADDRESS)

--- a/content/test/unit/service/Service.spec.ts
+++ b/content/test/unit/service/Service.spec.ts
@@ -4,6 +4,7 @@ import { createTestMetricsComponent } from '@well-known-components/metrics'
 import assert from 'assert'
 import { ContentFileHash, Deployment, Entity, EntityType, EntityVersion, Hashing } from 'dcl-catalyst-commons'
 import { Authenticator } from 'dcl-crypto'
+import ms from 'ms'
 import { Environment } from '../../../src/Environment'
 import { metricsDeclaration } from '../../../src/metrics'
 import { createDeploymentListComponent } from '../../../src/ports/deploymentListComponent'
@@ -241,7 +242,8 @@ describe('Service', function () {
     const serverValidator = new NoOpServerValidator()
     const deploymentManager = new DeploymentManager()
     const failedDeploymentsCache = createFailedDeploymentsCache()
-    const rateLimitDeploymentCacheMap = createRateLimitDeploymentCacheMap(env)
+    const rateLimitDeploymentCacheMap = createRateLimitDeploymentCacheMap(
+      { defaultMax: 300, defaultTtl: ms('1m'), entitiesConfigMax: new Map(), entitiesConfigTtl: new Map() })
     const metrics = createTestMetricsComponent(metricsDeclaration)
     const logs = createLogComponent()
     const storage = new MockedStorage()

--- a/content/test/unit/service/Service.spec.ts
+++ b/content/test/unit/service/Service.spec.ts
@@ -9,6 +9,7 @@ import { metricsDeclaration } from '../../../src/metrics'
 import { createDeploymentListComponent } from '../../../src/ports/deploymentListComponent'
 import { createFailedDeploymentsCache } from '../../../src/ports/failedDeploymentsCache'
 import { createDatabaseComponent } from '../../../src/ports/postgres'
+import { createRateLimitDeploymentCacheMap } from '../../../src/ports/rateLimitDeploymentCacheMap'
 import { ContentAuthenticator } from '../../../src/service/auth/Authenticator'
 import { DeploymentManager } from '../../../src/service/deployments/DeploymentManager'
 import * as deployments from '../../../src/service/deployments/deployments'
@@ -240,6 +241,7 @@ describe('Service', function () {
     const serverValidator = new NoOpServerValidator()
     const deploymentManager = new DeploymentManager()
     const failedDeploymentsCache = createFailedDeploymentsCache()
+    const rateLimitDeploymentCacheMap = createRateLimitDeploymentCacheMap(env)
     const metrics = createTestMetricsComponent(metricsDeclaration)
     const logs = createLogComponent()
     const storage = new MockedStorage()
@@ -252,6 +254,7 @@ describe('Service', function () {
       env,
       pointerManager,
       failedDeploymentsCache,
+      rateLimitDeploymentCacheMap,
       deploymentManager,
       storage,
       repository,


### PR DESCRIPTION
Expand the rate limit when deploying functionality to all entity types, it was used only for profiles. 

It has a default configuration, but it can be overwritten by the owner of the catalyst.