### PR TITLE
chore: use common schemas for DeploymentsWithAuthChain

### DIFF
--- a/content/package.json
+++ b/content/package.json
@@ -21,7 +21,7 @@
     "@dcl/catalyst-node-commons": "1.0.4",
     "@dcl/content-validator": "1.4.8",
     "@dcl/hashing": "^1.1.0",
-    "@dcl/schemas": "4.8.0",
+    "@dcl/schemas": "^4.10.0",
     "@dcl/snapshots-fetcher": "3.0.2",
     "@dcl/urn-resolver": "1.3.1",
     "@well-known-components/http-server": "^1.0.0",

--- a/content/src/logic/database-queries/deployments-queries.ts
+++ b/content/src/logic/database-queries/deployments-queries.ts
@@ -1,10 +1,9 @@
+import { DeploymentWithAuthChain } from '@dcl/schemas'
 import {
   DeploymentFilters,
   DeploymentSorting,
-  EntityId,
   EntityType,
   EntityVersion,
-  Pointer,
   SortingField,
   SortingOrder
 } from 'dcl-catalyst-commons'
@@ -13,17 +12,12 @@ import pg from 'pg'
 import SQL, { SQLStatement } from 'sql-template-strings'
 import { AppComponents } from '../../types'
 
-export interface HistoricalDeployment {
+export type HistoricalDeployment = DeploymentWithAuthChain & {
   deploymentId: number
-  entityType: EntityType
-  entityId: string
-  pointers: Pointer[]
   entityTimestamp: number
   metadata: any
   deployerAddress: string
   version: EntityVersion
-  authChain: AuthChain
-  localTimestamp: number
   overwrittenBy?: string
 }
 
@@ -35,7 +29,7 @@ export interface HistoricalDeploymentsRow {
   entity_id: string
   entity_metadata: any
   entity_timestamp: number
-  entity_pointers: Pointer[]
+  entity_pointers: string[]
   local_timestamp: number
   auth_chain: AuthChain
   deleter_deployment: number

--- a/content/src/logic/database-queries/pointers-queries.ts
+++ b/content/src/logic/database-queries/pointers-queries.ts
@@ -1,18 +1,17 @@
-import { EntityId, Pointer } from 'dcl-catalyst-commons'
 import SQL from 'sql-template-strings'
 import { AppComponents } from '../../types'
 
 export async function getActiveDeploymentsByUrnPrefix(
   components: Pick<AppComponents, 'database'>,
   collectionUrn: string
-): Promise<{ pointer: Pointer; entityId: EntityId }[]> {
+): Promise<{ pointer: string; entityId: string }[]> {
   // sql-template-strings doesn't allow ' in the query string
   const matchingString = `${collectionUrn}%`
   const query = SQL`SELECT * FROM active_pointers as p WHERE p.pointer LIKE ${matchingString};`
 
   const queryResult = (await components.database.queryWithValues(query, 'filter_by_urn_prefix')).rows
 
-  const entities = queryResult.map((deployment: { entity_id: EntityId; pointer: Pointer }) => {
+  const entities = queryResult.map((deployment: { entity_id: string; pointer: string }) => {
     return {
       entityId: deployment.entity_id,
       pointer: deployment.pointer
@@ -24,8 +23,8 @@ export async function getActiveDeploymentsByUrnPrefix(
 
 export async function updateActiveDeployments(
   components: Pick<AppComponents, 'database'>,
-  pointers: Pointer[],
-  entityId: EntityId
+  pointers: string[],
+  entityId: string
 ): Promise<void> {
   const value_list = pointers.map((p, i) => {
     if (i < pointers.length - 1) {
@@ -44,7 +43,7 @@ export async function updateActiveDeployments(
 
 export async function removeActiveDeployments(
   components: Pick<AppComponents, 'database'>,
-  pointers: Pointer[]
+  pointers: string[]
 ): Promise<void> {
   const value_list = pointers.map((p, i) => {
     if (i < pointers.length - 1) {

--- a/content/src/logic/database-queries/snapshots-queries.ts
+++ b/content/src/logic/database-queries/snapshots-queries.ts
@@ -1,15 +1,6 @@
-import { EntityId, EntityType, Pointer, Timestamp } from 'dcl-catalyst-commons'
-import { AuthChain } from 'dcl-crypto'
+import { DeploymentWithAuthChain } from '@dcl/schemas'
 import SQL from 'sql-template-strings'
 import { AppComponents } from '../../types'
-
-export type DeploymentWithAuthChain = {
-  entityId: EntityId
-  entityType: EntityType
-  pointers: Pointer[]
-  localTimestamp: Timestamp
-  authChain: AuthChain
-}
 
 export async function* streamActiveDeployments(
   components: Pick<AppComponents, 'database'>

--- a/content/src/migrations/Helper.ts
+++ b/content/src/migrations/Helper.ts
@@ -1,8 +1,8 @@
-import { EntityId, EntityType, Pointer } from 'dcl-catalyst-commons'
+import { EntityType } from 'dcl-catalyst-commons'
 import { MigrationBuilder } from 'node-pg-migrate'
 import { FailureReason } from '../ports/failedDeploymentsCache'
 
-export function deleteFailedDeployments(pgm: MigrationBuilder, ...entityIds: EntityId[]): void {
+export function deleteFailedDeployments(pgm: MigrationBuilder, ...entityIds: string[]): void {
   const inClause = entityIds.map((entityId) => `'${entityId}'`).join(',')
   pgm.sql(`DELETE FROM failed_deployments WHERE entity_id IN (${inClause})`)
 }
@@ -24,7 +24,7 @@ const SUPPORTED_TYPES = [EntityType.WEARABLE] // This has only been tested on we
 export async function considerDeploymentsOnPointersAsFailed(
   pgm: MigrationBuilder,
   entityType: EntityType,
-  ...pointers: Pointer[]
+  ...pointers: string[]
 ): Promise<void> {
   if (!SUPPORTED_TYPES.includes(entityType)) {
     throw new Error(`${entityType} is not supported right now`)
@@ -34,7 +34,7 @@ export async function considerDeploymentsOnPointersAsFailed(
   }
 }
 
-async function considerDeploymentsOnPointerAsFailed(pgm: MigrationBuilder, entityType: EntityType, pointer: Pointer) {
+async function considerDeploymentsOnPointerAsFailed(pgm: MigrationBuilder, entityType: EntityType, pointer: string) {
   const now = Date.now()
   const { rows } = await pgm.db.query(`
     SELECT id, entity_id, entity_pointers

--- a/content/src/ports/deployRateLimiterComponent.ts
+++ b/content/src/ports/deployRateLimiterComponent.ts
@@ -1,12 +1,12 @@
 import { ILoggerComponent } from '@well-known-components/interfaces'
-import { EntityType, Pointer, Timestamp } from 'dcl-catalyst-commons'
+import { EntityType } from 'dcl-catalyst-commons'
 import ms from 'ms'
 import NodeCache from 'node-cache'
 import { AppComponents } from '../types'
 
 export type IDeployRateLimiterComponent = {
-  newDeployment(entityType: EntityType, pointers: Pointer[], localTimestamp: Timestamp): void
-  isRateLimited(entityType: EntityType, pointers: Pointer[]): boolean
+  newDeployment(entityType: EntityType, pointers: string[], localTimestamp: number): void
+  isRateLimited(entityType: EntityType, pointers: string[]): boolean
 }
 
 export type DeploymentRateLimitConfig = {
@@ -36,7 +36,7 @@ export function createDeployRateLimiter(
   }
 
   return {
-    newDeployment(entityType: EntityType, pointers: Pointer[], localTimestamp: Timestamp): void {
+    newDeployment(entityType: EntityType, pointers: string[], localTimestamp: number): void {
       const cacheByEntityType = getCacheFromEntityType(entityType)
       for (const pointer in pointers) {
         cacheByEntityType.cache.set(pointer, localTimestamp)
@@ -45,7 +45,7 @@ export function createDeployRateLimiter(
 
     /** Check if the entity should be rate limit: no deployment has been made for the same pointer in the last ttl
      * and no more than max size of deployments were made either   */
-    isRateLimited(entityType: EntityType, pointers: Pointer[]): boolean {
+    isRateLimited(entityType: EntityType, pointers: string[]): boolean {
       const cacheByEntityType = getCacheFromEntityType(entityType)
       return (
         pointers.some((p) => !!cacheByEntityType.cache.get(p)) ||

--- a/content/src/ports/failedDeploymentsCache.ts
+++ b/content/src/ports/failedDeploymentsCache.ts
@@ -1,4 +1,4 @@
-import { EntityId, EntityType, Timestamp } from 'dcl-catalyst-commons'
+import { EntityType } from 'dcl-catalyst-commons'
 import { AuthChain } from 'dcl-crypto'
 
 export enum FailureReason {
@@ -13,8 +13,8 @@ export type DeploymentStatus = FailureReason | NoFailure
 
 export type FailedDeployment = {
   entityType: EntityType
-  entityId: EntityId
-  failureTimestamp: Timestamp
+  entityId: string
+  failureTimestamp: number
   reason: FailureReason
   authChain: AuthChain
   errorDescription?: string
@@ -22,28 +22,28 @@ export type FailedDeployment = {
 
 export type IFailedDeploymentsCacheComponent = {
   getAllFailedDeployments(): FailedDeployment[]
-  findFailedDeployment(entityId: EntityId): FailedDeployment | undefined
-  removeFailedDeployment(entityId: EntityId): boolean
+  findFailedDeployment(entityId: string): FailedDeployment | undefined
+  removeFailedDeployment(entityId: string): boolean
   reportFailure(failedDeployment: FailedDeployment): void
-  getDeploymentStatus(entityId: EntityId): DeploymentStatus
+  getDeploymentStatus(entityId: string): DeploymentStatus
 }
 
 export function createFailedDeploymentsCache(): IFailedDeploymentsCacheComponent {
-  const failedDeployments: Map<EntityId, FailedDeployment> = new Map()
+  const failedDeployments: Map<string, FailedDeployment> = new Map()
   return {
     getAllFailedDeployments() {
       return Array.from(failedDeployments.values())
     },
-    findFailedDeployment(entityId: EntityId) {
+    findFailedDeployment(entityId: string) {
       return failedDeployments.get(entityId)
     },
-    removeFailedDeployment(entityId: EntityId) {
+    removeFailedDeployment(entityId: string) {
       return failedDeployments.delete(entityId)
     },
     reportFailure(failedDeployment: FailedDeployment) {
       failedDeployments.set(failedDeployment.entityId, failedDeployment)
     },
-    getDeploymentStatus(entityId: EntityId) {
+    getDeploymentStatus(entityId: string) {
       return failedDeployments.get(entityId)?.reason ?? NoFailure.NOT_MARKED_AS_FAILED
     }
   }

--- a/content/src/repository/extensions/ContentFilesRepository.ts
+++ b/content/src/repository/extensions/ContentFilesRepository.ts
@@ -1,11 +1,11 @@
-import { ContentFileHash, DeploymentContent, EntityContentItemReference, Timestamp } from 'dcl-catalyst-commons'
+import { ContentFileHash, DeploymentContent, EntityContentItemReference } from 'dcl-catalyst-commons'
 import { Database } from '../../repository/Database'
 import { DeploymentId } from './DeploymentsRepository'
 
 export class ContentFilesRepository {
   constructor(private readonly db: Database) {}
 
-  findContentHashesNotBeingUsedAnymore(lastGarbageCollection: Timestamp): Promise<ContentFileHash[]> {
+  findContentHashesNotBeingUsedAnymore(lastGarbageCollectionTimestamp: number): Promise<ContentFileHash[]> {
     return this.db.map(
       `
             SELECT content_files.content_hash
@@ -16,7 +16,7 @@ export class ContentFilesRepository {
             GROUP BY content_files.content_hash
             HAVING bool_or(deployments.deleter_deployment IS NULL) = FALSE
             `,
-      [lastGarbageCollection],
+      [lastGarbageCollectionTimestamp],
       (row) => row.content_hash
     )
   }

--- a/content/src/repository/extensions/DeploymentsRepository.ts
+++ b/content/src/repository/extensions/DeploymentsRepository.ts
@@ -1,19 +1,11 @@
-import { AuditInfo, Entity, EntityId, EntityType, Pointer, Timestamp } from 'dcl-catalyst-commons'
-import { AuthChain, Authenticator } from 'dcl-crypto'
+import { AuditInfo, Entity, EntityType } from 'dcl-catalyst-commons'
+import { Authenticator } from 'dcl-crypto'
 import { Database } from '../../repository/Database'
-
-export type FullSnapshot = {
-  entityId: EntityId
-  entityType: EntityType
-  pointers: Pointer[]
-  localTimestamp: Timestamp
-  authChain: AuthChain
-}
 
 export class DeploymentsRepository {
   constructor(private readonly db: Database) {}
 
-  async getEntityById(entityId: EntityId) {
+  async getEntityById(entityId: string) {
     const result = await this.db.map(
       `
         SELECT
@@ -41,7 +33,7 @@ export class DeploymentsRepository {
     return new Map(entries)
   }
 
-  deploymentsSince(entityType: EntityType, timestamp: Timestamp): Promise<number> {
+  deploymentsSince(entityType: EntityType, timestamp: number): Promise<number> {
     return this.db.one(
       `SELECT COUNT(*) AS count ` +
         `FROM deployments ` +

--- a/content/src/repository/extensions/LastDeployedPointersRepository.ts
+++ b/content/src/repository/extensions/LastDeployedPointersRepository.ts
@@ -1,4 +1,4 @@
-import { EntityId, EntityType, Pointer, Timestamp } from 'dcl-catalyst-commons'
+import { EntityType } from 'dcl-catalyst-commons'
 import { Database } from '../Database'
 import { DeploymentId } from './DeploymentsRepository'
 
@@ -8,9 +8,9 @@ export class LastDeployedPointersRepository {
   /** Returns the last deployments that were active on the given pointers (could be active or not right now) */
   getLastActiveDeploymentsOnPointers(
     entityType: EntityType,
-    pointers: Pointer[]
+    pointers: string[]
   ): Promise<
-    { deployment: DeploymentId; entityId: EntityId; timestamp: Timestamp; pointers: Pointer[]; deleted: boolean }[]
+    { deployment: DeploymentId; entityId: string; timestamp: number; pointers: string[]; deleted: boolean }[]
   > {
     if (pointers.length === 0) {
       return Promise.resolve([])
@@ -45,7 +45,7 @@ export class LastDeployedPointersRepository {
   async setAsLastActiveDeploymentsOnPointers(
     deploymentId: DeploymentId,
     entityType: EntityType,
-    pointers: Pointer[]
+    pointers: string[]
   ): Promise<void> {
     if (pointers.length > 0) {
       await this.db.txIf((transaction) => {

--- a/content/src/service/EntityFactory.ts
+++ b/content/src/service/EntityFactory.ts
@@ -1,7 +1,7 @@
-import { Entity, EntityContentItemReference, EntityId, EntityType, EntityVersion, Pointer } from 'dcl-catalyst-commons'
+import { Entity, EntityContentItemReference, EntityType, EntityVersion } from 'dcl-catalyst-commons'
 
 export class EntityFactory {
-  static fromBufferWithId(buffer: Uint8Array, id: EntityId): Entity {
+  static fromBufferWithId(buffer: Uint8Array, id: string): Entity {
     const object = EntityFactory.parseJsonIntoObject(buffer)
     return EntityFactory.fromObject(object, id)
   }
@@ -21,7 +21,7 @@ export class EntityFactory {
     }
   }
 
-  private static fromObject(object: any, id: EntityId): Entity {
+  private static fromObject(object: any, id: string): Entity {
     if (!object.type || !Object.values(EntityType).includes(object.type)) {
       throw new Error(
         `Please set a valid type. It must be one of ${Object.values(EntityType)}. We got '${object.type}'`
@@ -53,7 +53,7 @@ export class EntityFactory {
     return {
       id,
       type,
-      pointers: object.pointers.map((pointer: Pointer) => pointer.toLowerCase()),
+      pointers: object.pointers.map((pointer: string) => pointer.toLowerCase()),
       timestamp: object.timestamp,
       version,
       content,

--- a/content/src/service/Service.ts
+++ b/content/src/service/Service.ts
@@ -1,13 +1,4 @@
-import {
-  AuditInfo,
-  ContentFileHash,
-  Deployment,
-  Entity,
-  EntityId,
-  EntityType,
-  PartialDeploymentHistory,
-  Timestamp
-} from 'dcl-catalyst-commons'
+import { AuditInfo, ContentFileHash, Deployment, EntityType, PartialDeploymentHistory } from 'dcl-catalyst-commons'
 import { AuthChain } from 'dcl-crypto'
 import { ContentItem } from '../ports/contentStorage/contentStorage'
 import { FailedDeployment } from '../ports/failedDeploymentsCache'
@@ -21,7 +12,7 @@ import { DeploymentOptions } from './deployments/types'
 export interface MetaverseContentService {
   deployEntity(
     files: DeploymentFiles,
-    entityId: EntityId,
+    entityId: string,
     auditInfo: LocalDeploymentAuditInfo,
     context: DeploymentContext,
     task?: Database
@@ -32,31 +23,26 @@ export interface MetaverseContentService {
   getAllFailedDeployments(): FailedDeployment[]
   reportErrorDuringSync(
     entityType: EntityType,
-    entityId: EntityId,
+    entityId: string,
     reason: string,
     authChain: AuthChain,
     errorDescription?: string
   ): void
-  getEntityById(entityId: EntityId): Promise<{ entityId: string; localTimestamp: number } | void>
+  getEntityById(entityId: string): Promise<{ entityId: string; localTimestamp: number } | void>
 }
 
 export type LocalDeploymentAuditInfo = Pick<AuditInfo, 'authChain'>
-
-export type DeploymentEvent = {
-  entity: Entity
-  auditInfo: AuditInfo
-}
 
 export type InvalidResult = { errors: string[] }
 export function InvalidResult(val: InvalidResult): InvalidResult {
   return val
 }
 
-export type DeploymentResult = Timestamp | InvalidResult
+export type DeploymentResult = number | InvalidResult
 
 export type DeploymentFiles = Uint8Array[] | Map<ContentFileHash, Uint8Array>
 
-export function isSuccessfulDeployment(deploymentResult: DeploymentResult): deploymentResult is Timestamp {
+export function isSuccessfulDeployment(deploymentResult: DeploymentResult): deploymentResult is number {
   return typeof deploymentResult === 'number'
 }
 

--- a/content/src/service/ServiceImpl.ts
+++ b/content/src/service/ServiceImpl.ts
@@ -5,11 +5,10 @@ import {
   ContentFileHash,
   Deployment,
   Entity,
-  EntityId,
   EntityType,
+  // TODO: replace this Hashing by the new lib
   Hashing,
-  PartialDeploymentHistory,
-  Pointer
+  PartialDeploymentHistory
 } from 'dcl-catalyst-commons'
 import { AuthChain, Authenticator } from 'dcl-crypto'
 import { EnvironmentConfig } from '../Environment'
@@ -36,7 +35,7 @@ import { happenedBefore } from './time/TimeSorting'
 
 export class ServiceImpl implements MetaverseContentService {
   private static LOGGER: ILoggerComponent.ILogger
-  private readonly pointersBeingDeployed: Map<EntityType, Set<Pointer>> = new Map()
+  private readonly pointersBeingDeployed: Map<EntityType, Set<string>> = new Map()
 
   private readonly LEGACY_CONTENT_MIGRATION_TIMESTAMP: Date = new Date(1582167600000) // DCL Launch Day
 
@@ -66,7 +65,7 @@ export class ServiceImpl implements MetaverseContentService {
 
   async deployEntity(
     files: DeploymentFiles,
-    entityId: EntityId,
+    entityId: string,
     auditInfo: LocalDeploymentAuditInfo,
     context: DeploymentContext,
     task?: Database
@@ -339,7 +338,7 @@ export class ServiceImpl implements MetaverseContentService {
 
   reportErrorDuringSync(
     entityType: EntityType,
-    entityId: EntityId,
+    entityId: string,
     reason: FailureReason,
     authChain: AuthChain,
     errorDescription?: string
@@ -391,7 +390,7 @@ export class ServiceImpl implements MetaverseContentService {
    * They could come hashed because the denylist decorator might have already hashed them for its own validations. In order to avoid re-hashing
    * them in the service (because there might be hundreds of files), we will send the hash result.
    */
-  static async hashFiles(files: DeploymentFiles, entityId: EntityId): Promise<Map<ContentFileHash, Uint8Array>> {
+  static async hashFiles(files: DeploymentFiles, entityId: string): Promise<Map<ContentFileHash, Uint8Array>> {
     if (files instanceof Map) {
       return files
     } else {
@@ -414,10 +413,7 @@ export class ServiceImpl implements MetaverseContentService {
     return this.components.storage.existMultiple(fileHashes)
   }
 
-  async getEntityById(
-    entityId: EntityId,
-    task?: Database
-  ): Promise<{ entityId: EntityId; localTimestamp: number } | void> {
+  async getEntityById(entityId: string, task?: Database): Promise<{ entityId: string; localTimestamp: number } | void> {
     return this.components.repository.reuseIfPresent(
       task,
       (db) => this.components.deploymentManager.getEntityById(db.deployments, entityId),

--- a/content/src/service/deployments/deployments.ts
+++ b/content/src/service/deployments/deployments.ts
@@ -1,4 +1,4 @@
-import { Deployment, EntityVersion, PartialDeploymentHistory } from 'dcl-catalyst-commons'
+import { Deployment, EntityType, EntityVersion, PartialDeploymentHistory } from 'dcl-catalyst-commons'
 import { getContentFiles } from '../../logic/database-queries/content-files-queries'
 import { getHistoricalDeployments } from '../../logic/database-queries/deployments-queries'
 import { AppComponents } from '../../types'
@@ -43,7 +43,7 @@ export async function getDeployments(
 
   const deployments: Deployment[] = deploymentsResult.map((result) => ({
     entityVersion: result.version as EntityVersion,
-    entityType: result.entityType,
+    entityType: result.entityType as EntityType,
     entityId: result.entityId,
     pointers: result.pointers,
     entityTimestamp: result.entityTimestamp,

--- a/content/src/service/garbage-collection/GarbageCollectionManager.ts
+++ b/content/src/service/garbage-collection/GarbageCollectionManager.ts
@@ -1,5 +1,5 @@
 import { ILoggerComponent } from '@well-known-components/interfaces'
-import { ContentFileHash, delay, Timestamp } from 'dcl-catalyst-commons'
+import { ContentFileHash, delay } from 'dcl-catalyst-commons'
 import { DB_REQUEST_PRIORITY } from '../../repository/RepositoryQueue'
 import { SystemProperty } from '../../service/system-properties/SystemProperties'
 import { AppComponents } from '../../types'
@@ -7,7 +7,7 @@ import { AppComponents } from '../../types'
 export class GarbageCollectionManager {
   private LOGGER: ILoggerComponent.ILogger
   private hashesDeletedInLastSweep: Set<ContentFileHash> = new Set()
-  private lastTimeOfCollection: Timestamp
+  private lastTimeOfCollection: number
   private nextGarbageCollectionTimeout: NodeJS.Timeout
   private stopping = false
   private sweeping = false
@@ -47,7 +47,7 @@ export class GarbageCollectionManager {
    * If they are not being used, then we will delete them.
    */
   async performSweep() {
-    const newTimeOfCollection: Timestamp = Date.now()
+    const newTimeOfCollection: number = Date.now()
     this.sweeping = true
     try {
       await this.components.repository.tx(

--- a/content/src/service/pointers/PointerManager.ts
+++ b/content/src/service/pointers/PointerManager.ts
@@ -1,4 +1,4 @@
-import { Entity, Pointer } from 'dcl-catalyst-commons'
+import { Entity } from 'dcl-catalyst-commons'
 import { DeploymentId } from '../../repository/extensions/DeploymentsRepository'
 import { LastDeployedPointersRepository } from '../../repository/extensions/LastDeployedPointersRepository'
 import { PointerHistoryRepository } from '../../repository/extensions/PointerHistoryRepository'
@@ -42,11 +42,11 @@ export class PointerManager {
 
     // Prepare variables
     const result: DeploymentResult = new Map()
-    const overwrite: Set<Pointer> = new Set()
+    const overwrite: Set<string> = new Set()
 
     lastDeployments.forEach((lastDeployment) => {
       // Calculate the intersection of pointers between the last deployment and the new one
-      const intersection: Set<Pointer> = intersect(lastDeployment.pointers, entity.pointers)
+      const intersection: Set<string> = intersect(lastDeployment.pointers, entity.pointers)
 
       if (happenedBefore(lastDeployment, entity)) {
         intersection.forEach((pointer) => {
@@ -64,7 +64,7 @@ export class PointerManager {
 
         // If the last deployment wasn't already deleted, then the pointers not pointing to the new entity will point to nothing
         if (!lastDeployment.deleted) {
-          const onlyOnLastDeployed: Set<Pointer> = diff(lastDeployment.pointers, entity.pointers)
+          const onlyOnLastDeployed: Set<string> = diff(lastDeployment.pointers, entity.pointers)
           onlyOnLastDeployed.forEach((pointer) =>
             result.set(pointer, { before: lastDeployment.deployment, after: DELTA_POINTER_RESULT.CLEARED })
           )
@@ -94,17 +94,17 @@ export class PointerManager {
   }
 }
 
-export type DeploymentResult = Map<Pointer, { before: DeploymentId | undefined; after: DELTA_POINTER_RESULT }>
+export type DeploymentResult = Map<string, { before: DeploymentId | undefined; after: DELTA_POINTER_RESULT }>
 
 export enum DELTA_POINTER_RESULT {
   SET = 'set',
   CLEARED = 'cleared'
 }
 
-function intersect(pointers1: Pointer[], pointers2: Pointer[]): Set<Pointer> {
+function intersect(pointers1: string[], pointers2: string[]): Set<string> {
   return new Set(pointers1.filter((pointer) => pointers2.includes(pointer)))
 }
 
-function diff(pointers1: Pointer[], pointers2: Pointer[]): Set<Pointer> {
+function diff(pointers1: string[], pointers2: string[]): Set<string> {
   return new Set(pointers1.filter((pointer) => !pointers2.includes(pointer)))
 }

--- a/content/src/service/pointers/pointers.ts
+++ b/content/src/service/pointers/pointers.ts
@@ -1,5 +1,5 @@
+import { DeploymentWithAuthChain } from '@dcl/schemas'
 import { getHistoricalDeployments, HistoricalDeployment } from '../../logic/database-queries/deployments-queries'
-import { DeploymentWithAuthChain } from '../../logic/database-queries/snapshots-queries'
 import { AppComponents } from '../../types'
 import { PointerChangesOptions } from '../deployments/types'
 import { DeploymentPointerChanges } from './types'

--- a/content/src/service/pointers/types.ts
+++ b/content/src/service/pointers/types.ts
@@ -1,5 +1,5 @@
+import { DeploymentWithAuthChain } from '@dcl/schemas'
 import { DeploymentFilters } from 'dcl-catalyst-commons'
-import { DeploymentWithAuthChain } from '../../logic/database-queries/snapshots-queries'
 
 export type PointerChangesFilters = Pick<DeploymentFilters, 'from' | 'to' | 'entityTypes'>
 

--- a/content/src/service/snapshots/SnapshotManager.ts
+++ b/content/src/service/snapshots/SnapshotManager.ts
@@ -1,7 +1,7 @@
 import { delay } from '@dcl/catalyst-node-commons'
 import { hashV1 } from '@dcl/hashing'
 import { ILoggerComponent } from '@well-known-components/interfaces'
-import { ContentFileHash, EntityType, Hashing, Timestamp } from 'dcl-catalyst-commons'
+import { ContentFileHash, EntityType, Hashing } from 'dcl-catalyst-commons'
 import future from 'fp-future'
 import * as fs from 'fs'
 import { streamActiveDeployments } from '../../logic/database-queries/snapshots-queries'
@@ -296,5 +296,5 @@ export class SnapshotManager implements IStatusCapableComponent, ISnapshotManage
   }
 }
 
-export type SnapshotMetadata = { hash: ContentFileHash; lastIncludedDeploymentTimestamp: Timestamp }
+export type SnapshotMetadata = { hash: ContentFileHash; lastIncludedDeploymentTimestamp: number }
 export type FullSnapshotMetadata = SnapshotMetadata & { entities: Record<string, SnapshotMetadata> }

--- a/content/src/service/system-properties/SystemProperties.ts
+++ b/content/src/service/system-properties/SystemProperties.ts
@@ -1,5 +1,5 @@
 import { ServerBaseUrl } from '@dcl/catalyst-node-commons'
-import { EntityType, Timestamp } from 'dcl-catalyst-commons'
+import { EntityType } from 'dcl-catalyst-commons'
 import { Database } from '../../repository/Database'
 import { Repository } from '../../repository/Repository'
 import { DB_REQUEST_PRIORITY } from '../../repository/RepositoryQueue'
@@ -7,7 +7,7 @@ import { SnapshotMetadata } from '../snapshots/SnapshotManager'
 import { IntPropertyMapper, JSONPropertyMapper, SystemPropertyMapper } from './SystemPropertyMappers'
 
 export class SystemProperty<PropertyType> {
-  static readonly LAST_KNOWN_LOCAL_DEPLOYMENTS: SystemProperty<[ServerBaseUrl, Timestamp][]> = new SystemProperty(
+  static readonly LAST_KNOWN_LOCAL_DEPLOYMENTS: SystemProperty<[ServerBaseUrl, number][]> = new SystemProperty(
     'last_known_local_deployments',
     new JSONPropertyMapper()
   )
@@ -15,7 +15,7 @@ export class SystemProperty<PropertyType> {
     'last_full_snapshot_per_entity',
     new JSONPropertyMapper()
   )
-  static readonly LAST_GARBAGE_COLLECTION_TIME: SystemProperty<Timestamp> = new SystemProperty(
+  static readonly LAST_GARBAGE_COLLECTION_TIME: SystemProperty<number> = new SystemProperty(
     'last_garbage_collection_time',
     new IntPropertyMapper()
   )

--- a/content/src/service/time/TimeSorting.ts
+++ b/content/src/service/time/TimeSorting.ts
@@ -1,4 +1,4 @@
-import { Deployment, Entity, EntityId, Timestamp } from 'dcl-catalyst-commons'
+import { Deployment, Entity } from 'dcl-catalyst-commons'
 
 /** Return true if the first object happened before the second one */
 function happenedBeforeComparable(comparable1: EntityComparable, comparable2: EntityComparable): boolean {
@@ -32,6 +32,6 @@ function toComparable(toBeComparable: EntityComparable | Deployment | Entity) {
 }
 
 type EntityComparable = {
-  timestamp: Timestamp
-  entityId: EntityId
+  timestamp: number
+  entityId: string
 }

--- a/content/test/helpers/service/EntityTestFactory.ts
+++ b/content/test/helpers/service/EntityTestFactory.ts
@@ -1,13 +1,13 @@
 import { DeploymentBuilder } from 'dcl-catalyst-client'
-import { ContentFileHash, Entity, EntityType, EntityVersion, Pointer, Timestamp } from 'dcl-catalyst-commons'
+import { ContentFileHash, Entity, EntityType, EntityVersion } from 'dcl-catalyst-commons'
 import { random } from 'faker'
 import { EntityFactory } from '../../../src/service/EntityFactory'
 
 /** Builds an entity with the given params, and also the file what represents it */
 export async function buildEntityAndFile(
   type: EntityType,
-  pointers: Pointer[],
-  timestamp: Timestamp,
+  pointers: string[],
+  timestamp: number,
   content?: Map<string, ContentFileHash>,
   metadata?: any
 ): Promise<[Entity, Uint8Array]> {

--- a/content/test/helpers/service/MockedMetaverseContentService.ts
+++ b/content/test/helpers/service/MockedMetaverseContentService.ts
@@ -1,19 +1,16 @@
+import { DeploymentWithAuthChain } from '@dcl/schemas'
 import {
   AuditInfo,
   ContentFileHash,
   Deployment,
   Entity,
-  EntityId,
   EntityType,
   EntityVersion,
-  PartialDeploymentHistory,
-  Pointer,
-  Timestamp
+  PartialDeploymentHistory
 } from 'dcl-catalyst-commons'
 import { AuthChain, AuthLinkType } from 'dcl-crypto'
 import { random } from 'faker'
 import { CURRENT_CONTENT_VERSION } from '../../../src/Environment'
-import { DeploymentWithAuthChain } from '../../../src/logic/database-queries/snapshots-queries'
 import { ContentItem, SimpleContentItem } from '../../../src/ports/contentStorage/contentStorage'
 import { FailedDeployment } from '../../../src/ports/failedDeploymentsCache'
 import { DeploymentOptions, PointerChangesOptions } from '../../../src/service/deployments/types'
@@ -70,7 +67,7 @@ export class MockedMetaverseContentService implements MetaverseContentService, I
     throw new Error('Method not implemented.')
   }
 
-  getEntityById(entityId: EntityId): Promise<{ entityId: string; localTimestamp: number } | void> {
+  getEntityById(entityId: string): Promise<{ entityId: string; localTimestamp: number } | void> {
     throw new Error('Method not implemented.')
   }
 
@@ -108,10 +105,10 @@ export class MockedMetaverseContentService implements MetaverseContentService, I
 
   deployEntity(
     files: Buffer[],
-    entityId: EntityId,
+    entityId: string,
     auditInfo: LocalDeploymentAuditInfo,
     context: DeploymentContext
-  ): Promise<Timestamp> {
+  ): Promise<number> {
     return Promise.resolve(Date.now())
   }
 
@@ -163,7 +160,7 @@ export class MockedMetaverseContentService implements MetaverseContentService, I
     }
   }
 
-  private isThereAnEntityWithId(entityId: EntityId): boolean {
+  private isThereAnEntityWithId(entityId: string): boolean {
     return this.entities.map((entity) => entity.id == entityId).reduce((accum, currentValue) => accum || currentValue)
   }
 }
@@ -194,7 +191,7 @@ export class MockedMetaverseContentServiceBuilder {
 }
 
 export function buildEntity(
-  pointers: Pointer[],
+  pointers: string[],
   ...content: { hash: ContentFileHash; buffer: Buffer }[]
 ): Promise<[Entity, Uint8Array]> {
   const entityContent: Map<string, ContentFileHash> = new Map(

--- a/content/test/integration/E2EAssertions.ts
+++ b/content/test/integration/E2EAssertions.ts
@@ -6,8 +6,7 @@ import {
   Deployment as ControllerDeployment,
   Entity as ControllerEntity,
   EntityContentItemReference,
-  EntityVersion,
-  Timestamp
+  EntityVersion
 } from 'dcl-catalyst-commons'
 import { Authenticator } from 'dcl-crypto'
 import { Response } from 'node-fetch'
@@ -243,7 +242,7 @@ export async function assertContentIsDenylisted(
 export function buildDeployment(
   deployData: DeploymentData,
   entity: ControllerEntity,
-  deploymentTimestamp: Timestamp
+  deploymentTimestamp: number
 ): ControllerDeployment {
   return {
     ...entity,
@@ -318,7 +317,7 @@ export async function assertResponseIsOkOrThrow(response: Response) {
   }
 }
 
-export function assertResultIsSuccessfulWithTimestamp(result: DeploymentResult, expectedTimestamp: Timestamp): void {
+export function assertResultIsSuccessfulWithTimestamp(result: DeploymentResult, expectedTimestamp: number): void {
   if (isSuccessfulDeployment(result)) {
     expect(result).toEqual(expectedTimestamp)
   } else {

--- a/content/test/integration/E2ETestUtils.ts
+++ b/content/test/integration/E2ETestUtils.ts
@@ -1,5 +1,5 @@
 import { DeploymentBuilder, DeploymentData } from 'dcl-catalyst-client'
-import { Entity as ControllerEntity, Entity, EntityType, EntityVersion, Pointer, Timestamp } from 'dcl-catalyst-commons'
+import { Entity as ControllerEntity, Entity, EntityType, EntityVersion } from 'dcl-catalyst-commons'
 import { Authenticator, EthAddress } from 'dcl-crypto'
 import EthCrypto from 'eth-crypto'
 import fs from 'fs'
@@ -15,8 +15,8 @@ import {
 } from '../../src/service/Service'
 
 export async function buildDeployDataAfterEntity(
-  afterEntity: { timestamp: Timestamp } | { entity: { timestamp: Timestamp } },
-  pointers: Pointer[],
+  afterEntity: { timestamp: number } | { entity: { timestamp: number } },
+  pointers: string[],
   options?: Exclude<DeploymentOptions, 'timestamp'>
 ): Promise<EntityCombo> {
   const after = 'timestamp' in afterEntity ? afterEntity.timestamp : afterEntity.entity.timestamp
@@ -25,7 +25,7 @@ export async function buildDeployDataAfterEntity(
   return buildDeployData(pointers, opts)
 }
 
-export async function buildDeployData(pointers: Pointer[], options?: DeploymentOptions): Promise<EntityCombo> {
+export async function buildDeployData(pointers: string[], options?: DeploymentOptions): Promise<EntityCombo> {
   const opts = Object.assign(
     {
       version: EntityVersion.V3,
@@ -145,7 +145,7 @@ export type Identity = {
 
 type DeploymentOptions = {
   type?: EntityType
-  timestamp?: Timestamp
+  timestamp?: number
   metadata?: any
   contentPaths?: string[]
   identity?: Identity

--- a/content/test/integration/Server.spec.ts
+++ b/content/test/integration/Server.spec.ts
@@ -2,7 +2,7 @@ import { Entity as ControllerEntity, Entity, EntityType } from 'dcl-catalyst-com
 import fetch from 'node-fetch'
 import { stub } from 'sinon'
 import { EnvironmentConfig } from '../../src/Environment'
-import { DeploymentWithAuthChain } from '../../src/logic/database-queries/snapshots-queries'
+import { DeploymentWithAuthChain } from '@dcl/schemas'
 import { SimpleContentItem } from '../../src/ports/contentStorage/contentStorage'
 import { Server } from '../../src/service/Server'
 import { randomEntity } from '../helpers/service/EntityTestFactory'

--- a/content/test/integration/TestProgram.ts
+++ b/content/test/integration/TestProgram.ts
@@ -6,11 +6,8 @@ import {
   ContentFileHash,
   Deployment,
   Entity as ControllerEntity,
-  EntityId,
   EntityType,
-  Pointer,
-  ServerStatus,
-  Timestamp
+  ServerStatus
 } from 'dcl-catalyst-commons'
 import fetch from 'node-fetch'
 import { EnvironmentConfig } from '../../src/Environment'
@@ -71,7 +68,7 @@ export class TestProgram {
     }
   }
 
-  async deploy(deployData: DeploymentData, fix: boolean = false): Promise<Timestamp> {
+  async deploy(deployData: DeploymentData, fix: boolean = false): Promise<number> {
     this.logger.info('Deploying entity ' + deployData.entityId)
     const returnValue = await this.client.deployEntity(deployData, fix)
     if (isInvalidDeployment(returnValue)) {
@@ -85,7 +82,7 @@ export class TestProgram {
     return this.makeRequest(`${this.getUrl()}/failed-deployments`)
   }
 
-  getEntitiesByPointers(type: EntityType, pointers: Pointer[]): Promise<ControllerEntity[]> {
+  getEntitiesByPointers(type: EntityType, pointers: string[]): Promise<ControllerEntity[]> {
     return this.client.fetchEntitiesByPointers(type, pointers)
   }
 
@@ -93,11 +90,11 @@ export class TestProgram {
     return this.client.fetchContentStatus()
   }
 
-  getEntitiesByIds(type: EntityType, ...ids: EntityId[]): Promise<ControllerEntity[]> {
+  getEntitiesByIds(type: EntityType, ...ids: string[]): Promise<ControllerEntity[]> {
     return this.client.fetchEntitiesByIds(type, ids)
   }
 
-  getEntityById(type: EntityType, id: EntityId): Promise<ControllerEntity> {
+  getEntityById(type: EntityType, id: string): Promise<ControllerEntity> {
     return this.client.fetchEntityById(type, id)
   }
 

--- a/content/test/integration/controller/active-entities.spec.ts
+++ b/content/test/integration/controller/active-entities.spec.ts
@@ -1,4 +1,4 @@
-import { Entity, EntityId, Pointer } from 'dcl-catalyst-commons'
+import { Entity } from 'dcl-catalyst-commons'
 import fetch from 'node-fetch'
 import { EnvironmentConfig } from '../../../src/Environment'
 import * as deployments from '../../../src/service/deployments/deployments'
@@ -8,16 +8,15 @@ import { buildDeployData } from '../E2ETestUtils'
 import { TestProgram } from '../TestProgram'
 
 loadStandaloneTestEnvironment()('Integration - Get Active Entities', (testEnv) => {
-
   it('when asking without params, it returns client error', async () => {
     const server = await testEnv.configServer().withConfig(EnvironmentConfig.DISABLE_SYNCHRONIZATION, true).andBuild()
     makeNoopValidator(server.components)
     await server.startProgram()
 
     const result = await fetch(server.getUrl() + `/entities/active`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' }
-      })
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' }
+    })
 
     expect(result.status).toBe(400)
   })
@@ -273,7 +272,7 @@ loadStandaloneTestEnvironment()('Integration - Get Active Entities', (testEnv) =
       expect(newEntityId).not.toBe('NOT_ACTIVE_ENTITY')
       expect(activeEntities.getCachedEntity('0,1')).toBe(newEntityId)
       expect(entityId).toBeDefined()
-      if(entityId) {
+      if (entityId) {
         const notActiveEntity = activeEntities.getCachedEntity(entityId)
         expect(notActiveEntity).toBe('NOT_ACTIVE_ENTITY')
       }
@@ -350,7 +349,6 @@ loadStandaloneTestEnvironment()('Integration - Get Active Entities', (testEnv) =
     })
   })
 
-
   describe('Urn Prefix', () => {
     it('when fetching entities with invalid chars urn prefix, then a client error is returned', async () => {
       const server = await testEnv.configServer().withConfig(EnvironmentConfig.DISABLE_SYNCHRONIZATION, true).andBuild()
@@ -358,8 +356,8 @@ loadStandaloneTestEnvironment()('Integration - Get Active Entities', (testEnv) =
       await server.startProgram()
 
       const response = await fetch(server.getUrl() + `/entities/active/collections/in!valid`, {
-          method: 'GET',
-          headers: { 'Content-Type': 'application/json' }
+        method: 'GET',
+        headers: { 'Content-Type': 'application/json' }
       })
 
       expect(response.status).toBe(400)
@@ -369,10 +367,14 @@ loadStandaloneTestEnvironment()('Integration - Get Active Entities', (testEnv) =
       makeNoopValidator(server.components)
       await server.startProgram()
 
-      const response = await fetch(server.getUrl() + `/entities/active/collections/urn:decentraland:ethereum:collections-v1:0x32b7495895264ac9d0b12d32afd435453458b1c6`, {
+      const response = await fetch(
+        server.getUrl() +
+          `/entities/active/collections/urn:decentraland:ethereum:collections-v1:0x32b7495895264ac9d0b12d32afd435453458b1c6`,
+        {
           method: 'GET',
           headers: { 'Content-Type': 'application/json' }
-      })
+        }
+      )
 
       expect(response.status).toBe(400)
     })
@@ -387,7 +389,10 @@ loadStandaloneTestEnvironment()('Integration - Get Active Entities', (testEnv) =
 
       // Deploy entity
       await server.deploy(deployResult.deployData)
-      const response = await fetchActiveEntityByUrnPrefix(server, 'urn:decentraland:mumbai:collections-thirdparty:aThirdParty:winterCollection:1')
+      const response = await fetchActiveEntityByUrnPrefix(
+        server,
+        'urn:decentraland:mumbai:collections-thirdparty:aThirdParty:winterCollection:1'
+      )
 
       expect(response).toBeDefined()
       expect(response.length).toBe(1)
@@ -405,14 +410,17 @@ loadStandaloneTestEnvironment()('Integration - Get Active Entities', (testEnv) =
 
       // Deploy entity
       await server.deploy(deployResult.deployData)
-      const response = await fetchActiveEntityByUrnPrefix(server, 'urn:decentraland:mumbai:collections-thirdparty:aThirdParty:winterCollection')
+      const response = await fetchActiveEntityByUrnPrefix(
+        server,
+        'urn:decentraland:mumbai:collections-thirdparty:aThirdParty:winterCollection'
+      )
 
       expect(response).toBeDefined()
       expect(response.length).toBe(1)
       expect(response[0].entityId).toBe(deployResult.controllerEntity.id)
       expect(response[0].pointer).toBe('urn:decentraland:mumbai:collections-thirdparty:athirdparty:wintercollection:1')
     })
-        it('when fetching entities by third party name, then matching entity is retrieved', async () => {
+    it('when fetching entities by third party name, then matching entity is retrieved', async () => {
       const server = await testEnv.configServer().withConfig(EnvironmentConfig.DISABLE_SYNCHRONIZATION, true).andBuild()
       makeNoopValidator(server.components)
       await server.startProgram()
@@ -423,7 +431,10 @@ loadStandaloneTestEnvironment()('Integration - Get Active Entities', (testEnv) =
 
       // Deploy entity
       await server.deploy(deployResult.deployData)
-      const response = await fetchActiveEntityByUrnPrefix(server, 'urn:decentraland:mumbai:collections-thirdparty:aThirdParty')
+      const response = await fetchActiveEntityByUrnPrefix(
+        server,
+        'urn:decentraland:mumbai:collections-thirdparty:aThirdParty'
+      )
 
       expect(response).toBeDefined()
       expect(response.length).toBe(1)
@@ -442,12 +453,14 @@ loadStandaloneTestEnvironment()('Integration - Get Active Entities', (testEnv) =
 
       // Deploy entity
       await server.deploy(deployResult.deployData)
-      const response = await fetchActiveEntityByUrnPrefix(server, 'urn:decentraland:mumbai:collections-thirdparty:aThirdParty:winterCollection')
+      const response = await fetchActiveEntityByUrnPrefix(
+        server,
+        'urn:decentraland:mumbai:collections-thirdparty:aThirdParty:winterCollection'
+      )
 
       expect(response).toBeDefined()
       expect(response.length).toBe(0)
     })
-
 
     it('when pointer is updated and getting by prefix, the new one is retrieved', async () => {
       const server = await testEnv.configServer().withConfig(EnvironmentConfig.DISABLE_SYNCHRONIZATION, true).andBuild()
@@ -466,15 +479,17 @@ loadStandaloneTestEnvironment()('Integration - Get Active Entities', (testEnv) =
       // Deploy entity
       await server.deploy(firstDeploy.deployData)
       await server.deploy(secondDeploy.deployData)
-      const response = await fetchActiveEntityByUrnPrefix(server, 'urn:decentraland:mumbai:collections-thirdparty:aThirdParty:winterCollection')
+      const response = await fetchActiveEntityByUrnPrefix(
+        server,
+        'urn:decentraland:mumbai:collections-thirdparty:aThirdParty:winterCollection'
+      )
 
       expect(response).toBeDefined()
       expect(response.length).toBe(1)
       expect(response[0].entityId).toBe(secondDeploy.controllerEntity.id)
       expect(response[0].pointer).toBe('urn:decentraland:mumbai:collections-thirdparty:athirdparty:wintercollection:1')
     })
-
-   })
+  })
 
   async function fetchActiveEntityByIds(server: TestProgram, ...ids: string[]): Promise<Entity[]> {
     return (
@@ -496,7 +511,10 @@ loadStandaloneTestEnvironment()('Integration - Get Active Entities', (testEnv) =
     ).json()
   }
 
-  async function fetchActiveEntityByUrnPrefix(server: TestProgram, collectionUrn: string): Promise<{ pointer: Pointer; entityId: EntityId }[]> {
+  async function fetchActiveEntityByUrnPrefix(
+    server: TestProgram,
+    collectionUrn: string
+  ): Promise<{ pointer: string; entityId: string }[]> {
     return (
       await fetch(`${server.getUrl()}/entities/active/collections/${collectionUrn}`, {
         method: 'GET',
@@ -504,5 +522,4 @@ loadStandaloneTestEnvironment()('Integration - Get Active Entities', (testEnv) =
       })
     ).json()
   }
-
 })

--- a/content/test/integration/controller/active-entity-by-content-hash.spec.ts
+++ b/content/test/integration/controller/active-entity-by-content-hash.spec.ts
@@ -1,4 +1,3 @@
-import { EntityId } from 'dcl-catalyst-commons'
 import fetch from 'node-fetch'
 import { EnvironmentConfig } from '../../../src/Environment'
 import { makeNoopValidator } from '../../helpers/service/validations/NoOpValidator'
@@ -50,7 +49,7 @@ loadStandaloneTestEnvironment()('Integration - Get Active Entities By Content Ha
     expect(result).toEqual([deployResult.entity.id, secondDeployResult.entity.id])
   })
 
-  async function fetchActiveEntity(server: TestProgram, contentHash: string): Promise<EntityId[]> {
+  async function fetchActiveEntity(server: TestProgram, contentHash: string): Promise<string[]> {
     const url = server.getUrl() + `/contents/${contentHash}/active-entities`
 
     return (await fetch(url)).json()

--- a/content/test/integration/controller/deployment-pagination.spec.ts
+++ b/content/test/integration/controller/deployment-pagination.spec.ts
@@ -1,5 +1,5 @@
 import { toQueryParams } from '@dcl/catalyst-node-commons'
-import { EntityType, fetchJson, SortingField, SortingOrder, Timestamp } from 'dcl-catalyst-commons'
+import { EntityType, fetchJson, SortingField, SortingOrder } from 'dcl-catalyst-commons'
 import { DeploymentField } from '../../../src/controller/Controller'
 import { EnvironmentConfig } from '../../../src/Environment'
 import { DeploymentOptions } from '../../../src/service/deployments/types'
@@ -220,13 +220,13 @@ loadStandaloneTestEnvironment()('Integration - Deployment Pagination', (testEnv)
     expect(pointerChanges.pagination.next).toContain(`lastId=${E2.entity.id}`)
   })
 
-  async function deploy(...entities: EntityCombo[]): Promise<Timestamp[]> {
-    const result: Timestamp[] = []
+  async function deploy(...entities: EntityCombo[]): Promise<number[]> {
+    const timestamps: number[] = []
     for (const { deployData } of entities) {
       const deploymentResult = await server.deploy(deployData)
-      result.push(deploymentResult)
+      timestamps.push(deploymentResult)
     }
-    return result
+    return timestamps
   }
 
   async function fetchDeployments(options: DeploymentOptions) {

--- a/content/test/integration/service/deployments/deployment-entity-overlap.spec.ts
+++ b/content/test/integration/service/deployments/deployment-entity-overlap.spec.ts
@@ -1,120 +1,119 @@
-import { AuditInfo, EntityType, EntityVersion, Timestamp } from "dcl-catalyst-commons";
+import { AuditInfo, EntityType, EntityVersion } from 'dcl-catalyst-commons'
+import { stub } from 'sinon'
 import {
   DeploymentContext,
   DeploymentResult,
   isInvalidDeployment,
   isSuccessfulDeployment
-} from "../../../../src/service/Service";
-import { AppComponents } from "../../../../src/types";
-import { makeNoopServerValidator, makeNoopValidator } from "../../../helpers/service/validations/NoOpValidator";
-import { loadStandaloneTestEnvironment, testCaseWithComponents } from "../../E2ETestEnvironment";
-import { buildDeployData, buildDeployDataAfterEntity, createIdentity, EntityCombo, Identity } from "../../E2ETestUtils";
-import { stub } from "sinon";
+} from '../../../../src/service/Service'
+import { AppComponents } from '../../../../src/types'
+import { makeNoopServerValidator, makeNoopValidator } from '../../../helpers/service/validations/NoOpValidator'
+import { loadStandaloneTestEnvironment, testCaseWithComponents } from '../../E2ETestEnvironment'
+import { buildDeployData, buildDeployDataAfterEntity, createIdentity, EntityCombo, Identity } from '../../E2ETestUtils'
 
 /**
  * This test verifies some scenarios that could happen during scene deployments.
  */
-loadStandaloneTestEnvironment()("Integration - Deployment with Entity Overlaps", (testEnv) => {
-  const P1 = "0,0";
-  const P2 = "0,1";
-  const P3 = "1,1";
-  let identity: Identity;
-  let E1: EntityCombo, E2: EntityCombo;
+loadStandaloneTestEnvironment()('Integration - Deployment with Entity Overlaps', (testEnv) => {
+  const P1 = '0,0'
+  const P2 = '0,1'
+  const P3 = '1,1'
+  let identity: Identity
+  let E1: EntityCombo, E2: EntityCombo
 
   beforeEach(async () => {
-    identity = createIdentity();
+    identity = createIdentity()
     E1 = await buildDeployData([P1, P2], {
       type: EntityType.SCENE,
       metadata: {
-        main: "main.js",
+        main: 'main.js',
         scene: {
           base: P1,
           parcels: [P1, P2]
         }
       },
       identity
-    });
-  });
+    })
+  })
 
   testCaseWithComponents(
     testEnv,
-    "When new scene is deployed on overlapping parcels, then new deployment removes previous scenes from orphaned parcels",
+    'When new scene is deployed on overlapping parcels, then new deployment removes previous scenes from orphaned parcels',
     async (components) => {
       // make validators stub
-      makeNoopValidator(components);
-      makeNoopServerValidator(components);
+      makeNoopValidator(components)
+      makeNoopServerValidator(components)
 
       E2 = await buildDeployDataAfterEntity(E1, [P2], {
         type: EntityType.SCENE,
         metadata: {
-          main: "main.js",
+          main: 'main.js',
           scene: {
             base: P2,
             parcels: [P2]
           }
         },
         identity
-      });
+      })
 
       // Deploy E1 on P1, P2
-      await deploy(components, E1);
-      await assertDeploymentsAre(components, E1);
+      await deploy(components, E1)
+      await assertDeploymentsAre(components, E1)
 
       // Deploy E2 on P2
-      await deploy(components, E2);
-      await assertDeploymentsAre(components, E2); // E1 should no longer be active
+      await deploy(components, E2)
+      await assertDeploymentsAre(components, E2) // E1 should no longer be active
     }
-  );
+  )
 
-  testCaseWithComponents(
-    testEnv,
-    "When scene is deployed, then server checks for permissions",
-    async (components) => {
-      // make validators stub
-      stub(components.validator, "validate")
-        .onFirstCall()
-        .resolves({ ok: true })
-        .onSecondCall()
-        .resolves({
-          ok: false, errors: [
-            `The provided Eth Address does not have access to the following parcel: (${P1})`,
-            `The provided Eth Address does not have access to the following parcel: (${P2})`
-          ]
-        });
-      makeNoopServerValidator(components);
+  testCaseWithComponents(testEnv, 'When scene is deployed, then server checks for permissions', async (components) => {
+    // make validators stub
+    stub(components.validator, 'validate')
+      .onFirstCall()
+      .resolves({ ok: true })
+      .onSecondCall()
+      .resolves({
+        ok: false,
+        errors: [
+          `The provided Eth Address does not have access to the following parcel: (${P1})`,
+          `The provided Eth Address does not have access to the following parcel: (${P2})`
+        ]
+      })
+    makeNoopServerValidator(components)
 
-      E2 = await buildDeployDataAfterEntity(E1, [P1, P2], {
-        type: EntityType.SCENE,
-        metadata: {
-          main: "main.js",
-          scene: {
-            base: P1,
-            parcels: [P1, P2]
-          }
+    E2 = await buildDeployDataAfterEntity(E1, [P1, P2], {
+      type: EntityType.SCENE,
+      metadata: {
+        main: 'main.js',
+        scene: {
+          base: P1,
+          parcels: [P1, P2]
         }
-      });
+      }
+    })
 
-      // Deploy E1 on P1, P2
-      await deploy(components, E1);
-      await assertDeploymentsAre(components, E1);
+    // Deploy E1 on P1, P2
+    await deploy(components, E1)
+    await assertDeploymentsAre(components, E1)
 
-      // Deploy E2 on P1
-      await expect(deploy(components, E2)).rejects.toThrow('The provided Eth Address does not have access to the following parcel: (0,0),The provided Eth Address does not have access to the following parcel: (0,1)');
-      await assertDeploymentsAre(components, E1); // E2 should have not been deployed
-    }
-  );
+    // Deploy E2 on P1
+    await expect(deploy(components, E2)).rejects.toThrow(
+      'The provided Eth Address does not have access to the following parcel: (0,0),The provided Eth Address does not have access to the following parcel: (0,1)'
+    )
+    await assertDeploymentsAre(components, E1) // E2 should have not been deployed
+  })
 
   testCaseWithComponents(
     testEnv,
-    "When parcel changes owner, then new deployment by new owner succeeds and removes previous scenes from orphaned parcels",
+    'When parcel changes owner, then new deployment by new owner succeeds and removes previous scenes from orphaned parcels',
     async (components) => {
       // make noop server validator
-      makeNoopValidator(components);
-      makeNoopServerValidator(components);
+      makeNoopValidator(components)
+      makeNoopServerValidator(components)
 
       // Deploy E1 on P1, P2
-      await deploy(components, E1);
-      await assertDeploymentsAre(components, E1);
+      await deploy(components, E1)
+      await assertDeploymentsAre(components, E1)
 
       // Change ownership of P2
       // Nothing to do really, as the mock above already allows the new deployment
@@ -123,55 +122,52 @@ loadStandaloneTestEnvironment()("Integration - Deployment with Entity Overlaps",
       E2 = await buildDeployDataAfterEntity(E1, [P2, P3], {
         type: EntityType.SCENE,
         metadata: {
-          main: "main.js",
+          main: 'main.js',
           scene: {
             base: P2,
             parcels: [P2, P3]
           }
-        },
-      });
+        }
+      })
 
-      await deploy(components, E2);
-      await assertDeploymentsAre(components, E2); // E1 should have no scenes now
+      await deploy(components, E2)
+      await assertDeploymentsAre(components, E2) // E1 should have no scenes now
     }
-  );
+  )
 
-  async function assertDeploymentsAre(
-    components: Pick<AppComponents, "deployer">,
-    ...expectedEntities: EntityCombo[]
-  ) {
-    const actualDeployments = await components.deployer.getDeployments({ filters: {onlyCurrentlyPointed: true}});
-    const expectedEntityIds = expectedEntities.map((entityCombo) => entityCombo.entity.id).sort();
-    const actualEntityIds = actualDeployments.deployments.map(({ entityId }) => entityId).sort();
-    expect({ deployedEntityIds: actualEntityIds }).toEqual({ deployedEntityIds: expectedEntityIds });
+  async function assertDeploymentsAre(components: Pick<AppComponents, 'deployer'>, ...expectedEntities: EntityCombo[]) {
+    const actualDeployments = await components.deployer.getDeployments({ filters: { onlyCurrentlyPointed: true } })
+    const expectedEntityIds = expectedEntities.map((entityCombo) => entityCombo.entity.id).sort()
+    const actualEntityIds = actualDeployments.deployments.map(({ entityId }) => entityId).sort()
+    expect({ deployedEntityIds: actualEntityIds }).toEqual({ deployedEntityIds: expectedEntityIds })
   }
 
-  async function deploy(components: Pick<AppComponents, "deployer">, ...entities: EntityCombo[]): Promise<Timestamp[]> {
-    return deployWithAuditInfo(components, entities, {});
+  async function deploy(components: Pick<AppComponents, 'deployer'>, ...entities: EntityCombo[]): Promise<Timestamp[]> {
+    return deployWithAuditInfo(components, entities, {})
   }
 
   async function deployWithAuditInfo(
-    components: Pick<AppComponents, "deployer">,
+    components: Pick<AppComponents, 'deployer'>,
     entities: EntityCombo[],
     overrideAuditInfo?: Partial<AuditInfo>
   ) {
-    const result: Timestamp[] = [];
+    const timestamps: number[] = []
     for (const { deployData } of entities) {
-      const newAuditInfo = { version: EntityVersion.V3, authChain: deployData.authChain, ...overrideAuditInfo };
+      const newAuditInfo = { version: EntityVersion.V3, authChain: deployData.authChain, ...overrideAuditInfo }
       const deploymentResult: DeploymentResult = await components.deployer.deployEntity(
         Array.from(deployData.files.values()),
         deployData.entityId,
         newAuditInfo,
         DeploymentContext.LOCAL
-      );
+      )
       if (isSuccessfulDeployment(deploymentResult)) {
-        result.push(deploymentResult);
+        timestamps.push(deploymentResult)
       } else if (isInvalidDeployment(deploymentResult)) {
-        throw new Error(deploymentResult.errors.join(","));
+        throw new Error(deploymentResult.errors.join(','))
       } else {
-        throw new Error("deployEntity returned invalid result" + JSON.stringify(deploymentResult));
+        throw new Error('deployEntity returned invalid result' + JSON.stringify(deploymentResult))
       }
     }
-    return result;
+    return timestamps
   }
-});
+})

--- a/content/test/integration/service/deployments/deployment-filters.spec.ts
+++ b/content/test/integration/service/deployments/deployment-filters.spec.ts
@@ -1,5 +1,10 @@
-import { AuditInfo, DeploymentFilters, EntityType, EntityVersion, Timestamp } from 'dcl-catalyst-commons'
-import { DeploymentContext, DeploymentResult, isInvalidDeployment, isSuccessfulDeployment } from '../../../../src/service/Service'
+import { AuditInfo, DeploymentFilters, EntityType, EntityVersion } from 'dcl-catalyst-commons'
+import {
+  DeploymentContext,
+  DeploymentResult,
+  isInvalidDeployment,
+  isSuccessfulDeployment
+} from '../../../../src/service/Service'
 import { AppComponents } from '../../../../src/types'
 import { makeNoopServerValidator, makeNoopValidator } from '../../../helpers/service/validations/NoOpValidator'
 import { loadStandaloneTestEnvironment, testCaseWithComponents } from '../../E2ETestEnvironment'
@@ -124,7 +129,7 @@ loadStandaloneTestEnvironment()('Integration - Deployment Filters', (testEnv) =>
     expect({ filter, deployedEntityIds: actualEntityIds }).toEqual({ filter, deployedEntityIds: expectedEntityIds })
   }
 
-  async function deploy(components: Pick<AppComponents, 'deployer'>, ...entities: EntityCombo[]): Promise<Timestamp[]> {
+  async function deploy(components: Pick<AppComponents, 'deployer'>, ...entities: EntityCombo[]): Promise<number[]> {
     return deployWithAuditInfo(components, entities, {})
   }
 
@@ -133,7 +138,7 @@ loadStandaloneTestEnvironment()('Integration - Deployment Filters', (testEnv) =>
     entities: EntityCombo[],
     overrideAuditInfo?: Partial<AuditInfo>
   ) {
-    const result: Timestamp[] = []
+    const timestamps: number[] = []
     for (const { deployData } of entities) {
       const newAuditInfo = { version: EntityVersion.V3, authChain: deployData.authChain, ...overrideAuditInfo }
       const deploymentResult: DeploymentResult = await components.deployer.deployEntity(
@@ -143,13 +148,13 @@ loadStandaloneTestEnvironment()('Integration - Deployment Filters', (testEnv) =>
         DeploymentContext.LOCAL
       )
       if (isSuccessfulDeployment(deploymentResult)) {
-        result.push(deploymentResult)
+        timestamps.push(deploymentResult)
       } else if (isInvalidDeployment(deploymentResult)) {
         throw new Error(deploymentResult.errors.join(','))
       } else {
         throw new Error('deployEntity returned invalid result' + JSON.stringify(deploymentResult))
       }
     }
-    return result
+    return timestamps
   }
 })

--- a/content/test/integration/service/snapshots/SnapshotManager.spec.ts
+++ b/content/test/integration/service/snapshots/SnapshotManager.spec.ts
@@ -1,5 +1,5 @@
 import { processDeploymentsInStream } from '@dcl/snapshots-fetcher/dist/file-processor'
-import { EntityId, EntityType, Pointer } from 'dcl-catalyst-commons'
+import { EntityType } from 'dcl-catalyst-commons'
 import { inspect } from 'util'
 import { EnvironmentBuilder } from '../../../../src/Environment'
 import { stopAllComponents } from '../../../../src/logic/components-lifecycle'
@@ -116,22 +116,22 @@ loadStandaloneTestEnvironment()('Integration - Snapshot Manager', (testEnv) => {
     const { hash } = snapshotMetadata!
     const content: ContentItem = (await components.storage.retrieve(hash))!
 
-    const snapshot: Map<EntityId, Pointer[]> = new Map()
+    const entityToPointersSnapshot: Map<string, string[]> = new Map()
 
     const readStream = await content.asStream()
 
     for await (const deployment of processDeploymentsInStream(readStream)) {
-      snapshot.set(deployment.entityId, (deployment as any).pointers)
+      entityToPointersSnapshot.set(deployment.entityId, (deployment as any).pointers)
     }
 
     try {
-      expect(snapshot.size).toBe(entitiesCombo.length)
+      expect(entityToPointersSnapshot.size).toBe(entitiesCombo.length)
 
       for (const { entity } of entitiesCombo) {
-        expect(snapshot.get(entity.id)).toEqual(entity.pointers)
+        expect(entityToPointersSnapshot.get(entity.id)).toEqual(entity.pointers)
       }
     } catch (e) {
-      process.stderr.write(inspect({ hash, content, snapshot }) + '\n')
+      process.stderr.write(inspect({ hash, content, snapshot: entityToPointersSnapshot }) + '\n')
       throw e
     }
   }

--- a/content/test/integration/syncronization/cluster-synchronization.spec.ts
+++ b/content/test/integration/syncronization/cluster-synchronization.spec.ts
@@ -1,4 +1,3 @@
-import { Timestamp } from 'dcl-catalyst-commons'
 import ms from 'ms'
 import { makeNoopValidator } from '../../helpers/service/validations/NoOpValidator'
 import {
@@ -40,7 +39,7 @@ loadTestEnvironment()('End 2 end synchronization tests', function (testEnv) {
     await assertDeploymentsAreReported(server2)
 
     // Deploy the entity to server 1
-    const deploymentTimestamp: Timestamp = await server1.deploy(deployData)
+    const deploymentTimestamp = await server1.deploy(deployData)
     const deployment = buildDeployment(deployData, entityBeingDeployed, deploymentTimestamp)
 
     // Assert that the entity was deployed on server 1
@@ -117,7 +116,7 @@ loadTestEnvironment()('End 2 end synchronization tests', function (testEnv) {
     )
 
     // Deploy entity 2
-    const deploymentTimestamp2: Timestamp = await server2.deploy(deployData2)
+    const deploymentTimestamp2 = await server2.deploy(deployData2)
     const deployment2 = buildDeployment(deployData2, entity2, deploymentTimestamp2)
     await awaitUntil(() => assertDeploymentsAreReported(server2, deployment2))
 
@@ -129,10 +128,10 @@ loadTestEnvironment()('End 2 end synchronization tests', function (testEnv) {
     await Promise.all([server1.startProgram(), server3.startProgram()])
 
     // Deploy entities 1 and 3
-    const deploymentTimestamp1: Timestamp = await server1.deploy(deployData1)
+    const deploymentTimestamp1 = await server1.deploy(deployData1)
     const deployment1 = buildDeployment(deployData1, entity1, deploymentTimestamp1)
 
-    const deploymentTimestamp3: Timestamp = await server3.deploy(deployData3)
+    const deploymentTimestamp3 = await server3.deploy(deployData3)
     const deployment3 = buildDeployment(deployData3, entity3, deploymentTimestamp3)
 
     // Wait for servers 1 and 3 to sync

--- a/content/test/integration/syncronization/error-handling.spec.ts
+++ b/content/test/integration/syncronization/error-handling.spec.ts
@@ -1,4 +1,4 @@
-import { Entity as ControllerEntity, Timestamp } from 'dcl-catalyst-commons'
+import { Entity as ControllerEntity } from 'dcl-catalyst-commons'
 import ms from 'ms'
 import { EnvironmentConfig } from '../../../src/Environment'
 import { FailedDeployment, FailureReason } from '../../../src/ports/failedDeploymentsCache'
@@ -138,7 +138,7 @@ loadTestEnvironment()('End 2 end - Error handling', (testEnv) => {
     })
 
     // Deploy the entity
-    const deploymentTimestamp: Timestamp = await server1.deploy(deployData)
+    const deploymentTimestamp = await server1.deploy(deployData)
 
     // Cause failure
     await causeOfFailure(entityBeingDeployed)

--- a/content/test/integration/syncronization/node-onboarding.spec.ts
+++ b/content/test/integration/syncronization/node-onboarding.spec.ts
@@ -1,4 +1,3 @@
-import { ContentFileHash, Timestamp } from 'dcl-catalyst-commons'
 import { makeNoopValidator } from '../../helpers/service/validations/NoOpValidator'
 import {
   assertDeploymentsAreReported,
@@ -32,7 +31,7 @@ loadTestEnvironment()('End 2 end - Node onboarding', function (testEnv) {
       metadata: 'metadata',
       contentPaths: ['test/integration/resources/some-binary-file.png']
     })
-    const entity1ContentHash: ContentFileHash = entity1.content![0].hash
+    const entity1ContentHash = entity1.content![0].hash
     const { deployData: deployData2, controllerEntity: entity2 } = await buildDeployDataAfterEntity(
       entity1,
       ['X2,Y2'],
@@ -40,11 +39,11 @@ loadTestEnvironment()('End 2 end - Node onboarding', function (testEnv) {
     )
 
     // Deploy entity1 on server 1
-    const deploymentTimestamp1: Timestamp = await server1.deploy(deployData1)
+    const deploymentTimestamp1 = await server1.deploy(deployData1)
     const deployment1 = buildDeployment(deployData1, entity1, deploymentTimestamp1)
 
     // Deploy entity2 on server 2
-    const deploymentTimestamp2: Timestamp = await server2.deploy(deployData2)
+    const deploymentTimestamp2 = await server2.deploy(deployData2)
     const deployment2 = buildDeployment(deployData2, entity2, deploymentTimestamp2)
 
     // Wait for servers to sync and assert servers 1 and 2 are synced
@@ -73,10 +72,10 @@ loadTestEnvironment()('End 2 end - Node onboarding', function (testEnv) {
       metadata: 'metadata',
       contentPaths: ['test/integration/resources/some-binary-file.png']
     })
-    const entityContentHash: ContentFileHash = entity.content![0].hash
+    const entityContentHash = entity.content![0].hash
 
     // Deploy entity on server 1
-    const deploymentTimestamp: Timestamp = await server1.deploy(deployData)
+    const deploymentTimestamp = await server1.deploy(deployData)
     const deployment = buildDeployment(deployData, entity, deploymentTimestamp)
 
     // Wait for sync and assert servers 1 and 2 are synced

--- a/content/test/unit/service/EntityFactory.spec.ts
+++ b/content/test/unit/service/EntityFactory.spec.ts
@@ -1,4 +1,4 @@
-import { Entity, EntityId, EntityType } from 'dcl-catalyst-commons'
+import { Entity, EntityType } from 'dcl-catalyst-commons'
 import { EntityFactory } from '../../../src/service/EntityFactory'
 import { buildEntityAndFile, entityToFile } from '../../helpers/service/EntityTestFactory'
 
@@ -100,7 +100,7 @@ describe('Service', () => {
     assertInvalidFile(entityToFile(invalidEntity), invalidEntity.id, errorMessage)
   }
 
-  function assertInvalidFile(file: Buffer, entityId: EntityId, errorMessage: string) {
+  function assertInvalidFile(file: Buffer, entityId: string, errorMessage: string) {
     expect(() => {
       EntityFactory.fromBufferWithId(file, entityId)
     }).toThrowError(errorMessage)

--- a/yarn.lock
+++ b/yarn.lock
@@ -393,6 +393,13 @@
   dependencies:
     ajv "^7.1.0"
 
+"@dcl/schemas@^4.10.0":
+  version "4.10.0"
+  resolved "https://registry.yarnpkg.com/@dcl/schemas/-/schemas-4.10.0.tgz#3ad977e6bc27d30ab37413350a20ada1dcacf7c8"
+  integrity sha512-B5ts0h8kFbx9sijEq79HBF16D8iiysDP25mFkV3eQJ+Fb+y5Ohk0W5NAsW4vNIW49f6vXQlCwRnJQ5iGFdQWGg==
+  dependencies:
+    ajv "^7.1.0"
+
 "@dcl/snapshots-fetcher@3.0.2":
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@dcl/snapshots-fetcher/-/snapshots-fetcher-3.0.2.tgz#a8cc70481b775b1f4cb5e254dc0167a80a98c5b7"


### PR DESCRIPTION
This PR makes two changes

- Use of common-schemas for DeploymentsWithAuthChain since it became a critical part of a couple of services
- Starts removing dependencies with dcl-catalyst-commons to start its deprecation process