### PR TITLE
refactor: make externalCalls a component

### DIFF
--- a/content/src/components.ts
+++ b/content/src/components.ts
@@ -39,7 +39,7 @@ import { createRetryFailedDeployments } from './service/synchronization/retryFai
 import { createSynchronizationManager } from './service/synchronization/SynchronizationManager'
 import { SystemPropertiesManager } from './service/system-properties/SystemProperties'
 import { createServerValidator } from './service/validations/server'
-import { createValidator } from './service/validations/validator'
+import { createExternalCalls, createValidator } from './service/validations/validator'
 import { AppComponents } from './types'
 
 export async function initComponentsWithEnv(env: Environment): Promise<AppComponents> {
@@ -100,7 +100,8 @@ export async function initComponentsWithEnv(env: Environment): Promise<AppCompon
     }
   )
 
-  const validator = createValidator({ storage, authenticator, catalystFetcher, env, logs })
+  const externalCalls = createExternalCalls({ storage, authenticator, catalystFetcher, env, logs })
+  const validator = createValidator({ externalCalls, logs })
   const serverValidator = createServerValidator({ failedDeploymentsCache, metrics })
 
   const deployedEntitiesBloomFilter = createDeployedEntitiesBloomFilter({ database, logs })
@@ -266,6 +267,7 @@ export async function initComponentsWithEnv(env: Environment): Promise<AppCompon
     storage,
     authenticator,
     migrationManager,
+    externalCalls,
     validator,
     serverValidator,
     garbageCollectionManager,

--- a/content/src/service/validations/validator.ts
+++ b/content/src/service/validations/validator.ts
@@ -4,10 +4,10 @@ import { EnvironmentConfig } from '../../Environment'
 import { streamToBuffer } from '../../ports/contentStorage/contentStorage'
 import { AppComponents } from '../../types'
 
-export function createValidator(
+export function createExternalCalls(
   components: Pick<AppComponents, 'storage' | 'catalystFetcher' | 'authenticator' | 'env' | 'logs'>
-): IValidatorComponent {
-  const externalCalls: ExternalCalls = {
+): ExternalCalls {
+  return {
     isContentStoredAlready: (hashes) => components.storage.existMultiple(hashes),
     fetchContentFileSize: async (hash) => {
       const maybeFile = await components.storage.retrieve(hash)
@@ -36,6 +36,8 @@ export function createValidator(
       }
     }
   }
+}
 
-  return validator(externalCalls, components)
+export function createValidator(components: Pick<AppComponents, 'externalCalls' | 'logs'>): IValidatorComponent {
+  return validator(components.externalCalls, components)
 }

--- a/content/src/types.ts
+++ b/content/src/types.ts
@@ -1,5 +1,5 @@
 import { DAOClient } from '@dcl/catalyst-node-commons'
-import { Validator } from '@dcl/content-validator'
+import { ExternalCalls, Validator } from '@dcl/content-validator'
 import { JobLifecycleManagerComponent } from '@dcl/snapshots-fetcher/dist/job-lifecycle-manager'
 import { IJobQueue } from '@dcl/snapshots-fetcher/dist/job-queue-port'
 import { IDeployerComponent, RemoteEntityDeployment } from '@dcl/snapshots-fetcher/dist/types'
@@ -64,6 +64,7 @@ export type AppComponents = {
   authenticator: ContentAuthenticator
   migrationManager: MigrationManager
   serverValidator: ServerValidator
+  externalCalls: ExternalCalls
   validator: Validator
   garbageCollectionManager: GarbageCollectionManager
   systemPropertiesManager: SystemPropertiesManager


### PR DESCRIPTION
## Description

Extract externalCalls as a WKC so it's possible to mock individual checks of the content-validator.
