### PR TITLE
New denylist

### DIFF
--- a/content/package.json
+++ b/content/package.json
@@ -70,6 +70,7 @@
     "destroy": "1.0.4",
     "faker": "5.5.3",
     "jest": "27.4.7",
+    "jest-extra-utils": "^0.1.0",
     "jest-junit": "^13.0.0",
     "nyc": "^15.1.0",
     "on-finished": "2.3.0",

--- a/content/src/Environment.ts
+++ b/content/src/Environment.ts
@@ -9,6 +9,7 @@ import { AppComponents } from './types'
 export const CURRENT_CONTENT_VERSION: EntityVersion = EntityVersion.V3
 const DEFAULT_STORAGE_ROOT_FOLDER = 'storage'
 const DEFAULT_SERVER_PORT = 6969
+const DEFAULT_DENYLIST_FILE_NAME = 'denylist.txt'
 const DEFAULT_FOLDER_MIGRATION_MAX_CONCURRENCY = 1000
 export const DEFAULT_ETH_NETWORK = 'ropsten'
 export const DEFAULT_LAND_MANAGER_SUBGRAPH_ROPSTEN =
@@ -126,7 +127,8 @@ export enum EnvironmentConfig {
   BLOCKS_L2_SUBGRAPH_URL,
   VALIDATE_API,
   FOLDER_MIGRATION_MAX_CONCURRENCY,
-  RETRY_FAILED_DEPLOYMENTS_DELAY_TIME
+  RETRY_FAILED_DEPLOYMENTS_DELAY_TIME,
+  DENYLIST_FILE_NAME
 }
 
 export class EnvironmentBuilder {
@@ -155,6 +157,11 @@ export class EnvironmentBuilder {
       env,
       EnvironmentConfig.STORAGE_ROOT_FOLDER,
       () => process.env.STORAGE_ROOT_FOLDER ?? DEFAULT_STORAGE_ROOT_FOLDER
+    )
+    this.registerConfigIfNotAlreadySet(
+      env,
+      EnvironmentConfig.DENYLIST_FILE_NAME,
+      () => process.env.DENYLIST_FILE_NAME ?? DEFAULT_DENYLIST_FILE_NAME
     )
     this.registerConfigIfNotAlreadySet(
       env,

--- a/content/src/components.ts
+++ b/content/src/components.ts
@@ -42,7 +42,7 @@ export async function initComponentsWithEnv(env: Environment): Promise<AppCompon
   const repository = await RepositoryFactory.create({ env, metrics })
   const logs = createLogComponent()
   const fetcher = createFetchComponent()
-  const denylist = await createDenylistComponent({ env })
+  const denylist = await createDenylistComponent({ env, logs })
   const contentStorageFolder = path.join(env.getConfig(EnvironmentConfig.STORAGE_ROOT_FOLDER), 'contents')
   const tmpDownloadFolder = path.join(contentStorageFolder, '_tmp')
   await fs.promises.mkdir(tmpDownloadFolder, { recursive: true })

--- a/content/src/components.ts
+++ b/content/src/components.ts
@@ -3,7 +3,6 @@ import { createJobLifecycleManagerComponent } from '@dcl/snapshots-fetcher/dist/
 import { createJobQueue } from '@dcl/snapshots-fetcher/dist/job-queue-port'
 import { createLogComponent } from '@well-known-components/logger'
 import { createTestMetricsComponent } from '@well-known-components/metrics'
-import fs from 'fs'
 import path from 'path'
 import { Controller } from './controller/Controller'
 import { Environment, EnvironmentConfig } from './Environment'
@@ -14,6 +13,7 @@ import { createDenylistComponent } from './ports/denylist'
 import { createDeploymentListComponent } from './ports/deploymentListComponent'
 import { createFailedDeploymentsCache } from './ports/failedDeploymentsCache'
 import { createFetchComponent } from './ports/fetcher'
+import { createFsComponent } from './ports/fs'
 import { createDatabaseComponent } from './ports/postgres'
 import { createSequentialTaskExecutor } from './ports/sequecuentialTaskExecutor'
 import { RepositoryFactory } from './repository/RepositoryFactory'
@@ -42,10 +42,11 @@ export async function initComponentsWithEnv(env: Environment): Promise<AppCompon
   const repository = await RepositoryFactory.create({ env, metrics })
   const logs = createLogComponent()
   const fetcher = createFetchComponent()
-  const denylist = await createDenylistComponent({ env, logs })
+  const fs = createFsComponent()
+  const denylist = await createDenylistComponent({ env, logs, fs })
   const contentStorageFolder = path.join(env.getConfig(EnvironmentConfig.STORAGE_ROOT_FOLDER), 'contents')
   const tmpDownloadFolder = path.join(contentStorageFolder, '_tmp')
-  await fs.promises.mkdir(tmpDownloadFolder, { recursive: true })
+  await fs.mkdir(tmpDownloadFolder, { recursive: true })
   const staticConfigs = {
     contentStorageFolder,
     tmpDownloadFolder
@@ -240,6 +241,7 @@ export async function initComponentsWithEnv(env: Environment): Promise<AppCompon
     server,
     retryFailedDeployments,
     sequentialExecutor,
-    denylist
+    denylist,
+    fs
   }
 }

--- a/content/src/components.ts
+++ b/content/src/components.ts
@@ -103,7 +103,7 @@ export async function initComponentsWithEnv(env: Environment): Promise<AppCompon
   })
 
   const snapshotManager = new SnapshotManager(
-    { database, metrics, staticConfigs, logs, storage },
+    { database, metrics, staticConfigs, logs, storage, denylist },
     env.getConfig(EnvironmentConfig.SNAPSHOT_FREQUENCY_IN_MILLISECONDS)
   )
 
@@ -197,7 +197,8 @@ export async function initComponentsWithEnv(env: Environment): Promise<AppCompon
       logs,
       metrics,
       database,
-      sequentialExecutor
+      sequentialExecutor,
+      denylist
     },
     ethNetwork
   )

--- a/content/src/controller/Controller.ts
+++ b/content/src/controller/Controller.ts
@@ -271,7 +271,7 @@ export class Controller {
     const { deployments } = await this.components.deployer.getDeployments({
       fields: [DeploymentField.AUDIT_INFO],
       filters: { entityIds: [entityId], entityTypes: [type], includeOverwrittenInfo: true },
-      addDenylisted: true
+      includeDenylisted: true
     })
 
     if (deployments.length > 0) {

--- a/content/src/controller/Controller.ts
+++ b/content/src/controller/Controller.ts
@@ -411,8 +411,8 @@ export class Controller {
     // Path: /contents/:hashId/active-entities
     const hashId = req.params.hashId
 
-    const result = await getActiveDeploymentsByContentHash(this.components, hashId)
-    result.filter((entityId) => !this.components.denylist.isDenyListed(entityId))
+    let result = await getActiveDeploymentsByContentHash(this.components, hashId)
+    result = result.filter((entityId) => !this.components.denylist.isDenyListed(entityId))
 
     if (result.length === 0) {
       res.status(404).send({ error: 'The entity was not found' })

--- a/content/src/controller/Controller.ts
+++ b/content/src/controller/Controller.ts
@@ -20,6 +20,7 @@ import onFinished from 'on-finished'
 import { CURRENT_CATALYST_VERSION, CURRENT_COMMIT_HASH, CURRENT_CONTENT_VERSION } from '../Environment'
 import { getActiveDeploymentsByContentHash } from '../logic/database-queries/deployments-queries'
 import { statusResponseFromComponents } from '../logic/status-checks'
+import { getDeployments } from '../service/deployments/deployments'
 import { DeploymentOptions } from '../service/deployments/types'
 import { getPointerChanges } from '../service/pointers/pointers'
 import { DeploymentPointerChanges, PointerChangesFilters } from '../service/pointers/types'
@@ -267,8 +268,7 @@ export class Controller {
       return
     }
 
-    // don't replace this until the denylist is implemented outside of the service
-    const { deployments } = await this.components.deployer.getDeployments({
+    const { deployments } = await getDeployments(this.components, {
       fields: [DeploymentField.AUDIT_INFO],
       filters: { entityIds: [entityId], entityTypes: [type], includeOverwrittenInfo: true },
       includeDenylisted: true
@@ -526,10 +526,9 @@ export class Controller {
       lastId: lastId
     }
 
-    // don't replace this until the denylist is implemented outside of the service
     const { deployments, filters, pagination } = await this.components.sequentialExecutor.run(
       'GetDeploymentsEndpoint',
-      () => this.components.deployer.getDeployments(deploymentOptions)
+      () => getDeployments(this.components, deploymentOptions)
     )
     const controllerDeployments = deployments.map((deployment) =>
       ControllerDeploymentFactory.deployment2ControllerEntity(deployment, enumFields)

--- a/content/src/controller/Controller.ts
+++ b/content/src/controller/Controller.ts
@@ -53,6 +53,7 @@ export class Controller {
     Controller.LOGGER = components.logs.getLogger('Controller')
   }
 
+  //TODO! Cambiar aca
   async getEntities(req: express.Request, res: express.Response) {
     // Method: GET
     // Path: /entities/:type
@@ -233,6 +234,7 @@ export class Controller {
     }
   }
 
+  //TODO! ver de cambiar aca
   async getAvailableContent(req: express.Request, res: express.Response) {
     // Method: GET
     // Path: /available-content
@@ -252,6 +254,7 @@ export class Controller {
     }
   }
 
+  //TODO! cambiar aca
   async getAudit(req: express.Request, res: express.Response) {
     // Method: GET
     // Path: /audit/:type/:entityId
@@ -267,7 +270,8 @@ export class Controller {
     // don't replace this until the denylist is implemented outside of the service
     const { deployments } = await this.components.deployer.getDeployments({
       fields: [DeploymentField.AUDIT_INFO],
-      filters: { entityIds: [entityId], entityTypes: [type], includeOverwrittenInfo: true }
+      filters: { entityIds: [entityId], entityTypes: [type], includeOverwrittenInfo: true },
+      addDenylisted: true
     })
 
     if (deployments.length > 0) {
@@ -417,6 +421,7 @@ export class Controller {
     res.json(result)
   }
 
+  //TODO! cambiar aca
   async getDeployments(req: express.Request, res: express.Response) {
     // Method: GET
     // Path: /deployments

--- a/content/src/controller/ControllerEntityFactory.ts
+++ b/content/src/controller/ControllerEntityFactory.ts
@@ -1,4 +1,4 @@
-import { Deployment, Entity, EntityContentItemReference } from 'dcl-catalyst-commons'
+import { Entity, EntityContentItemReference } from 'dcl-catalyst-commons'
 import { EntityField } from './Controller'
 
 export class ControllerEntityFactory {
@@ -17,17 +17,5 @@ export class ControllerEntityFactory {
       pointers = fullEntity.pointers
     }
     return { version, id, type, timestamp, pointers, content, metadata }
-  }
-
-  static maskDeployment(fullDeployment: Deployment, fields?: EntityField[]): Entity {
-    const entity: Entity = {
-      ...fullDeployment,
-      version: fullDeployment.entityVersion,
-      id: fullDeployment.entityId,
-      timestamp: fullDeployment.entityTimestamp,
-      type: fullDeployment.entityType,
-      content: fullDeployment.content?.map((item) => ({ file: item.key, hash: item.hash }))
-    }
-    return this.maskEntity(entity, fields)
   }
 }

--- a/content/src/logic/database-queries/deployments-queries.ts
+++ b/content/src/logic/database-queries/deployments-queries.ts
@@ -262,7 +262,7 @@ export async function getActiveDeploymentsByContentHash(
   components: Pick<AppComponents, 'database'>,
   contentHash: string
 ): Promise<EntityId[]> {
-  const query = SQL`SELECT deployment.entity_id FROM deployments as deployment INNER JOIN content_files ON content_files.deployment=id \
+  const query = SQL`SELECT deployment.entity_id FROM deployments as deployment INNER JOIN content_files ON content_files.deployment=deployment.id
     WHERE content_hash=${contentHash} AND deployment.deleter_deployment IS NULL;`
 
   const queryResult = (await components.database.queryWithValues(query)).rows

--- a/content/src/logic/database-queries/deployments-queries.ts
+++ b/content/src/logic/database-queries/deployments-queries.ts
@@ -1,6 +1,7 @@
 import {
   DeploymentFilters,
   DeploymentSorting,
+  EntityId,
   EntityType,
   EntityVersion,
   Pointer,
@@ -255,4 +256,18 @@ export function createOrClause(
     .append(` ${compare}`) // raw values need to be strings not sql templates
     .append(SQL` to_timestamp(${timestamp} / 1000.0))`)
   return SQL`(`.append(equalWithEntityIdComparison).append(' OR ').append(timestampComparison).append(')')
+}
+
+export async function getActiveDeploymentsByContentHash(
+  components: Pick<AppComponents, 'database'>,
+  contentHash: string
+): Promise<EntityId[]> {
+  const query = SQL`SELECT deployment.entity_id FROM deployments as deployment INNER JOIN content_files ON content_files.deployment=id \
+    WHERE content_hash=${contentHash} AND deployment.deleter_deployment IS NULL;`
+
+  const queryResult = (await components.database.queryWithValues(query)).rows
+
+  const entities = queryResult.map((deployment: { entity_id: EntityId }) => deployment.entity_id)
+
+  return entities
 }

--- a/content/src/ports/denylist.ts
+++ b/content/src/ports/denylist.ts
@@ -10,8 +10,6 @@ export interface DenylistComponent {
 export async function createDenylistComponent(components: Pick<AppComponents, 'env'>): Promise<DenylistComponent> {
   const bannedList = new Set()
 
-  console.log('storage', components.env.getConfig(EnvironmentConfig.STORAGE_ROOT_FOLDER))
-
   const fileName = resolve(
     components.env.getConfig(EnvironmentConfig.STORAGE_ROOT_FOLDER),
     components.env.getConfig(EnvironmentConfig.DENYLIST_FILE_NAME)

--- a/content/src/ports/denylist.ts
+++ b/content/src/ports/denylist.ts
@@ -1,0 +1,38 @@
+import { resolve } from 'path'
+import { EnvironmentConfig } from '../Environment'
+import { createReadStream, promises } from '../helpers/fsWrapper'
+import { AppComponents } from '../types'
+
+export interface DenylistComponent {
+  isDenyListed(hash: string): boolean
+}
+
+export async function createDenylistComponent(components: Pick<AppComponents, 'env'>): Promise<DenylistComponent> {
+  const bannedList = new Set()
+
+  console.log('storage', components.env.getConfig(EnvironmentConfig.STORAGE_ROOT_FOLDER))
+
+  const fileName = resolve(
+    components.env.getConfig(EnvironmentConfig.STORAGE_ROOT_FOLDER),
+    components.env.getConfig(EnvironmentConfig.DENYLIST_FILE_NAME)
+  )
+
+  try {
+    await promises.access(fileName)
+    const content = await createReadStream(fileName, {
+      encoding: 'utf-8'
+    })
+
+    for await (const line of content) {
+      bannedList.add((line as string).trim())
+    }
+  } catch (err) {}
+
+  const isDenyListed = (hash: string): boolean => {
+    return bannedList.has(hash)
+  }
+
+  return {
+    isDenyListed
+  }
+}

--- a/content/src/ports/denylist.ts
+++ b/content/src/ports/denylist.ts
@@ -1,7 +1,7 @@
+import { existPath } from '@catalyst/commons'
 import { resolve } from 'path'
 import { createInterface } from 'readline'
 import { EnvironmentConfig } from '../Environment'
-import { createReadStream, promises } from '../helpers/fsWrapper'
 import { AppComponents } from '../types'
 
 export interface DenylistComponent {
@@ -9,7 +9,7 @@ export interface DenylistComponent {
 }
 
 export async function createDenylistComponent(
-  components: Pick<AppComponents, 'env' | 'logs'>
+  components: Pick<AppComponents, 'env' | 'logs' | 'fs'>
 ): Promise<DenylistComponent> {
   const logs = components.logs.getLogger('Denylist')
   const bannedList = new Set()
@@ -20,9 +20,9 @@ export async function createDenylistComponent(
   )
 
   try {
-    await promises.access(fileName)
+    await existPath(fileName)
 
-    const content = await createReadStream(fileName, {
+    const content = await components.fs.createReadStream(fileName, {
       encoding: 'utf-8'
     })
 
@@ -37,6 +37,7 @@ export async function createDenylistComponent(
 
     logs.info('Load successfully the denylist')
   } catch (err) {
+    console.log('ERR', err)
     logs.warn("Couldn't load a denylist")
   }
 

--- a/content/src/ports/denylist.ts
+++ b/content/src/ports/denylist.ts
@@ -1,4 +1,5 @@
 import { resolve } from 'path'
+import { createInterface } from 'readline'
 import { EnvironmentConfig } from '../Environment'
 import { createReadStream, promises } from '../helpers/fsWrapper'
 import { AppComponents } from '../types'
@@ -25,7 +26,12 @@ export async function createDenylistComponent(
       encoding: 'utf-8'
     })
 
-    for await (const line of content) {
+    const lines = createInterface({
+      input: content,
+      crlfDelay: Infinity
+    })
+
+    for await (const line of lines) {
       bannedList.add((line as string).trim())
     }
 

--- a/content/src/ports/fs.ts
+++ b/content/src/ports/fs.ts
@@ -1,0 +1,16 @@
+import fs from 'fs'
+import * as fsPromises from 'fs/promises'
+
+export type FSComponent = Pick<typeof fs, 'createReadStream'> &
+  Pick<typeof fsPromises, 'access' | 'opendir' | 'stat' | 'unlink' | 'mkdir'>
+
+export function createFsComponent(): FSComponent {
+  return {
+    createReadStream: fs.createReadStream,
+    access: fsPromises.access,
+    opendir: fsPromises.opendir,
+    stat: fsPromises.stat,
+    unlink: fsPromises.unlink,
+    mkdir: fsPromises.mkdir
+  }
+}

--- a/content/src/repository/extensions/DeploymentsRepository.ts
+++ b/content/src/repository/extensions/DeploymentsRepository.ts
@@ -76,17 +76,6 @@ export class DeploymentsRepository {
       return transaction.batch(updates)
     })
   }
-
-  async getActiveDeploymentsByContentHash(contentHash: string): Promise<EntityId[]> {
-    return this.db.map(
-      `SELECT ` +
-        `deployment.entity_id ` +
-        `FROM deployments as deployment INNER JOIN content_files ON content_files.deployment=id ` +
-        `WHERE content_hash=$1 AND deployment.deleter_deployment IS NULL;`,
-      [contentHash],
-      (row) => row.entity_id
-    )
-  }
 }
 
 export type DeploymentId = number

--- a/content/src/service/Service.ts
+++ b/content/src/service/Service.ts
@@ -30,7 +30,6 @@ export interface MetaverseContentService {
   isContentAvailable(fileHashes: ContentFileHash[]): Promise<Map<ContentFileHash, boolean>>
   getContent(fileHash: ContentFileHash): Promise<ContentItem | undefined>
   getDeployments(options?: DeploymentOptions): Promise<PartialDeploymentHistory<Deployment>>
-  getActiveDeploymentsByContentHash(hash: string, task?: Database): Promise<EntityId[]>
   getAllFailedDeployments(): FailedDeployment[]
   getEntitiesByIds(ids: EntityId[]): Promise<Entity[]>
   getEntitiesByPointers(type: EntityType, pointers: Pointer[]): Promise<Entity[]>

--- a/content/src/service/ServiceFactory.ts
+++ b/content/src/service/ServiceFactory.ts
@@ -23,6 +23,7 @@ export class ServiceFactory {
       | 'authenticator'
       | 'database'
       | 'deployedEntitiesFilter'
+      | 'denylist'
     >
   ): ServiceImpl {
     const { env } = components

--- a/content/src/service/ServiceImpl.ts
+++ b/content/src/service/ServiceImpl.ts
@@ -56,6 +56,7 @@ export class ServiceImpl implements MetaverseContentService {
       | 'database'
       | 'deployedEntitiesFilter'
       | 'env'
+      | 'denylist'
     >,
     private readonly cache: CacheByType<Pointer, Entity>,
     private readonly deploymentsCache: { cache: NodeCache; maxSize: number }

--- a/content/src/service/ServiceImpl.ts
+++ b/content/src/service/ServiceImpl.ts
@@ -470,20 +470,6 @@ export class ServiceImpl implements MetaverseContentService {
     return getDeployments(this.components, options)
   }
 
-  // This endpoint is for debugging purposes
-  getActiveDeploymentsByContentHash(hash: string, task?: Database): Promise<EntityId[]> {
-    return this.components.repository.reuseIfPresent(
-      task,
-      (db) =>
-        db.taskIf((task) =>
-          this.components.deploymentManager.getActiveDeploymentsByContentHash(task.deployments, hash)
-        ),
-      {
-        priority: DB_REQUEST_PRIORITY.LOW
-      }
-    )
-  }
-
   getAllFailedDeployments(): FailedDeployment[] {
     return this.components.failedDeploymentsCache.getAllFailedDeployments()
   }

--- a/content/src/service/deployments/DeploymentManager.ts
+++ b/content/src/service/deployments/DeploymentManager.ts
@@ -1,4 +1,4 @@
-import { AuditInfo, Entity, EntityId } from 'dcl-catalyst-commons'
+import { AuditInfo, Entity } from 'dcl-catalyst-commons'
 import { ContentFilesRepository } from '../../repository/extensions/ContentFilesRepository'
 import { DeploymentPointerChangesRepository } from '../../repository/extensions/DeploymentPointerChangesRepository'
 import { DeploymentId, DeploymentsRepository } from '../../repository/extensions/DeploymentsRepository'
@@ -17,13 +17,6 @@ export class DeploymentManager {
     | undefined
   > {
     return deploymentsRepository.getEntityById(entityId)
-  }
-
-  async getActiveDeploymentsByContentHash(
-    deploymentsRepository: DeploymentsRepository,
-    hash: string
-  ): Promise<EntityId[]> {
-    return deploymentsRepository.getActiveDeploymentsByContentHash(hash)
   }
 
   async saveDeployment(

--- a/content/src/service/deployments/deployments.ts
+++ b/content/src/service/deployments/deployments.ts
@@ -41,7 +41,7 @@ export async function getDeployments(
   // TODO [new-sync]: migrationData nolonger required
   const migrationData = await getMigrationData(components, deploymentIds)
 
-  if (!options?.addDenylisted) {
+  if (!options?.includeDenylisted) {
     deploymentsResult = deploymentsResult.filter((result) => !components.denylist.isDenyListed(result.entityId))
   }
 

--- a/content/src/service/deployments/types.ts
+++ b/content/src/service/deployments/types.ts
@@ -15,5 +15,5 @@ export type PointerChangesOptions = {
 
 export type DeploymentOptions = {
   fields?: DeploymentField[]
-  addDenylisted?: boolean
+  includeDenylisted?: boolean
 } & DeploymentRequestOptions

--- a/content/src/service/deployments/types.ts
+++ b/content/src/service/deployments/types.ts
@@ -15,4 +15,5 @@ export type PointerChangesOptions = {
 
 export type DeploymentOptions = {
   fields?: DeploymentField[]
+  addDenylisted?: boolean
 } & DeploymentRequestOptions

--- a/content/src/service/snapshots/SnapshotManager.ts
+++ b/content/src/service/snapshots/SnapshotManager.ts
@@ -32,7 +32,10 @@ export class SnapshotManager implements IStatusCapableComponent, ISnapshotManage
   }
 
   constructor(
-    private readonly components: Pick<AppComponents, 'database' | 'metrics' | 'staticConfigs' | 'logs' | 'storage'>,
+    private readonly components: Pick<
+      AppComponents,
+      'database' | 'metrics' | 'staticConfigs' | 'logs' | 'storage' | 'denylist'
+    >,
     private readonly snapshotFrequencyInMilliSeconds: number
   ) {
     this.LOGGER = components.logs.getLogger('SnapshotManager')
@@ -186,6 +189,10 @@ export class SnapshotManager implements IStatusCapableComponent, ISnapshotManage
     // Phase 2) iterate all active deployments and write to files
     try {
       for await (const snapshotElem of streamActiveDeployments(this.components)) {
+        if (this.components.denylist.isDenyListed(snapshotElem.entityId)) {
+          continue
+        }
+
         // TODO: [new-sync] filter out denylisted entities
 
         const str = JSON.stringify(snapshotElem) + '\n'

--- a/content/src/service/snapshots/SnapshotManager.ts
+++ b/content/src/service/snapshots/SnapshotManager.ts
@@ -193,8 +193,6 @@ export class SnapshotManager implements IStatusCapableComponent, ISnapshotManage
           continue
         }
 
-        // TODO: [new-sync] filter out denylisted entities
-
         const str = JSON.stringify(snapshotElem) + '\n'
 
         // update ALL_ENTITIES timestamp

--- a/content/src/types.ts
+++ b/content/src/types.ts
@@ -13,6 +13,7 @@ import { MigrationManager } from './migrations/MigrationManager'
 import { DenylistComponent } from './ports/denylist'
 import { DeploymentListComponent } from './ports/deploymentListComponent'
 import { IFailedDeploymentsCacheComponent } from './ports/failedDeploymentsCache'
+import { FSComponent } from './ports/fs'
 import { IDatabaseComponent } from './ports/postgres'
 import { ISequentialTaskExecutorComponent } from './ports/sequecuentialTaskExecutor'
 import { Repository } from './repository/Repository'
@@ -69,6 +70,7 @@ export type AppComponents = {
   retryFailedDeployments: IRetryFailedDeploymentsComponent
   sequentialExecutor: ISequentialTaskExecutorComponent
   denylist: DenylistComponent
+  fs: FSComponent
 
   // this will be replaced by `database` and removed from here
   repository: Repository

--- a/content/src/types.ts
+++ b/content/src/types.ts
@@ -8,12 +8,13 @@ import { ILoggerComponent, IMetricsComponent } from '@well-known-components/inte
 import { Fetcher } from 'dcl-catalyst-commons'
 import { Controller } from './controller/Controller'
 import { Environment } from './Environment'
-import { ISequentialTaskExecutorComponent } from './ports/sequecuentialTaskExecutor'
 import { metricsDeclaration } from './metrics'
 import { MigrationManager } from './migrations/MigrationManager'
+import { DenylistComponent } from './ports/denylist'
 import { DeploymentListComponent } from './ports/deploymentListComponent'
 import { IFailedDeploymentsCacheComponent } from './ports/failedDeploymentsCache'
 import { IDatabaseComponent } from './ports/postgres'
+import { ISequentialTaskExecutorComponent } from './ports/sequecuentialTaskExecutor'
 import { Repository } from './repository/Repository'
 import { ContentAuthenticator } from './service/auth/Authenticator'
 import { DeploymentManager } from './service/deployments/DeploymentManager'
@@ -67,6 +68,7 @@ export type AppComponents = {
   server: Server
   retryFailedDeployments: IRetryFailedDeploymentsComponent
   sequentialExecutor: ISequentialTaskExecutorComponent
+  denylist: DenylistComponent
 
   // this will be replaced by `database` and removed from here
   repository: Repository

--- a/content/test/helpers/service/MockedMetaverseContentService.ts
+++ b/content/test/helpers/service/MockedMetaverseContentService.ts
@@ -108,15 +108,6 @@ export class MockedMetaverseContentService implements MetaverseContentService, I
     })
   }
 
-  getActiveDeploymentsByContentHash(hash: string): Promise<EntityId[]> {
-    return Promise.resolve(
-      this.entities
-        .filter((entity) => entity.content?.find((item) => item.hash === hash) !== undefined)
-        .map((entity) => this.entityToDeployment(entity))
-        .map((entity) => entity.entityId)
-    )
-  }
-
   deployEntity(
     files: Buffer[],
     entityId: EntityId,

--- a/content/test/integration/service/deployments/pointer-changes-check.spec.ts
+++ b/content/test/integration/service/deployments/pointer-changes-check.spec.ts
@@ -105,7 +105,7 @@ loadStandaloneTestEnvironment()('Integration - Pointer Changes Check', (testEnv)
   }
 
   async function getChangesInPointersFor(
-    components: Pick<AppComponents, 'database'>,
+    components: Pick<AppComponents, 'database' | 'denylist'>,
     entityCombo: EntityCombo
   ): Promise<PointerChanges> {
     const result = await getPointerChanges(components, {

--- a/content/test/unit/ports/denylist.spec.ts
+++ b/content/test/unit/ports/denylist.spec.ts
@@ -1,0 +1,31 @@
+import { createLogComponent } from '@well-known-components/logger'
+import { Environment, EnvironmentConfig } from '../../../src/Environment'
+import { createDenylistComponent } from '../../../src/ports/denylist'
+
+const lines = ['my', 'first', 'denylisted', 'item']
+
+jest.mock('../../../src/helpers/fsWrapper', () => ({
+  createReadStream: () => lines,
+  promises: { access: () => true }
+}))
+
+describe('denylist', () => {
+  describe('when creating a denylist it should read a file to load the denylisted items', () => {
+    const env = new Environment()
+    env.setConfig(EnvironmentConfig.STORAGE_ROOT_FOLDER, 'inexistent')
+    env.setConfig(EnvironmentConfig.DENYLIST_FILE_NAME, 'file')
+    const logs = createLogComponent()
+
+    it('should have denylisted each line from the file', async () => {
+      const denylist = await createDenylistComponent({ env, logs })
+
+      expect(lines.every((line) => denylist.isDenyListed(line))).toBe(true)
+    })
+
+    it('should not have denylisted another word', async () => {
+      const denylist = await createDenylistComponent({ env, logs })
+
+      expect(denylist.isDenyListed('RANDOM')).toBe(false)
+    })
+  })
+})

--- a/content/test/unit/ports/denylist.spec.ts
+++ b/content/test/unit/ports/denylist.spec.ts
@@ -1,11 +1,12 @@
 import { createLogComponent } from '@well-known-components/logger'
+import { Readable } from 'stream'
 import { Environment, EnvironmentConfig } from '../../../src/Environment'
 import { createDenylistComponent } from '../../../src/ports/denylist'
 
-const lines = ['my', 'first', 'denylisted', 'item']
+const lines = ['my\n', 'first\n', 'denylisted\n', 'item\n']
 
 jest.mock('../../../src/helpers/fsWrapper', () => ({
-  createReadStream: () => lines,
+  createReadStream: () => Readable.from(lines),
   promises: { access: () => true }
 }))
 
@@ -19,7 +20,7 @@ describe('denylist', () => {
     it('should have denylisted each line from the file', async () => {
       const denylist = await createDenylistComponent({ env, logs })
 
-      expect(lines.every((line) => denylist.isDenyListed(line))).toBe(true)
+      expect(lines.every((line) => denylist.isDenyListed(line.trimEnd()))).toBe(true)
     })
 
     it('should not have denylisted another word', async () => {

--- a/content/test/unit/repository/DeploymentsRepository.spec.ts
+++ b/content/test/unit/repository/DeploymentsRepository.spec.ts
@@ -153,23 +153,4 @@ describe('DeploymentRepository', () => {
       verify(db.batch(anything())).once()
     })
   })
-
-  describe('getDeploymentByHash', () => {
-    const dbResult = ['1', '2']
-    const hashToSearch = 'myCustomHash'
-
-    beforeEach(async () => {
-      db = mock(MockedDataBase)
-      repository = new DeploymentsRepository(instance(db) as any)
-
-      when(db.map(anything(), anything(), anything())).thenReturn(Promise.resolve(dbResult))
-      await repository.getActiveDeploymentsByContentHash(hashToSearch)
-    })
-
-    it('should call the db with the expected parameters', () => {
-      const expectedQuery = `SELECT deployment.entity_id FROM deployments as deployment INNER JOIN content_files ON content_files.deployment=id WHERE content_hash=$1 AND deployment.deleter_deployment IS NULL;`
-
-      verify(db.map(expectedQuery, deepEqual([hashToSearch]), anything())).once()
-    })
-  })
 })

--- a/content/test/unit/service/Service.spec.ts
+++ b/content/test/unit/service/Service.spec.ts
@@ -9,6 +9,7 @@ import { metricsDeclaration } from '../../../src/metrics'
 import { createDenylistComponent, DenylistComponent } from '../../../src/ports/denylist'
 import { createDeploymentListComponent } from '../../../src/ports/deploymentListComponent'
 import { createFailedDeploymentsCache } from '../../../src/ports/failedDeploymentsCache'
+import { createFsComponent } from '../../../src/ports/fs'
 import { createDatabaseComponent } from '../../../src/ports/postgres'
 import { ContentAuthenticator } from '../../../src/service/auth/Authenticator'
 import { DeploymentManager } from '../../../src/service/deployments/DeploymentManager'
@@ -251,7 +252,8 @@ describe('Service', function () {
     const authenticator = new ContentAuthenticator('', DECENTRALAND_ADDRESS)
     const database = await createDatabaseComponent({ logs, env })
     const deployedEntitiesFilter = createDeploymentListComponent({ database, logs })
-    const denylist: DenylistComponent = await createDenylistComponent({ env, logs })
+    const fs = createFsComponent()
+    const denylist: DenylistComponent = await createDenylistComponent({ env, logs, fs })
 
     return ServiceFactory.create({
       env,

--- a/content/test/unit/service/Service.spec.ts
+++ b/content/test/unit/service/Service.spec.ts
@@ -4,8 +4,9 @@ import { createTestMetricsComponent } from '@well-known-components/metrics'
 import assert from 'assert'
 import { ContentFileHash, Deployment, Entity, EntityType, EntityVersion, Hashing } from 'dcl-catalyst-commons'
 import { Authenticator } from 'dcl-crypto'
-import { Environment } from '../../../src/Environment'
+import { Environment, EnvironmentConfig } from '../../../src/Environment'
 import { metricsDeclaration } from '../../../src/metrics'
+import { createDenylistComponent, DenylistComponent } from '../../../src/ports/denylist'
 import { createDeploymentListComponent } from '../../../src/ports/deploymentListComponent'
 import { createFailedDeploymentsCache } from '../../../src/ports/failedDeploymentsCache'
 import { createDatabaseComponent } from '../../../src/ports/postgres'
@@ -236,6 +237,9 @@ describe('Service', function () {
   async function buildService() {
     const repository = MockedRepository.build(new Map([[EntityType.SCENE, initialAmountOfDeployments]]))
     const env = new Environment()
+    env.setConfig(EnvironmentConfig.STORAGE_ROOT_FOLDER, 'inexistent')
+    env.setConfig(EnvironmentConfig.DENYLIST_FILE_NAME, 'file')
+
     const validator = new NoOpValidator()
     const serverValidator = new NoOpServerValidator()
     const deploymentManager = new DeploymentManager()
@@ -247,6 +251,7 @@ describe('Service', function () {
     const authenticator = new ContentAuthenticator('', DECENTRALAND_ADDRESS)
     const database = await createDatabaseComponent({ logs, env })
     const deployedEntitiesFilter = createDeploymentListComponent({ database, logs })
+    const denylist: DenylistComponent = await createDenylistComponent({ env })
 
     return ServiceFactory.create({
       env,
@@ -261,7 +266,8 @@ describe('Service', function () {
       logs,
       authenticator,
       database,
-      deployedEntitiesFilter
+      deployedEntitiesFilter,
+      denylist
     })
   }
 

--- a/content/test/unit/service/Service.spec.ts
+++ b/content/test/unit/service/Service.spec.ts
@@ -251,7 +251,7 @@ describe('Service', function () {
     const authenticator = new ContentAuthenticator('', DECENTRALAND_ADDRESS)
     const database = await createDatabaseComponent({ logs, env })
     const deployedEntitiesFilter = createDeploymentListComponent({ database, logs })
-    const denylist: DenylistComponent = await createDenylistComponent({ env })
+    const denylist: DenylistComponent = await createDenylistComponent({ env, logs })
 
     return ServiceFactory.create({
       env,

--- a/content/test/unit/service/deployments/deployments.spec.ts
+++ b/content/test/unit/service/deployments/deployments.spec.ts
@@ -14,7 +14,7 @@ import { AppComponents } from '../../../../src/types'
 
 describe('deployments service', () => {
   describe('getDeployments', () => {
-    let components: Pick<AppComponents, 'database'>
+    let components: Pick<AppComponents, 'database' | 'denylist'>
     let result: PartialDeploymentHistory<Deployment>
 
     const deploymentIds = [127, 255]
@@ -80,7 +80,7 @@ describe('deployments service', () => {
     }
 
     beforeAll(() => {
-      components = { database: { queryWithValues: () => {} } as any }
+      components = { database: { queryWithValues: () => {} } as any, denylist: { isDenyListed: () => false } }
       stub(components.database, 'queryWithValues')
         .onFirstCall()
         .resolves({ rows: historicalDeploymentsRows, rowCount: 2 })

--- a/content/test/unit/service/deployments/deployments.spec.ts
+++ b/content/test/unit/service/deployments/deployments.spec.ts
@@ -140,6 +140,38 @@ describe('deployments service', () => {
         )
       })
     })
+
+    describe('with a denylisted item but with includeDenylisted param', () => {
+      beforeAll(() => {
+        components = { database: { queryWithValues: () => {} } as any, denylist: { isDenyListed: () => false } }
+        stub(components.database, 'queryWithValues')
+          .onFirstCall()
+          .resolves({ rows: historicalDeploymentsRows, rowCount: 2 })
+          .onSecondCall()
+          .resolves({ rows: contentFiles, rowCount: 2 })
+          .onThirdCall()
+          .resolves({ rows: migrationData, rowCount: 2 })
+      })
+
+      afterAll(() => {
+        restore()
+      })
+
+      it("should not return a deployment if it's denylisted", async () => {
+        stub(components.denylist, 'isDenyListed').onFirstCall().returns(true).returns(false)
+        result = await getDeployments(components, { ...options, includeDenylisted: true })
+
+        expect(result).toEqual(
+          expect.objectContaining({
+            deployments: expect.arrayContaining([
+              expect.objectContaining({ entityId: historicalDeploymentsRows[0].entity_id }),
+              expect.objectContaining({ entityId: historicalDeploymentsRows[1].entity_id })
+            ]),
+            filters: options.filters
+          })
+        )
+      })
+    })
   })
 
   describe('getCuratedOffset', () => {

--- a/content/test/unit/service/deployments/deployments.spec.ts
+++ b/content/test/unit/service/deployments/deployments.spec.ts
@@ -1,4 +1,5 @@
 import { Deployment, EntityType, EntityVersion, PartialDeploymentHistory } from 'dcl-catalyst-commons'
+import { safe } from 'jest-extra-utils'
 import { restore, stub } from 'sinon'
 import { ContentFilesRow } from '../../../../src/logic/database-queries/content-files-queries'
 import { HistoricalDeploymentsRow } from '../../../../src/logic/database-queries/deployments-queries'
@@ -81,7 +82,7 @@ describe('deployments service', () => {
 
     describe('when no item is denylisted', () => {
       beforeAll(() => {
-        components = { database: { queryWithValues: () => {} } as any, denylist: { isDenyListed: () => false } }
+        components = { database: safe({ queryWithValues: () => {} }), denylist: { isDenyListed: () => false } }
         stub(components.database, 'queryWithValues')
           .onFirstCall()
           .resolves({ rows: historicalDeploymentsRows, rowCount: 2 })
@@ -112,7 +113,7 @@ describe('deployments service', () => {
 
     describe('with a denylisted item', () => {
       beforeAll(() => {
-        components = { database: { queryWithValues: () => {} } as any, denylist: { isDenyListed: () => false } }
+        components = { database: safe({ queryWithValues: () => {} }), denylist: { isDenyListed: () => false } }
         stub(components.database, 'queryWithValues')
           .onFirstCall()
           .resolves({ rows: historicalDeploymentsRows, rowCount: 2 })
@@ -143,7 +144,7 @@ describe('deployments service', () => {
 
     describe('with a denylisted item but with includeDenylisted param', () => {
       beforeAll(() => {
-        components = { database: { queryWithValues: () => {} } as any, denylist: { isDenyListed: () => false } }
+        components = { database: safe({ queryWithValues: () => {} }), denylist: { isDenyListed: () => false } }
         stub(components.database, 'queryWithValues')
           .onFirstCall()
           .resolves({ rows: historicalDeploymentsRows, rowCount: 2 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -3788,6 +3788,13 @@ error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
+error-stack-parser@^2.0.6:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/error-stack-parser/-/error-stack-parser-2.0.7.tgz#b0c6e2ce27d0495cf78ad98715e0cad1219abb57"
+  integrity sha512-chLOW0ZGRf4s8raLrDxa5sdkvPec5YdvwbFnqJme4rk0rFajP8mPtrDL1+I+CwrQDCjswDA5sREX7jYQDQs9vA==
+  dependencies:
+    stackframe "^1.1.1"
+
 es-abstract@^1.18.0-next.2:
   version "1.18.5"
   resolved "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.5.tgz"
@@ -5864,6 +5871,13 @@ jest-environment-node@^27.4.6:
     "@types/node" "*"
     jest-mock "^27.4.6"
     jest-util "^27.4.2"
+
+jest-extra-utils@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/jest-extra-utils/-/jest-extra-utils-0.1.0.tgz#214b069d16b5a552d7c229d52bbc586bfb452349"
+  integrity sha512-NCSSKTgEmGcaat84mUu6diKRJoHjAWh65JJF/lPpujyhP7KqHkUrOJrlrTAjIyemghcC3FFBoMtBmr7JPOnhZg==
+  dependencies:
+    error-stack-parser "^2.0.6"
 
 jest-get-type@^27.4.0:
   version "27.4.0"
@@ -8850,6 +8864,11 @@ stack-utils@^2.0.3:
   integrity sha512-xrQcmYhOsn/1kX+Vraq+7j4oE2j/6BFscZ0etmYg81xuM8Gq0022Pxb8+IqgOFUIaxHs0KaSb7T1+OegiNrNFA==
   dependencies:
     escape-string-regexp "^2.0.0"
+
+stackframe@^1.1.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-1.2.1.tgz#1033a3473ee67f08e2f2fc8eba6aef4f845124e1"
+  integrity sha512-h88QkzREN/hy8eRdyNhhsO7RSJ5oyTqxxmmn0dzBIMUclZsjpfmrsg81vp8mjjAs2vAZ72nyWxRUwSwmh0e4xg==
 
 static-extend@^0.1.1:
   version "0.1.2"


### PR DESCRIPTION
## Description

This PR introduces a new denylist for entity ids.
The list is saved in disk in a file in the storage folder, where each line is an entity id.

The denylist is a component that given a string will return wether it's delisted or not.


Closes #916 

## Changes

The `/deployments` `/entities/:type` and `/audit` endpoints filter out the entity if a given id is denylisted.
The `/content/:hash/active-entities` doesn't return a found entity if it's denylisted
The `/pointer-changes` endpoint doesn't return denylisted ids


## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change). If there's an API change, link the pull request in the [API spec repository](https://github.com/decentraland/catalyst-api-specs) and the accepted [DAO governance poll](https://governance.decentraland.org/)
- [ ] I have read the [**CONTRIBUTING**](https://github.com/decentraland/catalyst/blob/main/docs/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
