### PR TITLE
chore: add api coverage for the content server

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,6 +107,7 @@ jobs:
             TESTFILES=$(circleci tests glob "test/**/*.spec.ts" | circleci tests split --split-by=timings)
             yarn test $TESTFILES --coverageDirectory=reports --reporters=jest-junit --reporters=default
             mv reports/coverage-final.json reports/coverage-${CIRCLE_NODE_INDEX:-0}.json
+            mv api-coverage/api-coverage.json api-coverage/api-coverage-${CIRCLE_NODE_INDEX:-0}.json
           environment:
             CI: 'true'
             JEST_JUNIT_OUTPUT_DIR: './test-result'
@@ -119,6 +120,7 @@ jobs:
           root: *workspace_root
           paths:
             - content/reports
+            - content/api-coverage
 
   report-content-coverage:
     <<: *base_env
@@ -136,6 +138,15 @@ jobs:
           path: content/coverage
       - store_artifacts:
           path: content/coverage
+  report-content-api-coverage:
+    <<: *base_env
+    steps:
+      - <<: *attach_root
+      - run:
+          name: Report API coverage
+          command: |
+            cd content
+            yarn report-api-coverage
   build-lambdas:
     <<: *base_env
     steps:
@@ -248,6 +259,10 @@ workflows:
           <<: *all_branches_and_tags
           requires:
             - build-content
+      - report-content-api-coverage:
+          <<: *all_branches_and_tags
+          requires:
+            - build-content
       - build-lambdas:
           <<: *all_branches_and_tags
           requires:
@@ -266,6 +281,7 @@ workflows:
             - build-lighthouse
             - build-content
             - report-content-coverage
+            - report-content-api-coverage
             - build-lambdas
 
       # NOT (main | semver) enables manual approval to release untagged docker images

--- a/.eslintignore
+++ b/.eslintignore
@@ -9,4 +9,6 @@ content/test
 lambdas/test
 comms/lighthouse/test
 jest.config.js
+printApiCoverage.js
+reportApiCoverage.js
 jest.*.ts

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 
 .env
 coverage
+api-coverage
 dist
 **/node_modules
 yarn-error.log

--- a/content/jest.globalSetup.ts
+++ b/content/jest.globalSetup.ts
@@ -83,9 +83,17 @@ class PostgresWaitStrategy extends LogWaitStrategy {
   }
 }
 
+export type ApiCoverage = {
+  [path: string]: {
+    [method: string]: {
+      [status: string]: boolean
+    }
+  }
+}
+
 async function initializeApiCoverage() {
   // Define an object to keep track of the API coverage
-  const coverage = {}
+  const coverage: ApiCoverage = {}
   // Fill the object with the definitions in the OpenAPI specs with default `false` values
   // Eg: { "/entities": { "POST": { "200": false, "400": false } }, "/status": { "GET": { "200": false } } }
   for (const apiPath in CONTENT_API.paths) {

--- a/content/jest.globalSetup.ts
+++ b/content/jest.globalSetup.ts
@@ -6,7 +6,6 @@ import { GenericContainer } from 'testcontainers'
 import { Container } from 'testcontainers/dist/container'
 import { LogWaitStrategy } from 'testcontainers/dist/wait-strategy'
 import { promisify } from 'util'
-import jestConfig from './jest.config'
 import { DEFAULT_DATABASE_CONFIG } from './src/Environment'
 import { E2ETestEnvironment } from './test/integration/E2ETestEnvironment'
 import { isCI } from './test/integration/E2ETestUtils'
@@ -108,7 +107,7 @@ async function initializeApiCoverage() {
   }
 
   // Write object to disk because Jest runs tests in isolated environments
-  const coverageDir = path.join(__dirname, jestConfig.coverageDirectory)
+  const coverageDir = path.join(__dirname, 'api-coverage')
   try {
     await fs.promises.access(coverageDir)
   } catch (err) {

--- a/content/jest.globalSetup.ts
+++ b/content/jest.globalSetup.ts
@@ -1,8 +1,12 @@
+import { CONTENT_API } from '@dcl/catalyst-api-specs'
 import { exec } from 'child_process'
+import fs from 'fs'
+import path from 'path'
 import { GenericContainer } from 'testcontainers'
 import { Container } from 'testcontainers/dist/container'
 import { LogWaitStrategy } from 'testcontainers/dist/wait-strategy'
 import { promisify } from 'util'
+import jestConfig from './jest.config'
 import { DEFAULT_DATABASE_CONFIG } from './src/Environment'
 import { E2ETestEnvironment } from './test/integration/E2ETestEnvironment'
 import { isCI } from './test/integration/E2ETestUtils'
@@ -36,6 +40,11 @@ const globalSetup = async (): Promise<void> => {
     globalThis.__POSTGRES_CONTAINER__ = container
     // get mapped port to be used for testing purposes
     process.env.MAPPED_POSTGRES_PORT = container.getMappedPort(E2ETestEnvironment.POSTGRES_PORT).toString()
+  }
+
+  // Initialize API Coverage Report
+  if (process.env.API_COVERAGE === 'true') {
+    await initializeApiCoverage()
   }
 }
 
@@ -72,6 +81,33 @@ class PostgresWaitStrategy extends LogWaitStrategy {
         })
     })
   }
+}
+
+async function initializeApiCoverage() {
+  // Define an object to keep track of the API coverage
+  const coverage = {}
+  // Fill the object with the definitions in the OpenAPI specs with default `false` values
+  // Eg: { "/entities": { "POST": { "200": false, "400": false } }, "/status": { "GET": { "200": false } } }
+  for (const apiPath in CONTENT_API.paths) {
+    coverage[apiPath] = {}
+    for (const method in CONTENT_API.paths[apiPath]) {
+      const uppercaseMethod = method.toUpperCase()
+      coverage[apiPath][uppercaseMethod] = {}
+      for (const status in CONTENT_API.paths[apiPath][method].responses) {
+        coverage[apiPath][uppercaseMethod][status] = false
+      }
+    }
+  }
+
+  // Write object to disk because Jest runs tests in isolated environments
+  const coverageDir = path.join(__dirname, jestConfig.coverageDirectory)
+  try {
+    await fs.promises.access(coverageDir)
+  } catch (err) {
+    await fs.promises.mkdir(coverageDir)
+  }
+  await fs.promises.writeFile(
+    path.join(coverageDir, 'api-coverage.json'), JSON.stringify(coverage))
 }
 
 export default globalSetup

--- a/content/jest.globalSetup.ts
+++ b/content/jest.globalSetup.ts
@@ -43,7 +43,7 @@ const globalSetup = async (): Promise<void> => {
   }
 
   // Initialize API Coverage Report
-  if (process.env.API_COVERAGE === 'true') {
+  if (process.env.API_COVERAGE === 'true' || isCI()) {
     await initializeApiCoverage()
   }
 }

--- a/content/jest.globalTeardown.ts
+++ b/content/jest.globalTeardown.ts
@@ -3,6 +3,7 @@ import columnify from 'columnify'
 import fs from 'fs'
 import path from 'path'
 import jestConfig from './jest.config'
+import { ApiCoverage } from './jest.globalSetup'
 
 const globalTeardown = async (): Promise<void> => {
   if (process.env.API_COVERAGE === 'true') {
@@ -12,11 +13,17 @@ const globalTeardown = async (): Promise<void> => {
   await globalThis.__POSTGRES_CONTAINER__?.stop()
 }
 
+type ApiCoverageRow = {
+  route: string,
+  method: string,
+  statuses: string[]
+}
+
 async function printApiCoverage() {
   const apiCoveragePath = path.join(__dirname, jestConfig.coverageDirectory, 'api-coverage.json')
-  const coverage = JSON.parse(((await fs.promises.readFile(apiCoveragePath)).toString()))
+  const coverage: ApiCoverage = JSON.parse(((await fs.promises.readFile(apiCoveragePath)).toString()))
 
-  const tableRows = []
+const tableRows: ApiCoverageRow[] = []
   for (const route in coverage) {
     for (const method in coverage[route]) {
       const statuses = Object.keys(coverage[route][method])
@@ -28,7 +35,7 @@ async function printApiCoverage() {
         (status) => coverage[route][method][status] ? chalk.green(status) : chalk.red(status)
       )
 
-      const row = {
+      const row: ApiCoverageRow = {
         route: coloredRoute,
         method: coloredMethod,
         statuses: coloredStatus,

--- a/content/jest.globalTeardown.ts
+++ b/content/jest.globalTeardown.ts
@@ -4,9 +4,10 @@ import fs from 'fs'
 import path from 'path'
 import jestConfig from './jest.config'
 import { ApiCoverage } from './jest.globalSetup'
+import { isCI } from './test/integration/E2ETestUtils'
 
 const globalTeardown = async (): Promise<void> => {
-  if (process.env.API_COVERAGE === 'true') {
+  if (process.env.API_COVERAGE === 'true' || isCI()) {
     await printApiCoverage()
   }
 

--- a/content/jest.globalTeardown.ts
+++ b/content/jest.globalTeardown.ts
@@ -1,5 +1,47 @@
+import chalk from 'chalk'
+import columnify from 'columnify'
+import fs from 'fs'
+import path from 'path'
+import jestConfig from './jest.config'
+
 const globalTeardown = async (): Promise<void> => {
+  if (process.env.API_COVERAGE === 'true') {
+    await printApiCoverage()
+  }
+
   await globalThis.__POSTGRES_CONTAINER__?.stop()
+}
+
+async function printApiCoverage() {
+  const apiCoveragePath = path.join(__dirname, jestConfig.coverageDirectory, 'api-coverage.json')
+  const coverage = JSON.parse(((await fs.promises.readFile(apiCoveragePath)).toString()))
+
+  const tableRows = []
+  for (const route in coverage) {
+    for (const method in coverage[route]) {
+      const statuses = Object.keys(coverage[route][method])
+      const covered = statuses.every(status => coverage[route][method][status])
+
+      const coloredRoute = covered ? chalk.green(route) : chalk.red(route)
+      const coloredMethod = covered ? chalk.green(method) : chalk.red(method)
+      const coloredStatus = statuses.map(
+        (status) => coverage[route][method][status] ? chalk.green(status) : chalk.red(status)
+      )
+
+      const row = {
+        route: coloredRoute,
+        method: coloredMethod,
+        statuses: coloredStatus,
+      }
+      tableRows.push(row)
+    }
+  }
+
+  const sortedData = tableRows.sort((obj1, obj2) => obj1.route.localeCompare(obj2.route))
+  const filteredData = sortedData.filter(obj => obj.statuses.length)
+
+  console.info('\nAPI Coverage:')
+  console.info(columnify(filteredData, { columnSplitter: ' | ' }))
 }
 
 export default globalTeardown

--- a/content/jest.globalTeardown.ts
+++ b/content/jest.globalTeardown.ts
@@ -1,55 +1,11 @@
-import chalk from 'chalk'
-import columnify from 'columnify'
-import fs from 'fs'
-import path from 'path'
-import jestConfig from './jest.config'
-import { ApiCoverage } from './jest.globalSetup'
-import { isCI } from './test/integration/E2ETestUtils'
+import printApiCoverage from './printApiCoverage'
 
 const globalTeardown = async (): Promise<void> => {
-  if (process.env.API_COVERAGE === 'true' || isCI()) {
+  if (process.env.API_COVERAGE === 'true') {
     await printApiCoverage()
   }
 
   await globalThis.__POSTGRES_CONTAINER__?.stop()
-}
-
-type ApiCoverageRow = {
-  route: string,
-  method: string,
-  statuses: string[]
-}
-
-async function printApiCoverage() {
-  const apiCoveragePath = path.join(__dirname, jestConfig.coverageDirectory, 'api-coverage.json')
-  const coverage: ApiCoverage = JSON.parse(((await fs.promises.readFile(apiCoveragePath)).toString()))
-
-const tableRows: ApiCoverageRow[] = []
-  for (const route in coverage) {
-    for (const method in coverage[route]) {
-      const statuses = Object.keys(coverage[route][method])
-      const covered = statuses.every(status => coverage[route][method][status])
-
-      const coloredRoute = covered ? chalk.green(route) : chalk.red(route)
-      const coloredMethod = covered ? chalk.green(method) : chalk.red(method)
-      const coloredStatus = statuses.map(
-        (status) => coverage[route][method][status] ? chalk.green(status) : chalk.red(status)
-      )
-
-      const row: ApiCoverageRow = {
-        route: coloredRoute,
-        method: coloredMethod,
-        statuses: coloredStatus,
-      }
-      tableRows.push(row)
-    }
-  }
-
-  const sortedData = tableRows.sort((obj1, obj2) => obj1.route.localeCompare(obj2.route))
-  const filteredData = sortedData.filter(obj => obj.statuses.length)
-
-  console.info('\nAPI Coverage:')
-  console.info(columnify(filteredData, { columnSplitter: ' | ' }))
 }
 
 export default globalTeardown

--- a/content/jest.setupFilesAfterEnv.ts
+++ b/content/jest.setupFilesAfterEnv.ts
@@ -2,6 +2,7 @@ import * as logger from '@well-known-components/logger'
 import fs from 'fs'
 import path from 'path'
 import jestConfig from './jest.config'
+import { ApiCoverage } from './jest.globalSetup'
 import { Server } from './src/service/Server'
 
 // Setup API Coverage Report process
@@ -32,7 +33,7 @@ if (process.env.LOG_LEVEL === 'off') {
 async function setupApiCoverage() {
   const coverageDir = path.join(__dirname, jestConfig.coverageDirectory)
   const coverageFilePath = path.join(coverageDir, 'api-coverage.json')
-  const coverage = JSON.parse(fs.readFileSync(coverageFilePath).toString())
+  const coverage: ApiCoverage = JSON.parse(fs.readFileSync(coverageFilePath).toString())
 
   // Hacky way of adding a middleware to keep track of the requests without changing the Server file
   const registerRoute = Server.prototype['registerRoute']

--- a/content/jest.setupFilesAfterEnv.ts
+++ b/content/jest.setupFilesAfterEnv.ts
@@ -1,7 +1,6 @@
 import * as logger from '@well-known-components/logger'
 import fs from 'fs'
 import path from 'path'
-import jestConfig from './jest.config'
 import { ApiCoverage } from './jest.globalSetup'
 import { Server } from './src/service/Server'
 import { isCI } from './test/integration/E2ETestUtils'
@@ -32,7 +31,7 @@ if (process.env.LOG_LEVEL === 'off') {
 }
 
 async function setupApiCoverage() {
-  const coverageDir = path.join(__dirname, jestConfig.coverageDirectory)
+  const coverageDir = path.join(__dirname, 'api-coverage')
   const coverageFilePath = path.join(coverageDir, 'api-coverage.json')
   const coverage: ApiCoverage = JSON.parse(fs.readFileSync(coverageFilePath).toString())
 

--- a/content/jest.setupFilesAfterEnv.ts
+++ b/content/jest.setupFilesAfterEnv.ts
@@ -1,5 +1,15 @@
 import * as logger from '@well-known-components/logger'
+import fs from 'fs'
+import path from 'path'
+import jestConfig from './jest.config'
+import { Server } from './src/service/Server'
 
+// Setup API Coverage Report process
+if (process.env.API_COVERAGE === 'true') {
+  setupApiCoverage()
+}
+
+// DISABLE LOGS
 if (process.env.LOG_LEVEL === 'off') {
   beforeAll(() => {
     // Mock logger implementation
@@ -16,5 +26,43 @@ if (process.env.LOG_LEVEL === 'off') {
       return logComponentMock
     })
     jest.spyOn(process.stdout, 'write').mockImplementation(() => true)
+  })
+}
+
+async function setupApiCoverage() {
+  const coverageDir = path.join(__dirname, jestConfig.coverageDirectory)
+  const coverageFilePath = path.join(coverageDir, 'api-coverage.json')
+  const coverage = JSON.parse(fs.readFileSync(coverageFilePath).toString())
+
+  // Hacky way of adding a middleware to keep track of the requests without changing the Server file
+  const registerRoute = Server.prototype['registerRoute']
+  Server.prototype['registerRoute'] = async function (this: Server, ...args) {
+    if (!this['_API_COVERED_']) {
+      this['_API_COVERED_'] = true
+      this['app'].use((req, res, next) => {
+        for (const apiPath in coverage) {
+          // Convert OpenAPI paths to a format that is testable against the server API
+          // Eg: /contents/{hashId}/active-entities -> /contents/[^\\/]*/active-entities
+          // This allows testing against any resource path like /contents/Qws4djflKjf9dJsa/active-entities
+          const testablePath = `^${apiPath.replace(/\{.*\}/, '[^\\/]*')}$`
+          const matchesPath = new RegExp(testablePath).test(req.path)
+
+          // Mark the path as tested if it is in the OpenAPI spec and it matches a tested path
+          const wasTested = coverage[req.path]?.[req.method]?.[res.statusCode]
+          if (matchesPath && wasTested !== undefined) {
+            coverage[req.path][req.method][res.statusCode] = true
+          }
+        }
+        next()
+      })
+    }
+    await registerRoute.apply(this, args)
+  }
+
+  // Write API Coverage results to disk in order to let the Reporter read it
+  // Jest tests run in a sandbox environment and it is not possible to pass data programatically
+  afterAll(async () => {
+    const coverageDir = path.join(__dirname, 'coverage')
+    await fs.promises.writeFile(coverageFilePath, JSON.stringify(coverage))
   })
 }

--- a/content/jest.setupFilesAfterEnv.ts
+++ b/content/jest.setupFilesAfterEnv.ts
@@ -4,9 +4,10 @@ import path from 'path'
 import jestConfig from './jest.config'
 import { ApiCoverage } from './jest.globalSetup'
 import { Server } from './src/service/Server'
+import { isCI } from './test/integration/E2ETestUtils'
 
 // Setup API Coverage Report process
-if (process.env.API_COVERAGE === 'true') {
+if (process.env.API_COVERAGE === 'true' || isCI()) {
   setupApiCoverage()
 }
 

--- a/content/jest.setupFilesAfterEnv.ts
+++ b/content/jest.setupFilesAfterEnv.ts
@@ -49,9 +49,9 @@ async function setupApiCoverage() {
           const matchesPath = new RegExp(testablePath).test(req.path)
 
           // Mark the path as tested if it is in the OpenAPI spec and it matches a tested path
-          const wasTested = coverage[req.path]?.[req.method]?.[res.statusCode]
+          const wasTested = coverage[apiPath]?.[req.method]?.[res.statusCode]
           if (matchesPath && wasTested !== undefined) {
-            coverage[req.path][req.method][res.statusCode] = true
+            coverage[apiPath][req.method][res.statusCode] = true
           }
         }
         next()

--- a/content/jest.setupFilesAfterEnv.ts
+++ b/content/jest.setupFilesAfterEnv.ts
@@ -46,7 +46,10 @@ async function setupApiCoverage() {
             // Convert OpenAPI paths to a format that is testable against the server API
             // Eg: /contents/{hashId}/active-entities -> /contents/[^\\/]*/active-entities
             // This allows testing against any resource path like /contents/Qws4djflKjf9dJsa/active-entities
-            const testablePath = `^${apiPath.replace(/\{.*\}/, '[^\\/]*')}$`
+            const replacedPath = apiPath
+              .replace(/\{.*?\}/, '[^\\/]*')
+              .replace(/\{.*?\}/, '[^\\/]*') // Replace a second time for URLs with two query params
+            const testablePath = `^${replacedPath}$`
             const matchesPath = new RegExp(testablePath).test(req.path)
 
             // Mark the path as tested if it is in the OpenAPI spec and it matches a tested path

--- a/content/package.json
+++ b/content/package.json
@@ -67,6 +67,8 @@
     "@types/parallel-transform": "^1",
     "@types/pg": "^8",
     "@types/uuid": "^8",
+    "chalk": "4.1.2",
+    "columnify": "1.6.0",
     "cpy-cli": "^3.1.1",
     "destroy": "1.0.4",
     "faker": "5.5.3",

--- a/content/package.json
+++ b/content/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@catalyst/commons": "0.1.0",
     "@catalyst/contracts": "0.1.0",
-    "@dcl/catalyst-api-specs": "1.0.2-20220307230343.commit-b0a78c1",
+    "@dcl/catalyst-api-specs": "1.1.0",
     "@dcl/content-validator": "1.3.0",
     "@dcl/schemas": "3.9.0",
     "@dcl/snapshots-fetcher": "3.0.0",

--- a/content/package.json
+++ b/content/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@catalyst/commons": "0.1.0",
     "@catalyst/contracts": "0.1.0",
-    "@dcl/catalyst-api-specs": "1.0.1",
+    "@dcl/catalyst-api-specs": "1.0.2-20220307230343.commit-b0a78c1",
     "@dcl/content-validator": "1.3.0",
     "@dcl/schemas": "3.9.0",
     "@dcl/snapshots-fetcher": "3.0.0",

--- a/content/package.json
+++ b/content/package.json
@@ -11,7 +11,8 @@
     "start:db": "node ./dist/src/entrypoints/run-local-database.js",
     "test": "jest --runInBand --forceExit --detectOpenHandles --coverage",
     "test:unit": "jest --selectProjects unit --runInBand --forceExit --detectOpenHandles --coverage",
-    "test:integration": "jest --selectProjects integration --runInBand --forceExit --detectOpenHandles --coverage"
+    "test:integration": "jest --selectProjects integration --runInBand --forceExit --detectOpenHandles --coverage",
+    "report-api-coverage": "node ./reportApiCoverage.js"
   },
   "dependencies": {
     "@catalyst/commons": "0.1.0",

--- a/content/printApiCoverage.js
+++ b/content/printApiCoverage.js
@@ -1,0 +1,58 @@
+const chalk = require('chalk')
+const columnify = require('columnify')
+const fs = require('fs')
+const path = require('path')
+const jestConfig = require('./jest.config')
+
+function printApiCoverage() {
+  let coverage = {}
+  const apiCoveragePath = path.join(__dirname, 'api-coverage', 'api-coverage.json')
+  if (process.env.CI === 'true') {
+    // Merge partial results from parallel processing
+    fs.readdirSync(path.join(__dirname, 'api-coverage')).forEach(file => {
+      if (file.startsWith('api-coverage-')) {
+        const partialCoverage = JSON.parse(((fs.readFileSync(path.resolve(__dirname, 'api-coverage', file))).toString()))
+        for (const apiPath in partialCoverage) {
+          coverage[apiPath] = coverage[apiPath] || {}
+          for (const method in partialCoverage[apiPath]) {
+            coverage[apiPath][method] = coverage[apiPath][method] || {}
+            for (const status in partialCoverage[apiPath][method]) {
+              coverage[apiPath][method][status] = coverage[apiPath][method][status] || partialCoverage[apiPath][method][status]
+            }
+          }
+        }
+      }
+    })
+  } else {
+    coverage = JSON.parse(((fs.readFileSync(apiCoveragePath)).toString()))
+  }
+
+  const tableRows = []
+  for (const route in coverage) {
+    for (const method in coverage[route]) {
+      const statuses = Object.keys(coverage[route][method])
+      const covered = statuses.every(status => coverage[route][method][status])
+
+      const coloredRoute = covered ? chalk.green(route) : chalk.red(route)
+      const coloredMethod = covered ? chalk.green(method) : chalk.red(method)
+      const coloredStatus = statuses.map(
+        (status) => coverage[route][method][status] ? chalk.green(status) : chalk.red(status)
+      )
+
+      const row = {
+        route: coloredRoute,
+        method: coloredMethod,
+        statuses: coloredStatus,
+      }
+      tableRows.push(row)
+    }
+  }
+
+  const sortedData = tableRows.sort((obj1, obj2) => obj1.route.localeCompare(obj2.route))
+  const filteredData = sortedData.filter(obj => obj.statuses.length)
+
+  console.info('\nAPI Coverage:')
+  console.info(columnify(filteredData, { columnSplitter: ' | ' }))
+}
+
+module.exports = printApiCoverage

--- a/content/reportApiCoverage.js
+++ b/content/reportApiCoverage.js
@@ -1,0 +1,3 @@
+const printApiCoverage = require('./printApiCoverage')
+
+printApiCoverage()

--- a/yarn.lock
+++ b/yarn.lock
@@ -2851,6 +2851,14 @@ caseless@~0.12.0:
   resolved "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
+chalk@4.1.2, chalk@^4.0.0:
+  version "4.1.2"
+  resolved "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chalk@^2.0.0, chalk@^2.4.1:
   version "2.4.2"
   resolved "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz"
@@ -2859,14 +2867,6 @@ chalk@^2.0.0, chalk@^2.4.1:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
-
-chalk@^4.0.0:
-  version "4.1.2"
-  resolved "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz"
-  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
-  dependencies:
-    ansi-styles "^4.1.0"
-    supports-color "^7.1.0"
 
 char-regex@^1.0.2:
   version "1.0.2"
@@ -2982,6 +2982,11 @@ clone@2.x:
   resolved "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz"
   integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
 
+clone@^1.0.2:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
+  integrity sha1-2jCcwmPfFZlMaIypAheco8fNfH4=
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -3054,6 +3059,14 @@ colors@1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
+
+columnify@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/columnify/-/columnify-1.6.0.tgz#6989531713c9008bb29735e61e37acf5bd553cf3"
+  integrity sha512-lomjuFZKfM6MSAnV9aCZC9sc0qGbmZdfygNv+nCpqVkSKdCxCklLtd16O0EILGkImHw9ZpHkAnHaB+8Zxq5W6Q==
+  dependencies:
+    strip-ansi "^6.0.1"
+    wcwidth "^1.0.0"
 
 combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   version "1.0.8"
@@ -3509,6 +3522,13 @@ default-require-extensions@^3.0.0:
   integrity sha512-ek6DpXq/SCpvjhpFsLFRVtIxJCRw6fUR42lYMVZuUMK7n8eMz4Uh5clckdBjEpLhn/gEBZo7hDJnJcwdKLKQjg==
   dependencies:
     strip-bom "^4.0.0"
+
+defaults@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/defaults/-/defaults-1.0.3.tgz#c656051e9817d9ff08ed881477f3fe4019f3ef7d"
+  integrity sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=
+  dependencies:
+    clone "^1.0.2"
 
 define-properties@^1.1.3:
   version "1.1.3"
@@ -9734,6 +9754,13 @@ walker@^1.0.7:
   integrity sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==
   dependencies:
     makeerror "1.0.12"
+
+wcwidth@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/wcwidth/-/wcwidth-1.0.1.tgz#f0b0dcf915bc5ff1528afadb2c0e17b532da2fe8"
+  integrity sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=
+  dependencies:
+    defaults "^1.0.3"
 
 web-streams-polyfill@^3.0.3:
   version "3.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -355,6 +355,13 @@
   dependencies:
     yaml "1.10.2"
 
+"@dcl/catalyst-api-specs@1.0.2-20220307230343.commit-b0a78c1":
+  version "1.0.2-20220307230343.commit-b0a78c1"
+  resolved "https://registry.yarnpkg.com/@dcl/catalyst-api-specs/-/catalyst-api-specs-1.0.2-20220307230343.commit-b0a78c1.tgz#4fdccaca822c2295b2e1733c00cbae8c7cb6364a"
+  integrity sha512-rtN9nhfpu3DbvJOgQureysFTozhsH8B2G56K5GbqDGh5fXN27RILRmNn/QbS+s5kc8UaMPRaGwHhWyaZo04/Hg==
+  dependencies:
+    yaml "1.10.2"
+
 "@dcl/content-validator@1.3.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@dcl/content-validator/-/content-validator-1.3.0.tgz#d9aa05e77a70f05e38ed290b8052b07bc76ec2e5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -355,10 +355,10 @@
   dependencies:
     yaml "1.10.2"
 
-"@dcl/catalyst-api-specs@1.0.2-20220307230343.commit-b0a78c1":
-  version "1.0.2-20220307230343.commit-b0a78c1"
-  resolved "https://registry.yarnpkg.com/@dcl/catalyst-api-specs/-/catalyst-api-specs-1.0.2-20220307230343.commit-b0a78c1.tgz#4fdccaca822c2295b2e1733c00cbae8c7cb6364a"
-  integrity sha512-rtN9nhfpu3DbvJOgQureysFTozhsH8B2G56K5GbqDGh5fXN27RILRmNn/QbS+s5kc8UaMPRaGwHhWyaZo04/Hg==
+"@dcl/catalyst-api-specs@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@dcl/catalyst-api-specs/-/catalyst-api-specs-1.1.0.tgz#71c7d7a125011f97f8bd34b49a30c139909702da"
+  integrity sha512-jelhOl/BS/W6cmrymlLN1riJpQghipXcXwV9dSv3mrEEsafsvqwuOpFHt0PZd6nKBYSq0phPjg3H1SMliJagPg==
   dependencies:
     yaml "1.10.2"
 


### PR DESCRIPTION
## Description

Add an option to create an API Coverage Report after running tests

<img width="454" alt="Screen Shot 2022-02-14 at 20 16 38" src="https://user-images.githubusercontent.com/12957692/153966923-e59df481-d61c-4df8-92fe-7dfabb333fe1.png">

Helps with:
- https://github.com/decentraland/catalyst/issues/895

## Changes

Create an API Coverage Report on the console when tests run with the `API_COVERAGE=true` environment variable.

- Add dev libraries `chalk` and `columnify` to create a beautiful report table
- Add report code to Jest setup files and avoid touching any production related code
  - Some code is written in a hacky way to setup a middleware from the Jest file
  - A temporary coverage file is generated to pass through the different Jest file, as tests run in sandbox environments. This may prevent running the report on a CI with parallel processing, making it available only when running locally or on a serial way.
  - Jest has a `reporter` functionality but it didn't work with TypeScript and it didn't provide additional solutions to this issue.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change). If there's an API change, link the pull request in the [API spec repository](https://github.com/decentraland/catalyst-api-specs) and the accepted [DAO governance poll](https://governance.decentraland.org/)
- [ ] I have read the [**CONTRIBUTING**](https://github.com/decentraland/catalyst/blob/main/docs/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
