### PR TITLE
test: add missing tests for the content server

### DIFF
--- a/content/test/integration/controller/audit.spec.ts
+++ b/content/test/integration/controller/audit.spec.ts
@@ -1,0 +1,56 @@
+import { EntityType } from 'dcl-catalyst-commons'
+import fetch from 'node-fetch'
+import { EnvironmentConfig } from '../../../src/Environment'
+import { makeNoopValidator } from '../../helpers/service/validations/NoOpValidator'
+import { loadStandaloneTestEnvironment } from '../E2ETestEnvironment'
+import { buildDeployData, deployEntitiesCombo } from '../E2ETestUtils'
+
+loadStandaloneTestEnvironment()('Integration - Audit', (testEnv) => {
+  it('returns the audit information about the entity', async () => {
+    const server = await testEnv.configServer().withConfig(EnvironmentConfig.DISABLE_SYNCHRONIZATION, true).andBuild()
+
+    makeNoopValidator(server.components)
+
+    await server.startProgram()
+
+    const entity = await buildDeployData(['profileId'], { type: EntityType.PROFILE })
+    await deployEntitiesCombo(server.components.deployer, entity)
+
+    const url = server.getUrl() + `/audit/profile/${entity.entity.id}`
+    const res = await fetch(url)
+
+    let text = (await res.buffer()).toString()
+
+    expect(res.status).toBe(200)
+  })
+
+  it('returns 400 when the entity type is invalid', async () => {
+    const server = await testEnv.configServer().withConfig(EnvironmentConfig.DISABLE_SYNCHRONIZATION, true).andBuild()
+
+    makeNoopValidator(server.components)
+
+    await server.startProgram()
+
+    const url = server.getUrl() + `/audit/non-existent-type/non-existent-entity`
+    const res = await fetch(url)
+
+    let text = (await res.buffer()).toString()
+
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 404 when it cannot find the entity', async () => {
+    const server = await testEnv.configServer().withConfig(EnvironmentConfig.DISABLE_SYNCHRONIZATION, true).andBuild()
+
+    makeNoopValidator(server.components)
+
+    await server.startProgram()
+
+    const url = server.getUrl() + `/audit/profile/non-existent-entity`
+    const res = await fetch(url)
+
+    let text = (await res.buffer()).toString()
+
+    expect(res.status).toBe(404)
+  })
+})

--- a/content/test/integration/controller/available-content.spec.ts
+++ b/content/test/integration/controller/available-content.spec.ts
@@ -1,0 +1,21 @@
+import fetch from 'node-fetch'
+import { EnvironmentConfig } from '../../../src/Environment'
+import { makeNoopValidator } from '../../helpers/service/validations/NoOpValidator'
+import { loadStandaloneTestEnvironment } from '../E2ETestEnvironment'
+
+loadStandaloneTestEnvironment()('Integration - Available Content', (testEnv) => {
+  it('returns 400 when no cid is provided', async () => {
+    const server = await testEnv.configServer().withConfig(EnvironmentConfig.DISABLE_SYNCHRONIZATION, true).andBuild()
+
+    makeNoopValidator(server.components)
+
+    await server.startProgram()
+
+    const url = server.getUrl() + `/available-content`
+    const res = await fetch(url)
+
+    let text = (await res.buffer()).toString()
+
+    expect(res.status).toBe(400)
+  })
+})

--- a/content/test/integration/controller/content.spec.ts
+++ b/content/test/integration/controller/content.spec.ts
@@ -34,4 +34,34 @@ loadStandaloneTestEnvironment()('Integration - Get Content', (testEnv) => {
     expect(headContentSpy).toHaveBeenCalledTimes(1)
     expect(getContentSpy).toHaveBeenCalledTimes(0)
   })
+
+  it('returns 404 when the content file does not exist', async () => {
+    const server = await testEnv.configServer().withConfig(EnvironmentConfig.DISABLE_SYNCHRONIZATION, true).andBuild()
+
+    makeNoopValidator(server.components)
+
+    await server.startProgram()
+
+    const url = server.getUrl() + `/contents/non-existent-file`
+    const res = await fetch(url)
+
+    let text = (await res.buffer()).toString()
+
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 404 when the content file does not exist for the head method', async () => {
+    const server = await testEnv.configServer().withConfig(EnvironmentConfig.DISABLE_SYNCHRONIZATION, true).andBuild()
+
+    makeNoopValidator(server.components)
+
+    await server.startProgram()
+
+    const url = server.getUrl() + `/contents/non-existent-file`
+    const res = await fetch(url, { method: 'HEAD' })
+
+    let text = (await res.buffer()).toString()
+
+    expect(res.status).toBe(404)
+  })
 })

--- a/content/test/integration/controller/entities.spec.ts
+++ b/content/test/integration/controller/entities.spec.ts
@@ -1,0 +1,22 @@
+import fetch from 'node-fetch'
+import { EnvironmentConfig } from '../../../src/Environment'
+import { makeNoopValidator } from '../../helpers/service/validations/NoOpValidator'
+import { loadStandaloneTestEnvironment } from '../E2ETestEnvironment'
+
+loadStandaloneTestEnvironment()('Integration - Entities', (testEnv) => {
+  it('returns 500 when there is an exception while deploying the entity', async () => {
+    const server = await testEnv.configServer().withConfig(EnvironmentConfig.DISABLE_SYNCHRONIZATION, true).andBuild()
+    jest.spyOn(server.components.deployer, 'deployEntity').mockRejectedValue({error: 'error'})
+
+    makeNoopValidator(server.components)
+
+    await server.startProgram()
+
+    const url = server.getUrl() + `/entities`
+    const res = await fetch(url, {method: 'POST'})
+
+    let text = (await res.buffer()).toString()
+
+    expect(res.status).toBe(500)
+  })
+})

--- a/content/test/integration/controller/snapshot.spec.ts
+++ b/content/test/integration/controller/snapshot.spec.ts
@@ -1,0 +1,22 @@
+import fetch from 'node-fetch'
+import { EnvironmentConfig } from '../../../src/Environment'
+import { makeNoopValidator } from '../../helpers/service/validations/NoOpValidator'
+import { loadStandaloneTestEnvironment } from '../E2ETestEnvironment'
+
+loadStandaloneTestEnvironment()('Integration - Snapshot', (testEnv) => {
+  it('returns 503 when the snapshot has no metadata', async () => {
+    const server = await testEnv.configServer().withConfig(EnvironmentConfig.DISABLE_SYNCHRONIZATION, true).andBuild()
+    jest.spyOn(server.components.snapshotManager, 'getFullSnapshotMetadata').mockReturnValue(undefined)
+
+    makeNoopValidator(server.components)
+
+    await server.startProgram()
+
+    const url = server.getUrl() + `/snapshot`
+    const res = await fetch(url)
+
+    let text = (await res.buffer()).toString()
+
+    expect(res.status).toBe(503)
+  })
+})

--- a/content/test/integration/controller/status.spec.ts
+++ b/content/test/integration/controller/status.spec.ts
@@ -1,0 +1,21 @@
+import fetch from 'node-fetch'
+import { EnvironmentConfig } from '../../../src/Environment'
+import { makeNoopValidator } from '../../helpers/service/validations/NoOpValidator'
+import { loadStandaloneTestEnvironment } from '../E2ETestEnvironment'
+
+loadStandaloneTestEnvironment()('Integration - Status', (testEnv) => {
+  it('returns 200 when the status is ok', async () => {
+    const server = await testEnv.configServer().withConfig(EnvironmentConfig.DISABLE_SYNCHRONIZATION, true).andBuild()
+
+    makeNoopValidator(server.components)
+
+    await server.startProgram()
+
+    const url = server.getUrl() + `/status`
+    const res = await fetch(url)
+
+    let text = (await res.buffer()).toString()
+
+    expect(res.status).toBe(200)
+  })
+})


### PR DESCRIPTION
## Description

Add missing tests to cover all API endpoints for the content server

<img width="511" alt="Screen Shot 2022-03-08 at 14 49 30" src="https://user-images.githubusercontent.com/12957692/157296151-99d842bc-4daf-42cf-bfcf-9e2a033428a5.png">

## Changes

- Add tests
- Bump `catalyst-api-specs` version
- Modify `OpenApiValidator` middleware
  - Validate responses on the CI
  - Ignore undocumented endpoints
  - Ignore `/entities` path as it leads to validation errors while testing other paths
- Add middleware to log `OpenApiValidator` errors

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change). If there's an API change, link the pull request in the [API spec repository](https://github.com/decentraland/catalyst-api-specs) and the accepted [DAO governance poll](https://governance.decentraland.org/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/decentraland/catalyst/blob/main/docs/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
