### PR TITLE
Feat: add name to tp collections

### DIFF
--- a/lambdas/src/apis/collections/types.ts
+++ b/lambdas/src/apis/collections/types.ts
@@ -78,6 +78,7 @@ export type ERC721StandardTrait = {
 
 export type ThirdPartyIntegration = {
   urn: string
+  name: string
   description: string
 }
 

--- a/lambdas/src/utils/TheGraphClient.ts
+++ b/lambdas/src/utils/TheGraphClient.ts
@@ -8,7 +8,7 @@ export class TheGraphClient {
   public static readonly MAX_PAGE_SIZE = 1000
   private static readonly LOGGER = log4js.getLogger('TheGraphClient')
 
-  constructor(private readonly urls: URLs, private readonly fetcher: Fetcher) { }
+  constructor(private readonly urls: URLs, private readonly fetcher: Fetcher) {}
 
   public async findOwnersByName(names: string[]): Promise<{ name: string; owner: EthAddress }[]> {
     const query: Query<
@@ -126,14 +126,13 @@ export class TheGraphClient {
    */
   public async getThirdPartyIntegrations(): Promise<ThirdPartyIntegration[]> {
     const query: Query<
-      { thirdParties: { id: string; metadata: { thirdParty: { name: string, description: string } } }[] },
+      { thirdParties: { id: string; metadata: { thirdParty: { name: string; description: string } } }[] },
       ThirdPartyIntegration[]
     > = {
       description: 'fetch third parties',
       subgraph: 'thirdPartyRegistrySubgraph',
       query: QUERY_THIRD_PARTIES,
-      mapper: (response) =>
-        response.thirdParties.map((tp) => ({ urn: tp.id, ...tp.metadata.thirdParty }))
+      mapper: (response) => response.thirdParties.map((tp) => ({ urn: tp.id, ...tp.metadata.thirdParty }))
     }
     return this.runQuery(query, { thirdPartyType: 'third_party_v1' })
   }

--- a/lambdas/src/utils/TheGraphClient.ts
+++ b/lambdas/src/utils/TheGraphClient.ts
@@ -8,7 +8,7 @@ export class TheGraphClient {
   public static readonly MAX_PAGE_SIZE = 1000
   private static readonly LOGGER = log4js.getLogger('TheGraphClient')
 
-  constructor(private readonly urls: URLs, private readonly fetcher: Fetcher) {}
+  constructor(private readonly urls: URLs, private readonly fetcher: Fetcher) { }
 
   public async findOwnersByName(names: string[]): Promise<{ name: string; owner: EthAddress }[]> {
     const query: Query<
@@ -126,14 +126,14 @@ export class TheGraphClient {
    */
   public async getThirdPartyIntegrations(): Promise<ThirdPartyIntegration[]> {
     const query: Query<
-      { thirdParties: { id: string; metadata: { thirdParty: { description: string } } }[] },
+      { thirdParties: { id: string; metadata: { thirdParty: { name: string, description: string } } }[] },
       ThirdPartyIntegration[]
     > = {
       description: 'fetch third parties',
       subgraph: 'thirdPartyRegistrySubgraph',
       query: QUERY_THIRD_PARTIES,
       mapper: (response) =>
-        response.thirdParties.map((tp) => ({ urn: tp.id, description: tp.metadata.thirdParty.description }))
+        response.thirdParties.map((tp) => ({ urn: tp.id, ...tp.metadata.thirdParty }))
     }
     return this.runQuery(query, { thirdPartyType: 'third_party_v1' })
   }
@@ -385,7 +385,7 @@ const QUERY_THIRD_PARTIES = `
     id
 		metadata {
       thirdParty {
-        id
+        name
         description
       }
     }


### PR DESCRIPTION
## Description

Add `name` to third-party collections lambda and remove the `id` inside the `metadata` which is not being used. 

The explorer need it: 
<img width="471" alt="Screen Shot 2022-04-01 at 18 50 29" src="https://user-images.githubusercontent.com/7549152/161345871-9eada656-3afd-472d-8525-8abdd97c9c38.png">

