### PR TITLE
chore: decrease query timeout

### DIFF
--- a/content/src/Environment.ts
+++ b/content/src/Environment.ts
@@ -119,6 +119,7 @@ export enum EnvironmentConfig {
   PSQL_PORT,
   PG_IDLE_TIMEOUT,
   PG_QUERY_TIMEOUT,
+  PG_STREAM_QUERY_TIMEOUT,
   GARBAGE_COLLECTION,
   GARBAGE_COLLECTION_INTERVAL,
   SNAPSHOT_FREQUENCY_IN_MILLISECONDS,
@@ -347,6 +348,9 @@ export class EnvironmentBuilder {
     )
     this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.PG_QUERY_TIMEOUT, () =>
       process.env.PG_QUERY_TIMEOUT ? ms(process.env.PG_QUERY_TIMEOUT) : ms('3m')
+    )
+    this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.PG_STREAM_QUERY_TIMEOUT, () =>
+      process.env.PG_STREAM_QUERY_TIMEOUT ? ms(process.env.PG_STREAM_QUERY_TIMEOUT) : ms('10m')
     )
     this.registerConfigIfNotAlreadySet(
       env,

--- a/content/src/Environment.ts
+++ b/content/src/Environment.ts
@@ -347,7 +347,7 @@ export class EnvironmentBuilder {
       process.env.PG_IDLE_TIMEOUT ? ms(process.env.PG_IDLE_TIMEOUT) : ms('30s')
     )
     this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.PG_QUERY_TIMEOUT, () =>
-      process.env.PG_QUERY_TIMEOUT ? ms(process.env.PG_QUERY_TIMEOUT) : ms('3m')
+      process.env.PG_QUERY_TIMEOUT ? ms(process.env.PG_QUERY_TIMEOUT) : ms('1m')
     )
     this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.PG_STREAM_QUERY_TIMEOUT, () =>
       process.env.PG_STREAM_QUERY_TIMEOUT ? ms(process.env.PG_STREAM_QUERY_TIMEOUT) : ms('10m')

--- a/content/src/Environment.ts
+++ b/content/src/Environment.ts
@@ -346,7 +346,7 @@ export class EnvironmentBuilder {
       process.env.PG_IDLE_TIMEOUT ? ms(process.env.PG_IDLE_TIMEOUT) : ms('30s')
     )
     this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.PG_QUERY_TIMEOUT, () =>
-      process.env.PG_QUERY_TIMEOUT ? ms(process.env.PG_QUERY_TIMEOUT) : ms('5m')
+      process.env.PG_QUERY_TIMEOUT ? ms(process.env.PG_QUERY_TIMEOUT) : ms('3m')
     )
     this.registerConfigIfNotAlreadySet(
       env,

--- a/content/src/ports/postgres.ts
+++ b/content/src/ports/postgres.ts
@@ -47,6 +47,7 @@ export async function createDatabaseComponent(
     idleTimeoutMillis: components.env.getConfig<number>(EnvironmentConfig.PG_IDLE_TIMEOUT),
     query_timeout: components.env.getConfig<number>(EnvironmentConfig.PG_QUERY_TIMEOUT)
   }
+  const streamQueryTimeout = components.env.getConfig<number>(EnvironmentConfig.PG_STREAM_QUERY_TIMEOUT)
 
   const finalOptions = { ...defaultOptions, ...options }
 
@@ -89,7 +90,7 @@ export async function createDatabaseComponent(
   async function* streamQuery<T>(sql: SQLStatement, config?: { batchSize?: number }): AsyncGenerator<T> {
     const client = new Client({
       ...finalOptions,
-      query_timeout: components.env.getConfig<number>(EnvironmentConfig.PG_STREAM_QUERY_TIMEOUT)
+      query_timeout: streamQueryTimeout
     })
     await client.connect()
 

--- a/content/src/ports/postgres.ts
+++ b/content/src/ports/postgres.ts
@@ -1,6 +1,6 @@
 import { sleep } from '@dcl/snapshots-fetcher/dist/utils'
 import { IBaseComponent, IDatabase } from '@well-known-components/interfaces'
-import { Pool, PoolConfig } from 'pg'
+import { Client, Pool, PoolConfig } from 'pg'
 import QueryStream from 'pg-query-stream'
 import { SQLStatement } from 'sql-template-strings'
 import { EnvironmentConfig } from '../Environment'
@@ -87,7 +87,12 @@ export async function createDatabaseComponent(
   }
 
   async function* streamQuery<T>(sql: SQLStatement, config?: { batchSize?: number }): AsyncGenerator<T> {
-    const client = await pool.connect()
+    const client = new Client({
+      ...finalOptions,
+      query_timeout: components.env.getConfig<number>(EnvironmentConfig.PG_STREAM_QUERY_TIMEOUT)
+    })
+    await client.connect()
+
     try {
       const stream: any = new QueryStream(sql.text, sql.values, config)
 
@@ -113,7 +118,7 @@ export async function createDatabaseComponent(
         throw err
       }
     } finally {
-      client.release()
+      await client.end()
     }
   }
 


### PR DESCRIPTION
## Description

The changes allow for decreasing the connection idle timeout for regular (non-streaming) queries and at the same time to run long-running streaming queries in a connection outside of the connection pool and configured with its own independent timeout.

Fixes #1040

Closes # (issue)

## Changes

Specify the behavior changes introduced by this pull request

i.e.

- Decreased default connection query_timeout for queries.
- Introduced new env variable to configure query_timeout for streaming queries.
- Changed `postgres#streamQuery` so that it uses fresh direct connections (outside of the connection pool) and with a separate query_timeout.

## Types of changes

What types of changes does your code introduce? Remove the lines that don't that apply:

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- I have read the [**CONTRIBUTING**](https://github.com/decentraland/catalyst/blob/main/docs/CONTRIBUTING.md) document.
- My code follows the code style of this project.
- My change requires a change to the documentation.
- I have updated the documentation accordingly.
- All new and existing tests passed.
