### PR TITLE
chore: bump gh-release-action to fix dependabot commits issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions: write-all
     steps:
-      - uses: decentraland/gh-action-release@0.2.1
+      - uses: decentraland/gh-action-release@0.2.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           dry_run: ${{ github.event.inputs.dry_run }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions: write-all
     steps:
-      - uses: decentraland/gh-action-release@0.2.0
+      - uses: decentraland/gh-action-release@0.2.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           dry_run: ${{ github.event.inputs.dry_run }}


### PR DESCRIPTION
## Description

gh-action-release@0.2.2 includes:
- Add the parenthesis to the regex for the commit message
- Add the multiline option to the regex

Closes #1101 