### PR TITLE
fix: use headContent controller for HEAD contents endpoint

### DIFF
--- a/content/src/controller/Controller.ts
+++ b/content/src/controller/Controller.ts
@@ -201,6 +201,7 @@ export class Controller {
       const rawStream = await contentItem.asRawStream()
       await setContentFileHeaders(rawStream, hashId, res)
       destroy(rawStream.stream)
+      res.send()
     } else {
       res.status(404).send()
     }

--- a/content/src/service/Server.ts
+++ b/content/src/service/Server.ts
@@ -76,8 +76,8 @@ export class Server implements IBaseComponent {
 
     this.registerRoute('/entities/:type', controller, controller.getEntities)
     this.registerRoute('/entities', controller, controller.createEntity, HttpMethod.POST, upload.any())
+    this.registerRoute('/contents/:hashId', controller, controller.headContent, HttpMethod.HEAD) // Register before GET
     this.registerRoute('/contents/:hashId', controller, controller.getContent, HttpMethod.GET)
-    this.registerRoute('/contents/:hashId', controller, controller.headContent, HttpMethod.HEAD)
     this.registerRoute('/available-content', controller, controller.getAvailableContent)
     this.registerRoute('/audit/:type/:entityId', controller, controller.getAudit)
     this.registerRoute('/deployments', controller, controller.getDeployments)

--- a/content/test/integration/controller/content.spec.ts
+++ b/content/test/integration/controller/content.spec.ts
@@ -3,7 +3,7 @@ import fetch from 'node-fetch'
 import path from 'path'
 import { Controller } from '../../../src/controller/Controller'
 import { EnvironmentConfig } from '../../../src/Environment'
-import { FileSystemContentStorage } from '../../../src/storage/FileSystemContentStorage'
+import { FileSystemContentStorage } from '../../../src/ports/contentStorage/fileSystemContentStorage'
 import { makeNoopValidator } from '../../helpers/service/validations/NoOpValidator'
 import { loadStandaloneTestEnvironment } from '../E2ETestEnvironment'
 

--- a/content/test/integration/controller/content.spec.ts
+++ b/content/test/integration/controller/content.spec.ts
@@ -1,0 +1,47 @@
+import fs from 'fs'
+import fetch from 'node-fetch'
+import path from 'path'
+import { Controller } from '../../../src/controller/Controller'
+import { EnvironmentConfig } from '../../../src/Environment'
+import { FileSystemContentStorage } from '../../../src/storage/FileSystemContentStorage'
+import { makeNoopValidator } from '../../helpers/service/validations/NoOpValidator'
+import { loadStandaloneTestEnvironment } from '../E2ETestEnvironment'
+
+loadStandaloneTestEnvironment()('Integration - Get Content', (testEnv) => {
+  let testFileText: string
+  let getFilePathSpy: jest.SpyInstance
+
+  beforeAll(async () => {
+    const testFilePath = path.resolve(__dirname, '../', 'resources', 'some-text-file.txt')
+    testFileText = (await fs.promises.readFile(testFilePath)).toString()
+
+    getFilePathSpy = jest.spyOn(FileSystemContentStorage.prototype as any, 'getFilePath')
+    getFilePathSpy.mockReturnValue(testFilePath)
+  })
+
+  afterAll(() => {
+    getFilePathSpy.mockRestore()
+  })
+
+  it('calls the headContent controller when the head endpoint is requested', async () => {
+    const headContentSpy = jest.spyOn(Controller.prototype, 'headContent')
+    const getContentSpy = jest.spyOn(Controller.prototype, 'getContent')
+
+    const server = await testEnv.configServer().withConfig(EnvironmentConfig.DISABLE_SYNCHRONIZATION, true).andBuild()
+
+    makeNoopValidator(server.components)
+
+    await server.startProgram()
+
+    const url = server.getUrl() + `/contents/QmNn5Zs21mZeYitXTQyjVyVaThvzjKUVFgvBjXxJPAevdU`
+    const res = await fetch(url, { method: 'HEAD' })
+
+    let text = (await res.buffer()).toString()
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-length')).toBe(testFileText.length.toString())
+
+    expect(headContentSpy).toHaveBeenCalledTimes(1)
+    expect(getContentSpy).toHaveBeenCalledTimes(0)
+  })
+})

--- a/content/test/integration/controller/content.spec.ts
+++ b/content/test/integration/controller/content.spec.ts
@@ -3,43 +3,33 @@ import fetch from 'node-fetch'
 import path from 'path'
 import { Controller } from '../../../src/controller/Controller'
 import { EnvironmentConfig } from '../../../src/Environment'
-import { FileSystemContentStorage } from '../../../src/ports/contentStorage/fileSystemContentStorage'
+import { bufferToStream } from '../../../src/ports/contentStorage/contentStorage'
 import { makeNoopValidator } from '../../helpers/service/validations/NoOpValidator'
 import { loadStandaloneTestEnvironment } from '../E2ETestEnvironment'
 
 loadStandaloneTestEnvironment()('Integration - Get Content', (testEnv) => {
-  let testFileText: string
-  let getFilePathSpy: jest.SpyInstance
-
-  beforeAll(async () => {
-    const testFilePath = path.resolve(__dirname, '../', 'resources', 'some-text-file.txt')
-    testFileText = (await fs.promises.readFile(testFilePath)).toString()
-
-    getFilePathSpy = jest.spyOn(FileSystemContentStorage.prototype as any, 'getFilePath')
-    getFilePathSpy.mockReturnValue(testFilePath)
-  })
-
-  afterAll(() => {
-    getFilePathSpy.mockRestore()
-  })
-
   it('calls the headContent controller when the head endpoint is requested', async () => {
+    const testFilePath = path.resolve(__dirname, '../', 'resources', 'some-text-file.txt')
+    const content = await fs.promises.readFile(testFilePath)
+    const id = 'some-id'
+
     const headContentSpy = jest.spyOn(Controller.prototype, 'headContent')
     const getContentSpy = jest.spyOn(Controller.prototype, 'getContent')
 
     const server = await testEnv.configServer().withConfig(EnvironmentConfig.DISABLE_SYNCHRONIZATION, true).andBuild()
+    await server.components.storage.storeStream(id, bufferToStream(content))
 
     makeNoopValidator(server.components)
 
     await server.startProgram()
 
-    const url = server.getUrl() + `/contents/QmNn5Zs21mZeYitXTQyjVyVaThvzjKUVFgvBjXxJPAevdU`
+    const url = server.getUrl() + `/contents/${id}`
     const res = await fetch(url, { method: 'HEAD' })
 
     let text = (await res.buffer()).toString()
 
     expect(res.status).toBe(200)
-    expect(res.headers.get('content-length')).toBe(testFileText.length.toString())
+    expect(res.headers.get('content-length')).toBe(content.length.toString())
 
     expect(headContentSpy).toHaveBeenCalledTimes(1)
     expect(getContentSpy).toHaveBeenCalledTimes(0)


### PR DESCRIPTION
## Description

The `getContent` controller was being used instead of the `headController` for the `HEAD /contents/{hashId}` endpoint.

This is because the `HEAD` method was registered after the `GET` for the same route, and the way Express works

Fixes https://github.com/decentraland/catalyst/issues/938

## Changes

- Change the order of the registered `HEAD` and `GET`
- Add the missing `res.send()` to the `headController`

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change). If there's an API change, link the pull request in the [API spec repository](https://github.com/decentraland/catalyst-api-specs) and the accepted [DAO governance poll](https://governance.decentraland.org/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/decentraland/catalyst/blob/main/docs/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
