### PR TITLE
fix: correct handling when deploying overlapping scenes with a new owner

### DIFF
--- a/content/src/logic/database-queries/deployments-queries.ts
+++ b/content/src/logic/database-queries/deployments-queries.ts
@@ -157,7 +157,7 @@ export function getHistoricalDeploymentsQuery(
     .append(` ORDER BY dep1.`)
     .append(pg.Client.prototype.escapeIdentifier(timestampField))
     .append(` ${order}, LOWER(dep1.entity_id) ${order} `) // raw values need to be strings not sql templates
-    .append(`LIMIT ${limit} OFFSET ${offset}`)
+    .append(SQL`LIMIT ${limit} OFFSET ${offset}`)
 
   return query
 }

--- a/content/src/logic/database-queries/deployments-queries.ts
+++ b/content/src/logic/database-queries/deployments-queries.ts
@@ -157,7 +157,7 @@ export function getHistoricalDeploymentsQuery(
     .append(` ORDER BY dep1.`)
     .append(pg.Client.prototype.escapeIdentifier(timestampField))
     .append(` ${order}, LOWER(dep1.entity_id) ${order} `) // raw values need to be strings not sql templates
-    .append(SQL`LIMIT ${limit} OFFSET ${offset}`)
+    .append(`LIMIT ${limit} OFFSET ${offset}`)
 
   return query
 }

--- a/content/test/integration/service/deployments/deployment-entity-overlap.spec.ts
+++ b/content/test/integration/service/deployments/deployment-entity-overlap.spec.ts
@@ -112,18 +112,12 @@ loadStandaloneTestEnvironment()("Integration - Deployment with Entity Overlaps",
       makeNoopValidator(components);
       makeNoopServerValidator(components);
 
-      // stub(components.externalCalls, 'queryGraph')
-      //   .callsFake((...args: any) => {
-      //     console.log("queryGraph called with", args);
-      //     return Promise.resolve({});
-      //   });
-
       // Deploy E1 on P1, P2
       await deploy(components, E1);
       await assertDeploymentsAre(components, E1);
 
       // Change ownership of P2
-      // Nothing to do really, as the mock above already allows it
+      // Nothing to do really, as the mock above already allows the new deployment
 
       // Deploy E2 on P2, P3
       E2 = await buildDeployDataAfterEntity(E1, [P2, P3], {

--- a/content/test/integration/service/deployments/deployment-entity-overlap.spec.ts
+++ b/content/test/integration/service/deployments/deployment-entity-overlap.spec.ts
@@ -41,34 +41,13 @@ loadStandaloneTestEnvironment()("Integration - Deployment with Entity Overlaps",
       // make noop server validator
       makeNoopServerValidator(components);
 
+      stub(components.externalCalls, 'queryGraph')
+        .callsFake((...args: any) => {
+          console.log("queryGraph called with", args);
+          return Promise.resolve({});
+        });
+
       // make stub validator
-      // TODO The real validator is built in a way we have no access to mock its externalCalls, so
-      //  we can't mock queryGraph responses.
-      //  Only option I found is by mocking the responses this way
-      stub(components.validator, "validate")
-        .onFirstCall()
-        .resolves({ok: true})
-        .onSecondCall()
-        .resolves({ok: true})
-        // .callThrough()
-        // .resolves({
-        //   ok: false,
-        //   errors: [
-        //     `The provided Eth Address does not have access to the following parcel: (${P2})`,
-        //     `The provided Eth Address does not have access to the following parcel: (${P3})`
-        //   ]
-        // })
-        // .callsFake((args: any) => {
-        //   console.log("validator called with", args);
-        //   return Promise.resolve({
-        //     ok: false,
-        //     errors: [
-        //       `The provided Eth Address does not have access to the following parcel: (${P2})`,
-        //       `The provided Eth Address does not have access to the following parcel: (${P3})`
-        //     ]
-        //   });
-        //   // return Promise.resolve({ ok: true })
-        // });
 
       // Deploy E1 on P1, P2
       await deploy(components, E1);

--- a/content/test/integration/service/deployments/deployment-entity-overlap.spec.ts
+++ b/content/test/integration/service/deployments/deployment-entity-overlap.spec.ts
@@ -6,22 +6,23 @@ import {
   isSuccessfulDeployment
 } from "../../../../src/service/Service";
 import { AppComponents } from "../../../../src/types";
-import { makeNoopServerValidator } from "../../../helpers/service/validations/NoOpValidator";
+import { makeNoopServerValidator, makeNoopValidator } from "../../../helpers/service/validations/NoOpValidator";
 import { loadStandaloneTestEnvironment, testCaseWithComponents } from "../../E2ETestEnvironment";
-import { buildDeployData, buildDeployDataAfterEntity, EntityCombo } from "../../E2ETestUtils";
+import { buildDeployData, buildDeployDataAfterEntity, createIdentity, EntityCombo, Identity } from "../../E2ETestUtils";
 import { stub } from "sinon";
 
 /**
- * This test verifies that after a parcel changed owner, a new deployment from new owner is allowed
- * and previous overlapping scenes end up with no scene.
+ * This test verifies some scenarios that could happen during scene deployments.
  */
 loadStandaloneTestEnvironment()("Integration - Deployment with Entity Overlaps", (testEnv) => {
   const P1 = "0,0";
   const P2 = "0,1";
   const P3 = "1,1";
+  let identity: Identity;
   let E1: EntityCombo, E2: EntityCombo;
 
   beforeEach(async () => {
+    identity = createIdentity();
     E1 = await buildDeployData([P1, P2], {
       type: EntityType.SCENE,
       metadata: {
@@ -30,24 +31,92 @@ loadStandaloneTestEnvironment()("Integration - Deployment with Entity Overlaps",
           base: P1,
           parcels: [P1, P2]
         }
-      }
+      },
+      identity
     });
   });
 
   testCaseWithComponents(
     testEnv,
-    "When parcel changes owner, then new deployment by new owner succeeds and removes previous scenes from other parcels",
+    "When new scene is deployed on overlapping parcels, then new deployment removes previous scenes from orphaned parcels",
     async (components) => {
-      // make noop server validator
+      // make validators stub
+      makeNoopValidator(components);
       makeNoopServerValidator(components);
 
-      stub(components.externalCalls, 'queryGraph')
-        .callsFake((...args: any) => {
-          console.log("queryGraph called with", args);
-          return Promise.resolve({});
-        });
+      E2 = await buildDeployDataAfterEntity(E1, [P2], {
+        type: EntityType.SCENE,
+        metadata: {
+          main: "main.js",
+          scene: {
+            base: P2,
+            parcels: [P2]
+          }
+        },
+        identity
+      });
 
-      // make stub validator
+      // Deploy E1 on P1, P2
+      await deploy(components, E1);
+      await assertDeploymentsAre(components, E1);
+
+      // Deploy E2 on P2
+      await deploy(components, E2);
+      await assertDeploymentsAre(components, E2); // E1 should no longer be active
+    }
+  );
+
+  testCaseWithComponents(
+    testEnv,
+    "When scene is deployed, then server checks for permissions",
+    async (components) => {
+      // make validators stub
+      stub(components.validator, "validate")
+        .onFirstCall()
+        .resolves({ ok: true })
+        .onSecondCall()
+        .resolves({
+          ok: false, errors: [
+            `The provided Eth Address does not have access to the following parcel: (${P1})`,
+            `The provided Eth Address does not have access to the following parcel: (${P2})`
+          ]
+        });
+      makeNoopServerValidator(components);
+
+      E2 = await buildDeployDataAfterEntity(E1, [P1, P2], {
+        type: EntityType.SCENE,
+        metadata: {
+          main: "main.js",
+          scene: {
+            base: P1,
+            parcels: [P1, P2]
+          }
+        }
+      });
+
+      // Deploy E1 on P1, P2
+      await deploy(components, E1);
+      await assertDeploymentsAre(components, E1);
+
+      // Deploy E2 on P1
+      await expect(deploy(components, E2)).rejects.toThrow('The provided Eth Address does not have access to the following parcel: (0,0),The provided Eth Address does not have access to the following parcel: (0,1)');
+      await assertDeploymentsAre(components, E1); // E2 should have not been deployed
+    }
+  );
+
+  testCaseWithComponents(
+    testEnv,
+    "When parcel changes owner, then new deployment by new owner succeeds and removes previous scenes from orphaned parcels",
+    async (components) => {
+      // make noop server validator
+      makeNoopValidator(components);
+      makeNoopServerValidator(components);
+
+      // stub(components.externalCalls, 'queryGraph')
+      //   .callsFake((...args: any) => {
+      //     console.log("queryGraph called with", args);
+      //     return Promise.resolve({});
+      //   });
 
       // Deploy E1 on P1, P2
       await deploy(components, E1);
@@ -78,7 +147,6 @@ loadStandaloneTestEnvironment()("Integration - Deployment with Entity Overlaps",
     ...expectedEntities: EntityCombo[]
   ) {
     const actualDeployments = await components.deployer.getDeployments();
-    console.log(actualDeployments);
     const expectedEntityIds = expectedEntities.map((entityCombo) => entityCombo.entity.id).sort();
     const actualEntityIds = actualDeployments.deployments.map(({ entityId }) => entityId).sort();
     expect({ deployedEntityIds: actualEntityIds }).toEqual({ deployedEntityIds: expectedEntityIds });

--- a/content/test/integration/service/deployments/deployment-entity-overlap.spec.ts
+++ b/content/test/integration/service/deployments/deployment-entity-overlap.spec.ts
@@ -146,7 +146,7 @@ loadStandaloneTestEnvironment()("Integration - Deployment with Entity Overlaps",
     components: Pick<AppComponents, "deployer">,
     ...expectedEntities: EntityCombo[]
   ) {
-    const actualDeployments = await components.deployer.getDeployments();
+    const actualDeployments = await components.deployer.getDeployments({ filters: {onlyCurrentlyPointed: true}});
     const expectedEntityIds = expectedEntities.map((entityCombo) => entityCombo.entity.id).sort();
     const actualEntityIds = actualDeployments.deployments.map(({ entityId }) => entityId).sort();
     expect({ deployedEntityIds: actualEntityIds }).toEqual({ deployedEntityIds: expectedEntityIds });

--- a/content/test/integration/service/deployments/deployment-entity-overlap.spec.ts
+++ b/content/test/integration/service/deployments/deployment-entity-overlap.spec.ts
@@ -1,0 +1,136 @@
+import { AuditInfo, EntityType, EntityVersion, Timestamp } from "dcl-catalyst-commons";
+import {
+  DeploymentContext,
+  DeploymentResult,
+  isInvalidDeployment,
+  isSuccessfulDeployment
+} from "../../../../src/service/Service";
+import { AppComponents } from "../../../../src/types";
+import { makeNoopServerValidator } from "../../../helpers/service/validations/NoOpValidator";
+import { loadStandaloneTestEnvironment, testCaseWithComponents } from "../../E2ETestEnvironment";
+import { buildDeployData, buildDeployDataAfterEntity, EntityCombo } from "../../E2ETestUtils";
+import { stub } from "sinon";
+
+/**
+ * This test verifies that after a parcel changed owner, a new deployment from new owner is allowed
+ * and previous overlapping scenes end up with no scene.
+ */
+loadStandaloneTestEnvironment()("Integration - Deployment with Entity Overlaps", (testEnv) => {
+  const P1 = "0,0";
+  const P2 = "0,1";
+  const P3 = "1,1";
+  let E1: EntityCombo, E2: EntityCombo;
+
+  beforeEach(async () => {
+    E1 = await buildDeployData([P1, P2], {
+      type: EntityType.SCENE,
+      metadata: {
+        main: "main.js",
+        scene: {
+          base: P1,
+          parcels: [P1, P2]
+        }
+      }
+    });
+  });
+
+  testCaseWithComponents(
+    testEnv,
+    "When parcel changes owner, then new deployment by new owner succeeds and removes previous scenes from other parcels",
+    async (components) => {
+      // make noop server validator
+      makeNoopServerValidator(components);
+
+      // make stub validator
+      // TODO The real validator is built in a way we have no access to mock its externalCalls, so
+      //  we can't mock queryGraph responses.
+      //  Only option I found is by mocking the responses this way
+      stub(components.validator, "validate")
+        .onFirstCall()
+        .resolves({ok: true})
+        .onSecondCall()
+        .resolves({ok: true})
+        // .callThrough()
+        // .resolves({
+        //   ok: false,
+        //   errors: [
+        //     `The provided Eth Address does not have access to the following parcel: (${P2})`,
+        //     `The provided Eth Address does not have access to the following parcel: (${P3})`
+        //   ]
+        // })
+        // .callsFake((args: any) => {
+        //   console.log("validator called with", args);
+        //   return Promise.resolve({
+        //     ok: false,
+        //     errors: [
+        //       `The provided Eth Address does not have access to the following parcel: (${P2})`,
+        //       `The provided Eth Address does not have access to the following parcel: (${P3})`
+        //     ]
+        //   });
+        //   // return Promise.resolve({ ok: true })
+        // });
+
+      // Deploy E1 on P1, P2
+      await deploy(components, E1);
+      await assertDeploymentsAre(components, E1);
+
+      // Change ownership of P2
+      // Nothing to do really, as the mock above already allows it
+
+      // Deploy E2 on P2, P3
+      E2 = await buildDeployDataAfterEntity(E1, [P2, P3], {
+        type: EntityType.SCENE,
+        metadata: {
+          main: "main.js",
+          scene: {
+            base: P2,
+            parcels: [P2, P3]
+          }
+        },
+      });
+
+      await deploy(components, E2);
+      await assertDeploymentsAre(components, E2); // E1 should have no scenes now
+    }
+  );
+
+  async function assertDeploymentsAre(
+    components: Pick<AppComponents, "deployer">,
+    ...expectedEntities: EntityCombo[]
+  ) {
+    const actualDeployments = await components.deployer.getDeployments();
+    console.log(actualDeployments);
+    const expectedEntityIds = expectedEntities.map((entityCombo) => entityCombo.entity.id).sort();
+    const actualEntityIds = actualDeployments.deployments.map(({ entityId }) => entityId).sort();
+    expect({ deployedEntityIds: actualEntityIds }).toEqual({ deployedEntityIds: expectedEntityIds });
+  }
+
+  async function deploy(components: Pick<AppComponents, "deployer">, ...entities: EntityCombo[]): Promise<Timestamp[]> {
+    return deployWithAuditInfo(components, entities, {});
+  }
+
+  async function deployWithAuditInfo(
+    components: Pick<AppComponents, "deployer">,
+    entities: EntityCombo[],
+    overrideAuditInfo?: Partial<AuditInfo>
+  ) {
+    const result: Timestamp[] = [];
+    for (const { deployData } of entities) {
+      const newAuditInfo = { version: EntityVersion.V3, authChain: deployData.authChain, ...overrideAuditInfo };
+      const deploymentResult: DeploymentResult = await components.deployer.deployEntity(
+        Array.from(deployData.files.values()),
+        deployData.entityId,
+        newAuditInfo,
+        DeploymentContext.LOCAL
+      );
+      if (isSuccessfulDeployment(deploymentResult)) {
+        result.push(deploymentResult);
+      } else if (isInvalidDeployment(deploymentResult)) {
+        throw new Error(deploymentResult.errors.join(","));
+      } else {
+        throw new Error("deployEntity returned invalid result" + JSON.stringify(deploymentResult));
+      }
+    }
+    return result;
+  }
+});


### PR DESCRIPTION
## Description

New tests have been added in `deployment-entity-overlap.spec.ts` to verify some scenarios that could happen during scene deployments overlapping with previous ones:

- When new scene is deployed on overlapping parcels, then new deployment removes previous scenes from orphaned parcels
- When scene is deployed, then server checks for permissions
- When parcel changes owner, then new deployment by new owner succeeds and removes previous scenes from orphaned parcels

## Types of changes

- All new and existing tests passed.
