### PR TITLE
feat: add support for emotes

### DIFF
--- a/lambdas/src/utils/TheGraphClient.ts
+++ b/lambdas/src/utils/TheGraphClient.ts
@@ -144,7 +144,7 @@ export class TheGraphClient {
     const urnList = wearableIds.map((wearableId) => `"${wearableId}"`).join(',')
     // We need to add a 'P' prefix, because the graph needs the fragment name to start with a letter
     return `
-      P${ethAddress}: nfts(where: { owner: "${ethAddress}", searchItemType_in: ["wearable_v1", "wearable_v2", "smart_wearable_v1"], urn_in: [${urnList}] }, first: 1000) {
+      P${ethAddress}: nfts(where: { owner: "${ethAddress}", searchItemType_in: ["wearable_v1", "wearable_v2", "smart_wearable_v1", "emote_v1"], urn_in: [${urnList}] }, first: 1000) {
         urn
       }
     `
@@ -246,7 +246,7 @@ export class TheGraphClient {
   }
 
   private buildFilterQuery(filters: WearablesFilters & { lastId?: string }): string {
-    const whereClause: string[] = [`searchItemType_in: ["wearable_v1", "wearable_v2", "smart_wearable_v1"]`]
+    const whereClause: string[] = [`searchItemType_in: ["wearable_v1", "wearable_v2", "smart_wearable_v1", "emote_v1"]`]
     const params: string[] = []
     if (filters.textSearch) {
       params.push('$textSearch: String')
@@ -350,7 +350,7 @@ export class TheGraphClient {
 
 const QUERY_WEARABLES_BY_OWNER: string = `
   query WearablesByOwner($owner: String, $first: Int, $skip: Int) {
-    nfts(where: {owner: $owner, searchItemType_in: ["wearable_v1", "wearable_v2", "smart_wearable_v1"]}, first: $first, skip: $skip) {
+    nfts(where: {owner: $owner, searchItemType_in: ["wearable_v1", "wearable_v2", "smart_wearable_v1", "emote_v1"]}, first: $first, skip: $skip) {
       urn,
       collection {
         isApproved


### PR DESCRIPTION
## Description

This PR adds support for items of type `emote`. Currently they share the same schema as a `wearable` with an extra `emoteDataV0` property. Eventually they will move to their own schema and at that point we will probably need to treat them different to avoid runtime errors, but for now it's safe since everything you would expect on a wearable exist on an emote.

Fixes # (issue)

Closes # (issue)

## Changes

Added the `emote_v1` to the list of accepted types in the GraphQL queries.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change). If there's an API change, link the pull request in the [API spec repository](https://github.com/decentraland/catalyst-api-specs) and the accepted [DAO governance poll](https://governance.decentraland.org/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/decentraland/catalyst/blob/main/docs/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
