### PR TITLE
fix: return 400 instead of 500 when invalid urn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ linked-peer-package
 storage_*/**
 storage/**
 serverStorage.json
+.vscode

--- a/content/src/controller/Controller.ts
+++ b/content/src/controller/Controller.ts
@@ -726,19 +726,23 @@ async function isUrnPrefixValid(collectionUrn: string): Promise<string | false> 
   const regex = /^[a-zA-Z0-9_.:,-]+$/g
   if (!regex.test(collectionUrn)) return false
 
-  const parsedUrn: DecentralandAssetIdentifier | null = await parseUrn(collectionUrn)
+  try {
+    const parsedUrn: DecentralandAssetIdentifier | null = await parseUrn(collectionUrn)
 
-  if (parseUrn === null) return false
+    if (parsedUrn === null) return false
 
-  // We want to reduce the matches of the query,
-  // so we enforce to write the full name of the third party or collection for the search
-  if (
-    parsedUrn?.type === 'blockchain-collection-third-party-name' ||
-    parsedUrn?.type === 'blockchain-collection-third-party-collection'
-  ) {
-    return `${collectionUrn}:`
+    // We want to reduce the matches of the query,
+    // so we enforce to write the full name of the third party or collection for the search
+    if (
+      parsedUrn?.type === 'blockchain-collection-third-party-name' ||
+      parsedUrn?.type === 'blockchain-collection-third-party-collection'
+    ) {
+      return `${collectionUrn}:`
+    }
+
+    if (parsedUrn?.type === 'blockchain-collection-third-party') return collectionUrn
+  } catch (error) {
+    console.error(error)
   }
-  if (parsedUrn?.type === 'blockchain-collection-third-party') return collectionUrn
-
   return false
 }


### PR DESCRIPTION
## Description

A `500` error is being returned when calling `/content/entities/active/collections/{collectionUrn}` with a collection urn that is invalid.

Fixes #1048 

## Changes

- Catch the `500` error retrieved from `parseUrn`
- Print it
- Let the previous method get the invalid result and return a `400`

