### PR TITLE
fix: denylist creates a denylist file if it doesn't exist

### DIFF
--- a/content/src/components.ts
+++ b/content/src/components.ts
@@ -46,7 +46,6 @@ export async function initComponentsWithEnv(env: Environment): Promise<AppCompon
   const logs = createLogComponent()
   const fetcher = createFetchComponent()
   const fs = createFsComponent()
-  const denylist = await createDenylistComponent({ env, logs, fs })
   const contentStorageFolder = path.join(env.getConfig(EnvironmentConfig.STORAGE_ROOT_FOLDER), 'contents')
   const tmpDownloadFolder = path.join(contentStorageFolder, '_tmp')
   await fs.mkdir(tmpDownloadFolder, { recursive: true })
@@ -54,7 +53,7 @@ export async function initComponentsWithEnv(env: Environment): Promise<AppCompon
     contentStorageFolder,
     tmpDownloadFolder
   }
-
+  const denylist = await createDenylistComponent({ env, logs, fs })
   const database = await createDatabaseComponent({ logs, env, metrics })
 
   const sequentialExecutor = createSequentialTaskExecutor({ metrics, logs })

--- a/content/src/ports/fs.ts
+++ b/content/src/ports/fs.ts
@@ -2,7 +2,9 @@ import fs from 'fs'
 import * as fsPromises from 'fs/promises'
 
 export type FSComponent = Pick<typeof fs, 'createReadStream'> &
-  Pick<typeof fsPromises, 'access' | 'opendir' | 'stat' | 'unlink' | 'mkdir'>
+  Pick<typeof fsPromises, 'access' | 'opendir' | 'stat' | 'unlink' | 'mkdir' | 'open'> & {
+    constants: Pick<typeof fs.constants, 'F_OK' | 'R_OK'>
+  }
 
 export function createFsComponent(): FSComponent {
   return {
@@ -11,6 +13,11 @@ export function createFsComponent(): FSComponent {
     opendir: fsPromises.opendir,
     stat: fsPromises.stat,
     unlink: fsPromises.unlink,
-    mkdir: fsPromises.mkdir
+    mkdir: fsPromises.mkdir,
+    open: fsPromises.open,
+    constants: {
+      F_OK: fs.constants.F_OK,
+      R_OK: fs.constants.R_OK
+    }
   }
 }

--- a/content/test/unit/ports/denylist.spec.ts
+++ b/content/test/unit/ports/denylist.spec.ts
@@ -1,14 +1,11 @@
 import { createLogComponent } from '@well-known-components/logger'
+import path from 'path'
 import { Readable } from 'stream'
 import { Environment, EnvironmentConfig } from '../../../src/Environment'
 import { createDenylistComponent } from '../../../src/ports/denylist'
 import { createFsComponent } from '../../../src/ports/fs'
 
 const lines = ['my\n', 'first\n', 'denylisted\n', 'item\n']
-
-jest.mock('@catalyst/commons', () => ({
-  existPath: () => true
-}))
 
 describe('denylist', () => {
   describe('when creating a denylist it should read a file to load the denylisted items', () => {
@@ -19,7 +16,8 @@ describe('denylist', () => {
 
     it('should have denylisted each line from the file', async () => {
       const fs = createFsComponent()
-      fs.createReadStream = jest.fn().mockResolvedValue(Readable.from(lines))
+      fs.access = jest.fn().mockResolvedValue(undefined)
+      fs.createReadStream = jest.fn().mockReturnValue(Readable.from(lines))
       const denylist = await createDenylistComponent({ env, logs, fs })
 
       expect(lines.every((line) => denylist.isDenyListed(line.trimEnd()))).toBe(true)
@@ -27,10 +25,26 @@ describe('denylist', () => {
 
     it('should not have denylisted another word', async () => {
       const fs = createFsComponent()
-      fs.createReadStream = jest.fn().mockResolvedValue(Readable.from(lines))
+      fs.access = jest.fn().mockResolvedValue(undefined)
+      fs.createReadStream = jest.fn().mockReturnValue(Readable.from(lines))
       const denylist = await createDenylistComponent({ env, logs, fs })
 
+      expect(fs.createReadStream).toBeCalled()
       expect(denylist.isDenyListed('RANDOM')).toBe(false)
+    })
+
+    it('should create a denylist file if it does not exist', async () => {
+      const fs = createFsComponent()
+      fs.access = jest.fn().mockRejectedValue(undefined)
+      fs.createReadStream = jest.fn().mockReturnValue(Readable.from(lines))
+      const fileMock = { close: jest.fn() }
+      fs.open = jest.fn().mockResolvedValue(fileMock)
+      const expectedDenylistFilePath = path.resolve(
+        env.getConfig(EnvironmentConfig.STORAGE_ROOT_FOLDER), env.getConfig(EnvironmentConfig.DENYLIST_FILE_NAME))
+
+      await createDenylistComponent({ env, logs, fs })
+      expect(fs.open).toBeCalledWith(expectedDenylistFilePath, 'a')
+      expect(fileMock.close).toBeCalled()
     })
   })
 })


### PR DESCRIPTION
## Description

This PR fixes the situation when creating the denylist component and its fs file doesn't exist.

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change). If there's an API change, link the pull request in the [API spec repository](https://github.com/decentraland/catalyst-api-specs) and the accepted [DAO governance poll](https://governance.decentraland.org/)
- [X] I have read the [**CONTRIBUTING**](https://github.com/decentraland/catalyst/blob/main/docs/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
