### PR TITLE
feat: set status 503 when some service is unhealthy

### DIFF
--- a/lambdas/src/apis/status/routes.ts
+++ b/lambdas/src/apis/status/routes.ts
@@ -29,7 +29,13 @@ export default (environment: Environment): Router => {
 
     peerHealthStatus
       .getPeerStatus()
-      .then(($) => res.send($))
+      .then(($) => {
+        const readyToUse = Object.values($).every((state) => state === 'Healthy')
+        if (!readyToUse) {
+          res.status(503)
+        }
+        res.send($)
+      })
       .catch((err) => {
         console.error(err)
         res.status(500)

--- a/lambdas/src/apis/status/routes.ts
+++ b/lambdas/src/apis/status/routes.ts
@@ -1,6 +1,7 @@
 import { Request, Response, Router } from 'express'
 import PeerHealthStatus from '../../apis/status/PeerHealthStatus'
 import { Bean, Environment, EnvironmentConfig } from '../../Environment'
+import { HealthStatus } from './health'
 
 export default (environment: Environment): Router => {
   const router = Router()
@@ -30,7 +31,7 @@ export default (environment: Environment): Router => {
     peerHealthStatus
       .getPeerStatus()
       .then(($) => {
-        const readyToUse = Object.values($).every((state) => state === 'Healthy')
+        const readyToUse = Object.values($).every((state) => state === HealthStatus.HEALTHY)
         if (!readyToUse) {
           res.status(503)
         }

--- a/lambdas/test/apis/status/PeerHealthStatus.spec.ts
+++ b/lambdas/test/apis/status/PeerHealthStatus.spec.ts
@@ -1,0 +1,54 @@
+import fetch from 'node-fetch'
+import { HealthStatus } from '../../../src/apis/status/health'
+import PeerHealthStatus from '../../../src/apis/status/PeerHealthStatus'
+import { Environment, EnvironmentConfig } from "../../../src/Environment"
+import { Server } from "../../../src/Server"
+import * as Commons from "../../../src/utils/commons"
+
+describe('PeerHealthStatus', () => {
+  describe('getPeerStatus', () => {
+    let server: Server
+    let baseUrl: string
+
+    beforeAll(async () => {
+      jest.spyOn(Commons, 'getCommsServerUrl').mockResolvedValue('')
+      process.env.CONTENT_SERVER_ADDRESS = ''
+      const env = await Environment.getInstance()
+      baseUrl = `http://localhost:${env.getConfig(EnvironmentConfig.SERVER_PORT)}`
+
+      server = new Server(env)
+      await server.start()
+    })
+
+    afterAll(async () => {
+      await server.stop()
+    })
+
+   it('is ready to use when all services are healthy', async () => {
+      jest.spyOn(PeerHealthStatus.prototype, 'getPeerStatus').mockResolvedValue({
+        comms: HealthStatus.HEALTHY,
+        content: HealthStatus.HEALTHY,
+        lambda: HealthStatus.HEALTHY,
+      })
+
+      const response = await fetch(`${baseUrl}/health`)
+      expect(response.status).toBe(200)
+
+      jest.spyOn(PeerHealthStatus.prototype, 'getPeerStatus').mockRestore()
+    })
+
+    it('is not available when some service is unhealthy', async () => {
+      jest.spyOn(PeerHealthStatus.prototype, 'getPeerStatus').mockResolvedValue({
+        comms: HealthStatus.HEALTHY,
+        content: HealthStatus.UNHEALTHY,
+        lambda: HealthStatus.HEALTHY,
+      })
+
+
+      const response = await fetch(`${baseUrl}/health`)
+      expect(response.status).toBe(503)
+
+      jest.spyOn(PeerHealthStatus.prototype, 'getPeerStatus').mockRestore()
+    })
+  })
+})


### PR DESCRIPTION
## Description

Send a status code `503` for indicating that a catalyst is unhealthy if some of its services is not `Healthy`

Closes https://github.com/decentraland/catalyst/issues/939

## Changes

- Status code `503` when some unhealthy service in `GET /lambdas/health` endpoint

Docs: https://github.com/decentraland/catalyst-api-specs/pull/26

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change). If there's an API change, link the pull request in the [API spec repository](https://github.com/decentraland/catalyst-api-specs) and the accepted [DAO governance poll](https://governance.decentraland.org/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/decentraland/catalyst/blob/main/docs/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
