### PR TITLE
feat: set content server as healthy only when it is Syncing

### DIFF
--- a/docs/lambdas-server-api/health/get.md
+++ b/docs/lambdas-server-api/health/get.md
@@ -19,11 +19,10 @@ Get the health status for each server running in catalyst
 **Content example**
 
 ```json
-
 {
-    "comms": "Healthy",
-    "content": "Unhealthy",
-    "lambda": "Healthy"
+  "comms": "Healthy",
+  "content": "Unhealthy",
+  "lambda": "Healthy",
+  "readyToUse": false
 }
-
 ```

--- a/lambdas/src/apis/status/health.ts
+++ b/lambdas/src/apis/status/health.ts
@@ -29,7 +29,9 @@ export async function refreshContentServerStatus(
 
     const obtainDeploymentTimeIsTooLong = obtainDeploymentTime > ms(maxDeploymentObtentionTime)
 
-    if (hasOldInformation || obtainDeploymentTimeIsTooLong) {
+    const isBootstrapping = (serverStatus as any).synchronizationStatus?.synchronizationState === 'Bootstrapping'
+
+    if (hasOldInformation || obtainDeploymentTimeIsTooLong || isBootstrapping) {
       healthStatus = HealthStatus.UNHEALTHY
     } else {
       healthStatus = HealthStatus.HEALTHY

--- a/lambdas/src/apis/status/health.ts
+++ b/lambdas/src/apis/status/health.ts
@@ -29,9 +29,10 @@ export async function refreshContentServerStatus(
 
     const obtainDeploymentTimeIsTooLong = obtainDeploymentTime > ms(maxDeploymentObtentionTime)
 
-    const isBootstrapping = (serverStatus as any).synchronizationStatus?.synchronizationState === 'Bootstrapping'
+    // This is the only valid syncronization state that ensures content is being served up to date
+    const isSyncStateOk = (serverStatus as any).synchronizationStatus?.synchronizationState === 'Syncing'
 
-    if (hasOldInformation || obtainDeploymentTimeIsTooLong || isBootstrapping) {
+    if (hasOldInformation || obtainDeploymentTimeIsTooLong || !isSyncStateOk) {
       healthStatus = HealthStatus.UNHEALTHY
     } else {
       healthStatus = HealthStatus.HEALTHY

--- a/lambdas/test/apis/status/PeerHealthStatus.spec.ts
+++ b/lambdas/test/apis/status/PeerHealthStatus.spec.ts
@@ -1,0 +1,36 @@
+import { mock } from 'ts-mockito'
+import { HealthStatus } from '../../../src/apis/status/health'
+import PeerHealthStatus from "../../../src/apis/status/PeerHealthStatus"
+import { SmartContentClient } from "../../../src/utils/SmartContentClient"
+
+describe('PeerHealthStatus', () => {
+  describe('getPeerStatus', () => {
+    it('is ready to use when all services are healthy', async () => {
+      let contentClientMock: SmartContentClient
+      contentClientMock = mock(SmartContentClient)
+
+      const peerHealthStatus = new PeerHealthStatus(contentClientMock, '15m', '3s', 'http://comms-server:9000')
+      jest.spyOn(peerHealthStatus['lambdaServerStatus'], 'get').mockResolvedValue(HealthStatus.HEALTHY)
+      jest.spyOn(peerHealthStatus['contentServerStatus'], 'get').mockResolvedValue(HealthStatus.HEALTHY)
+      jest.spyOn(peerHealthStatus['commsServerStatus'], 'get').mockResolvedValue(HealthStatus.HEALTHY)
+
+      const peerStatus = await peerHealthStatus.getPeerStatus()
+
+      expect(peerStatus.readyToUse).toBe(true)
+    })
+
+    it('is not ready to use when some service is down', async () => {
+      let contentClientMock: SmartContentClient
+      contentClientMock = mock(SmartContentClient)
+
+      const peerHealthStatus = new PeerHealthStatus(contentClientMock, '15m', '3s', 'http://comms-server:9000')
+      jest.spyOn(peerHealthStatus['lambdaServerStatus'], 'get').mockResolvedValue(HealthStatus.HEALTHY)
+      jest.spyOn(peerHealthStatus['contentServerStatus'], 'get').mockResolvedValue(HealthStatus.UNHEALTHY)
+      jest.spyOn(peerHealthStatus['commsServerStatus'], 'get').mockResolvedValue(HealthStatus.HEALTHY)
+
+      const peerStatus = await peerHealthStatus.getPeerStatus()
+
+      expect(peerStatus.readyToUse).toBe(false)
+    })
+  })
+})

--- a/lambdas/test/apis/status/health.spec.ts
+++ b/lambdas/test/apis/status/health.spec.ts
@@ -12,7 +12,8 @@ describe("Lambda's Controller Utils", () => {
       const mockedHealthyStatus = {
         currentTime: 100,
         synchronizationStatus: {
-          lastSyncWithOtherServers: 100
+          lastSyncWithOtherServers: 100,
+          synchronizationState: 'Syncing',
         }
       }
 
@@ -37,7 +38,8 @@ describe("Lambda's Controller Utils", () => {
       const mockedHealthyStatus = {
         currentTime: 1000000,
         synchronizationStatus: {
-          lastSyncWithOtherServers: 100
+          lastSyncWithOtherServers: 100,
+          synchronizationState: 'Syncing',
         }
       }
 
@@ -62,7 +64,8 @@ describe("Lambda's Controller Utils", () => {
       const mockedHealthyStatus = {
         currentTime: 100,
         synchronizationStatus: {
-          lastSyncWithOtherServers: 100
+          lastSyncWithOtherServers: 100,
+          synchronizationState: 'Syncing',
         }
       }
       let dateNowStub: sinon.SinonStub

--- a/lambdas/test/apis/status/health.spec.ts
+++ b/lambdas/test/apis/status/health.spec.ts
@@ -95,6 +95,32 @@ describe("Lambda's Controller Utils", () => {
       })
     })
 
+    describe('when the service is bootstrapping', () => {
+      const mockedUnhealthyStatus = {
+        currentTime: 100,
+        synchronizationStatus: {
+          lastSyncWithOtherServers: 100,
+          synchronizationState: 'Bootstrapping',
+        }
+      }
+
+      beforeAll(() => {
+        contentClientMock = mock(SmartContentClient)
+        when(contentClientMock.fetchContentStatus()).thenReturn(Promise.resolve(mockedUnhealthyStatus as any))
+        when(contentClientMock.fetchEntitiesByPointers(anything(), anything())).thenReturn(
+          Promise.resolve(mockedUnhealthyStatus as any)
+        )
+      })
+
+      it('should return an unhealthy status', async () => {
+        const logger = mock(Logger)
+
+        expect(await refreshContentServerStatus(instance(contentClientMock), '10s', '10s', logger)).toEqual(
+          HealthStatus.UNHEALTHY
+        )
+      })
+    })
+
     describe('when the request fails', () => {
       it('should return a down status', async () => {
         const logger = mock(Logger)


### PR DESCRIPTION
## Description

Prevent client issues trying to fetch content from a server that is bootstrapping

Closes https://github.com/decentraland/catalyst/issues/925
Closes https://github.com/decentraland/catalyst/issues/926

## Changes

- Mark content server as `Healthy` only when Syncing. Otherwise it would be `Unhealthy`, like when Bootstrapping
- Add attribute `readyToUse` to the health route to make it easy for a load balancer to understand the health of the whole system

### Minor changes
- Make calls to the comms, lambda, and content server in parallel instead of serial
- Create `PeerStatus` type for the peer health response, as it is not possible to create some type with the form `Record<string, HealthStatus> & { readyToUse: boolean }`

### Doc changes

- https://github.com/decentraland/catalyst-api-specs/pull/24

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change). If there's an API change, link the pull request in the [API spec repository](https://github.com/decentraland/catalyst-api-specs) and the accepted [DAO governance poll](https://governance.decentraland.org/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/decentraland/catalyst/blob/main/docs/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
