### PR TITLE
fix: support pagination over result sets larger than 5000 records

### DIFF
--- a/lambdas/src/utils/TheGraphClient.ts
+++ b/lambdas/src/utils/TheGraphClient.ts
@@ -333,7 +333,7 @@ export class TheGraphClient {
         })}`
       )
       const queried = await this.runQuery(query, { ...variables, first: TheGraphClient.MAX_PAGE_SIZE, skip: offset })
-      console.log(`result ${JSON.stringify(result).substring(0, 2000)}`)
+      console.log(`result ${JSON.stringify(result)}`)
       if (!result) {
         result = queried
       } else {

--- a/lambdas/src/utils/TheGraphClient.ts
+++ b/lambdas/src/utils/TheGraphClient.ts
@@ -325,6 +325,7 @@ export class TheGraphClient {
     let shouldContinue = true
     let offset = 0
     while (shouldContinue) {
+      console.log(`about to query: ${query.description}, query: ${query.query}, variables: ${variables}`)
       const queried = await this.runQuery(query, { ...variables, first: TheGraphClient.MAX_PAGE_SIZE, skip: offset })
       if (!result) {
         result = queried
@@ -333,6 +334,7 @@ export class TheGraphClient {
       }
       shouldContinue = queried.length === TheGraphClient.MAX_PAGE_SIZE
       offset += TheGraphClient.MAX_PAGE_SIZE
+      console.log(`shouldContinue: ${shouldContinue}, offset: ${offset}`)
     }
     return result!
   }

--- a/lambdas/src/utils/TheGraphClient.ts
+++ b/lambdas/src/utils/TheGraphClient.ts
@@ -332,8 +332,8 @@ export class TheGraphClient {
       } else {
         result.push(...queried)
       }
-      shouldContinue = queried.length === TheGraphClient.MAX_PAGE_SIZE
-      start = queried[queried.length - 1].id
+      start = queried[queried.length - 1]?.id
+      shouldContinue = queried.length === TheGraphClient.MAX_PAGE_SIZE && !!start
     }
     return result!
   }

--- a/lambdas/src/utils/TheGraphClient.ts
+++ b/lambdas/src/utils/TheGraphClient.ts
@@ -341,7 +341,9 @@ export class TheGraphClient {
       }
       shouldContinue = queried.length === TheGraphClient.MAX_PAGE_SIZE
       offset += TheGraphClient.MAX_PAGE_SIZE
-      console.log(`shouldContinue: ${shouldContinue}, offset: ${offset}, so far: ${result.length}`)
+      console.log(
+        `shouldContinue: ${shouldContinue}, offset: ${offset}, this query: ${queried.length} so far: ${result.length}`
+      )
     }
     return result!
   }

--- a/lambdas/src/utils/TheGraphClient.ts
+++ b/lambdas/src/utils/TheGraphClient.ts
@@ -339,7 +339,7 @@ export class TheGraphClient {
       } else {
         result.push(...queried)
       }
-      shouldContinue = queried.length === TheGraphClient.MAX_PAGE_SIZE
+      shouldContinue = queried.length === TheGraphClient.MAX_PAGE_SIZE && offset <= 5000
       offset += TheGraphClient.MAX_PAGE_SIZE
       console.log(
         `shouldContinue: ${shouldContinue}, offset: ${offset}, this query: ${queried.length} so far: ${result.length}`

--- a/lambdas/src/utils/TheGraphClient.ts
+++ b/lambdas/src/utils/TheGraphClient.ts
@@ -340,7 +340,7 @@ export class TheGraphClient {
         result.push(...queried)
       }
       shouldContinue = queried.length === TheGraphClient.MAX_PAGE_SIZE
-      start = queried[queried.length - 1].urn
+      start = result[result.length - 1].id
       console.log(
         `shouldContinue: ${shouldContinue}, start: ${start}, this query: ${queried.length} so far: ${result.length}`
       )

--- a/lambdas/src/utils/TheGraphClient.ts
+++ b/lambdas/src/utils/TheGraphClient.ts
@@ -326,15 +326,7 @@ export class TheGraphClient {
     let shouldContinue = true
     let start = ''
     while (shouldContinue) {
-      console.log(
-        `about to query: ${query.description}, query: ${query.query}, variables: ${JSON.stringify({
-          ...variables,
-          first: TheGraphClient.MAX_PAGE_SIZE,
-          start: start
-        })}`
-      )
       const queried = await this.runQuery(query, { ...variables, first: TheGraphClient.MAX_PAGE_SIZE, start: start })
-      console.log(`queried ${JSON.stringify(queried)}`)
       if (!result) {
         result = queried
       } else {
@@ -342,11 +334,7 @@ export class TheGraphClient {
       }
       shouldContinue = queried.length === TheGraphClient.MAX_PAGE_SIZE
       start = queried[queried.length - 1].id
-      console.log(
-        `shouldContinue: ${shouldContinue}, start: ${start}, this query: ${queried.length} so far: ${result.length}`
-      )
     }
-    console.log(`total ${result?.length}`)
     return result!
   }
 

--- a/lambdas/src/utils/TheGraphClient.ts
+++ b/lambdas/src/utils/TheGraphClient.ts
@@ -333,13 +333,13 @@ export class TheGraphClient {
         })}`
       )
       const queried = await this.runQuery(query, { ...variables, first: TheGraphClient.MAX_PAGE_SIZE, skip: offset })
-      console.log(`result ${JSON.stringify(result)}`)
+      console.log(`result ${JSON.stringify(result).substring(0, 2000)}`)
       if (!result) {
         result = queried
       } else {
         result.push(...queried)
       }
-      shouldContinue = queried.length === TheGraphClient.MAX_PAGE_SIZE && offset <= 5000
+      shouldContinue = queried.length === TheGraphClient.MAX_PAGE_SIZE && offset < 5000
       offset += TheGraphClient.MAX_PAGE_SIZE
       console.log(
         `shouldContinue: ${shouldContinue}, offset: ${offset}, this query: ${queried.length} so far: ${result.length}`

--- a/lambdas/src/utils/TheGraphClient.ts
+++ b/lambdas/src/utils/TheGraphClient.ts
@@ -325,7 +325,9 @@ export class TheGraphClient {
     let shouldContinue = true
     let offset = 0
     while (shouldContinue) {
-      console.log(`about to query: ${query.description}, query: ${query.query}, variables: ${variables}`)
+      console.log(
+        `about to query: ${query.description}, query: ${query.query}, variables: ${JSON.stringify(variables)}`
+      )
       const queried = await this.runQuery(query, { ...variables, first: TheGraphClient.MAX_PAGE_SIZE, skip: offset })
       if (!result) {
         result = queried
@@ -334,7 +336,7 @@ export class TheGraphClient {
       }
       shouldContinue = queried.length === TheGraphClient.MAX_PAGE_SIZE
       offset += TheGraphClient.MAX_PAGE_SIZE
-      console.log(`shouldContinue: ${shouldContinue}, offset: ${offset}`)
+      console.log(`shouldContinue: ${shouldContinue}, offset: ${offset}, so far: ${result.length}`)
     }
     return result!
   }

--- a/lambdas/src/utils/TheGraphClient.ts
+++ b/lambdas/src/utils/TheGraphClient.ts
@@ -326,9 +326,14 @@ export class TheGraphClient {
     let offset = 0
     while (shouldContinue) {
       console.log(
-        `about to query: ${query.description}, query: ${query.query}, variables: ${JSON.stringify(variables)}`
+        `about to query: ${query.description}, query: ${query.query}, variables: ${JSON.stringify({
+          ...variables,
+          first: TheGraphClient.MAX_PAGE_SIZE,
+          skip: offset
+        })}`
       )
       const queried = await this.runQuery(query, { ...variables, first: TheGraphClient.MAX_PAGE_SIZE, skip: offset })
+      console.log(`result ${JSON.stringify(result)}`)
       if (!result) {
         result = queried
       } else {

--- a/lambdas/test/__fixtures__/wearables-by-owner-matic-p1.json
+++ b/lambdas/test/__fixtures__/wearables-by-owner-matic-p1.json
@@ -1,0 +1,7004 @@
+{
+  "nfts": [
+    {
+      "id": "0x0031117212a5849c87efc4fc32b91ba6a02fdbc0-12",
+      "urn": "urn:decentraland:matic:collections-v2:0x0031117212a5849c87efc4fc32b91ba6a02fdbc0:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x0031117212a5849c87efc4fc32b91ba6a02fdbc0-15",
+      "urn": "urn:decentraland:matic:collections-v2:0x0031117212a5849c87efc4fc32b91ba6a02fdbc0:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x0031117212a5849c87efc4fc32b91ba6a02fdbc0-324",
+      "urn": "urn:decentraland:matic:collections-v2:0x0031117212a5849c87efc4fc32b91ba6a02fdbc0:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x0031117212a5849c87efc4fc32b91ba6a02fdbc0-325",
+      "urn": "urn:decentraland:matic:collections-v2:0x0031117212a5849c87efc4fc32b91ba6a02fdbc0:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x0031117212a5849c87efc4fc32b91ba6a02fdbc0-326",
+      "urn": "urn:decentraland:matic:collections-v2:0x0031117212a5849c87efc4fc32b91ba6a02fdbc0:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x0031117212a5849c87efc4fc32b91ba6a02fdbc0-327",
+      "urn": "urn:decentraland:matic:collections-v2:0x0031117212a5849c87efc4fc32b91ba6a02fdbc0:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x0031117212a5849c87efc4fc32b91ba6a02fdbc0-328",
+      "urn": "urn:decentraland:matic:collections-v2:0x0031117212a5849c87efc4fc32b91ba6a02fdbc0:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x0031117212a5849c87efc4fc32b91ba6a02fdbc0-329",
+      "urn": "urn:decentraland:matic:collections-v2:0x0031117212a5849c87efc4fc32b91ba6a02fdbc0:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x0031117212a5849c87efc4fc32b91ba6a02fdbc0-330",
+      "urn": "urn:decentraland:matic:collections-v2:0x0031117212a5849c87efc4fc32b91ba6a02fdbc0:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x0031117212a5849c87efc4fc32b91ba6a02fdbc0-332",
+      "urn": "urn:decentraland:matic:collections-v2:0x0031117212a5849c87efc4fc32b91ba6a02fdbc0:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x0031117212a5849c87efc4fc32b91ba6a02fdbc0-333",
+      "urn": "urn:decentraland:matic:collections-v2:0x0031117212a5849c87efc4fc32b91ba6a02fdbc0:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x0031117212a5849c87efc4fc32b91ba6a02fdbc0-334",
+      "urn": "urn:decentraland:matic:collections-v2:0x0031117212a5849c87efc4fc32b91ba6a02fdbc0:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x0031117212a5849c87efc4fc32b91ba6a02fdbc0-335",
+      "urn": "urn:decentraland:matic:collections-v2:0x0031117212a5849c87efc4fc32b91ba6a02fdbc0:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x0031117212a5849c87efc4fc32b91ba6a02fdbc0-338",
+      "urn": "urn:decentraland:matic:collections-v2:0x0031117212a5849c87efc4fc32b91ba6a02fdbc0:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x0031117212a5849c87efc4fc32b91ba6a02fdbc0-340",
+      "urn": "urn:decentraland:matic:collections-v2:0x0031117212a5849c87efc4fc32b91ba6a02fdbc0:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x0031117212a5849c87efc4fc32b91ba6a02fdbc0-342",
+      "urn": "urn:decentraland:matic:collections-v2:0x0031117212a5849c87efc4fc32b91ba6a02fdbc0:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x0031117212a5849c87efc4fc32b91ba6a02fdbc0-343",
+      "urn": "urn:decentraland:matic:collections-v2:0x0031117212a5849c87efc4fc32b91ba6a02fdbc0:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x0031117212a5849c87efc4fc32b91ba6a02fdbc0-344",
+      "urn": "urn:decentraland:matic:collections-v2:0x0031117212a5849c87efc4fc32b91ba6a02fdbc0:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x0031117212a5849c87efc4fc32b91ba6a02fdbc0-345",
+      "urn": "urn:decentraland:matic:collections-v2:0x0031117212a5849c87efc4fc32b91ba6a02fdbc0:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x0031117212a5849c87efc4fc32b91ba6a02fdbc0-346",
+      "urn": "urn:decentraland:matic:collections-v2:0x0031117212a5849c87efc4fc32b91ba6a02fdbc0:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x0031117212a5849c87efc4fc32b91ba6a02fdbc0-347",
+      "urn": "urn:decentraland:matic:collections-v2:0x0031117212a5849c87efc4fc32b91ba6a02fdbc0:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x0031117212a5849c87efc4fc32b91ba6a02fdbc0-351",
+      "urn": "urn:decentraland:matic:collections-v2:0x0031117212a5849c87efc4fc32b91ba6a02fdbc0:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-1",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-10",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-194",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-195",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-196",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-197",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-198",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-199",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-2",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-200",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-202",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-3",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-4",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-401",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-402",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-403",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-404",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-405",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-406",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-407",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-408",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-409",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-410",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-411",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-412",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-413",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-414",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-415",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-416",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-417",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-418",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-419",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-420",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-421",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-422",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-423",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-424",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-425",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-426",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-427",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-428",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-429",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-430",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-431",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-432",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-433",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-434",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-435",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-436",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-437",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-438",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-439",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-440",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-441",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-442",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-443",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-444",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-445",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-446",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-447",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-448",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-449",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-450",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-451",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-452",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-453",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-454",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-455",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-456",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-457",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-458",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-459",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-460",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-461",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-462",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-463",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-464",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-465",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-466",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-467",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-468",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-469",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-470",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-471",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-472",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-473",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-474",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-475",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-476",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-477",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-478",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-479",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-480",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-481",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-482",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-483",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-484",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-485",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-486",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-488",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-49",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-490",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-491",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-493",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-495",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-496",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-497",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-499",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-5",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-500",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-514",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-515",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-516",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-517",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-518",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-519",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-520",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-521",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-522",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-523",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-524",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-525",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-526",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-527",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-528",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-529",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-530",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-531",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-532",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-533",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-534",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-535",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-536",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-537",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-538",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-539",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-540",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-541",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-542",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-543",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-544",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-545",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-546",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-547",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-548",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-549",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-550",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-551",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-552",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-553",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-554",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-555",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-556",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-557",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-558",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-559",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-560",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-561",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-562",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-563",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-564",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-565",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-566",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-567",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-568",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-569",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-570",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-571",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-572",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-573",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-574",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-575",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-576",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-577",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-578",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-579",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-580",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-581",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-582",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-583",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-584",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-585",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-586",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-587",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-588",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-589",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-590",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-591",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-592",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-593",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-594",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-595",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-596",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-597",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-598",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-599",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-6",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-600",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-601",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-602",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-603",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-604",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-605",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-606",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-607",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-608",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-609",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-610",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-611",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-612",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-613",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-614",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-615",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-616",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-617",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-618",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-619",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-620",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-621",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-622",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-623",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-624",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-625",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-626",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-627",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-628",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-629",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-630",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-631",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-632",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-633",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-634",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-635",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-636",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-637",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-638",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-640",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-641",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-642",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-643",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-644",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-645",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-646",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-647",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-648",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-649",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-650",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-651",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-653",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-654",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-655",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-656",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-657",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-658",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-659",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-660",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-661",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-662",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-663",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-7",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-8",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x00925b9b061b314d5fd2b35b1720c932d03ee132-9",
+      "urn": "urn:decentraland:matic:collections-v2:0x00925b9b061b314d5fd2b35b1720c932d03ee132:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x06392188d39efb1a15c178846122f18140e8945d-78",
+      "urn": "urn:decentraland:matic:collections-v2:0x06392188d39efb1a15c178846122f18140e8945d:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x06392188d39efb1a15c178846122f18140e8945d-79",
+      "urn": "urn:decentraland:matic:collections-v2:0x06392188d39efb1a15c178846122f18140e8945d:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x06392188d39efb1a15c178846122f18140e8945d-80",
+      "urn": "urn:decentraland:matic:collections-v2:0x06392188d39efb1a15c178846122f18140e8945d:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x07f70720dbb6c244987c7af2cf4c3d82e3bc23b1-1",
+      "urn": "urn:decentraland:matic:collections-v2:0x07f70720dbb6c244987c7af2cf4c3d82e3bc23b1:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x07f70720dbb6c244987c7af2cf4c3d82e3bc23b1-3",
+      "urn": "urn:decentraland:matic:collections-v2:0x07f70720dbb6c244987c7af2cf4c3d82e3bc23b1:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x07f70720dbb6c244987c7af2cf4c3d82e3bc23b1-4",
+      "urn": "urn:decentraland:matic:collections-v2:0x07f70720dbb6c244987c7af2cf4c3d82e3bc23b1:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-11",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-1268",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-1292",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-240",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-241",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-242",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-243",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-244",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-245",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-246",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-247",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-248",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-249",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-250",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-251",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-252",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-253",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-254",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-255",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-256",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-257",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-258",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-259",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-260",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-261",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-262",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-263",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-264",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-265",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-266",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-267",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-268",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-269",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-270",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-271",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-272",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-273",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-274",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-275",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-276",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-277",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-278",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-279",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-280",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-281",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-282",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-283",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-284",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-285",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-286",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-287",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-288",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-289",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-290",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-291",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-292",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-293",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-294",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-295",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-296",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-297",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-298",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-299",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-300",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-301",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-302",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-303",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-304",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-305",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-306",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-307",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-308",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-309",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-310",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-311",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-312",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-313",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-314",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-315",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-316",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-317",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-318",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-319",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-320",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-321",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-322",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-323",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-324",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-326",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-327",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-329",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-330",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-331",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-332",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-333",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-334",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-335",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-336",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-337",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-338",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-339",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-340",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-341",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-342",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-343",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-344",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-345",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-347",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-35",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-350",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-351",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-352",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-353",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-354",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-355",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-356",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-357",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-358",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-359",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-360",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-362",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-363",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-364",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-365",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-366",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-368",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c-970",
+      "urn": "urn:decentraland:matic:collections-v2:0x08cbc78c1b2e2eea7627c39c8adf660d52e3d82c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x0a92f166d5e030dacd5c33fd5fc810d9b14c0802-60",
+      "urn": "urn:decentraland:matic:collections-v2:0x0a92f166d5e030dacd5c33fd5fc810d9b14c0802:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x0ae9bfce31a5c9530ee6b7b35799a0dae029cd00-31",
+      "urn": "urn:decentraland:matic:collections-v2:0x0ae9bfce31a5c9530ee6b7b35799a0dae029cd00:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x0be429aa3c8fa39a82a005f97c7913ee669c7675-210624583337114373395836055367340864637790190801098222508621955737",
+      "urn": "urn:decentraland:matic:collections-v2:0x0be429aa3c8fa39a82a005f97c7913ee669c7675:2",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x0be429aa3c8fa39a82a005f97c7913ee669c7675-315936875005671560093754083051011296956685286201647333762932933581",
+      "urn": "urn:decentraland:matic:collections-v2:0x0be429aa3c8fa39a82a005f97c7913ee669c7675:3",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x0c797b4ea1d668192611808171b14d2b80bd3bc4-16",
+      "urn": "urn:decentraland:matic:collections-v2:0x0c797b4ea1d668192611808171b14d2b80bd3bc4:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x0c797b4ea1d668192611808171b14d2b80bd3bc4-62",
+      "urn": "urn:decentraland:matic:collections-v2:0x0c797b4ea1d668192611808171b14d2b80bd3bc4:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x0e859150ff9308b9a40cbaeb30b04b3d114257d8-118",
+      "urn": "urn:decentraland:matic:collections-v2:0x0e859150ff9308b9a40cbaeb30b04b3d114257d8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x0f05d6899686a0bb927b93739ae124ea25e6224c-105312291668557186697918027683670432318895095400549111254310977548",
+      "urn": "urn:decentraland:matic:collections-v2:0x0f05d6899686a0bb927b93739ae124ea25e6224c:1",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x0f05d6899686a0bb927b93739ae124ea25e6224c-15",
+      "urn": "urn:decentraland:matic:collections-v2:0x0f05d6899686a0bb927b93739ae124ea25e6224c:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x1010900618c0706a5ba1003bcf0be05bf1f9cf19-151",
+      "urn": "urn:decentraland:matic:collections-v2:0x1010900618c0706a5ba1003bcf0be05bf1f9cf19:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-1",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-10",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-105312291668557186697918027683670432318895095400549111254310977537",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:1",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-105312291668557186697918027683670432318895095400549111254310977538",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:1",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-105312291668557186697918027683670432318895095400549111254310977539",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:1",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-105312291668557186697918027683670432318895095400549111254310977540",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:1",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-105312291668557186697918027683670432318895095400549111254310977541",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:1",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-105312291668557186697918027683670432318895095400549111254310977542",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:1",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-105312291668557186697918027683670432318895095400549111254310977543",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:1",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-105312291668557186697918027683670432318895095400549111254310977544",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:1",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-105312291668557186697918027683670432318895095400549111254310977545",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:1",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-105312291668557186697918027683670432318895095400549111254310977546",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:1",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-105312291668557186697918027683670432318895095400549111254310977611",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:1",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-105312291668557186697918027683670432318895095400549111254310977722",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:1",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-105312291668557186697918027683670432318895095400549111254310977941",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:1",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-105312291668557186697918027683670432318895095400549111254310978048",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:1",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-105312291668557186697918027683670432318895095400549111254310978065",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:1",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-105312291668557186697918027683670432318895095400549111254310978119",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:1",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-2",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-210624583337114373395836055367340864637790190801098222508621955073",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:2",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-210624583337114373395836055367340864637790190801098222508621955074",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:2",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-210624583337114373395836055367340864637790190801098222508621955075",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:2",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-210624583337114373395836055367340864637790190801098222508621955076",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:2",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-210624583337114373395836055367340864637790190801098222508621955077",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:2",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-210624583337114373395836055367340864637790190801098222508621955078",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:2",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-210624583337114373395836055367340864637790190801098222508621955079",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:2",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-210624583337114373395836055367340864637790190801098222508621955080",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:2",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-210624583337114373395836055367340864637790190801098222508621955081",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:2",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-210624583337114373395836055367340864637790190801098222508621955082",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:2",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-210624583337114373395836055367340864637790190801098222508621955160",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:2",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-210624583337114373395836055367340864637790190801098222508621955411",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:2",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-210624583337114373395836055367340864637790190801098222508621955517",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:2",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-210624583337114373395836055367340864637790190801098222508621955548",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:2",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-210624583337114373395836055367340864637790190801098222508621955628",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:2",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-210624583337114373395836055367340864637790190801098222508621955656",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:2",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-287",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-3",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-315936875005671560093754083051011296956685286201647333762932932609",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:3",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-315936875005671560093754083051011296956685286201647333762932932610",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:3",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-315936875005671560093754083051011296956685286201647333762932932611",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:3",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-315936875005671560093754083051011296956685286201647333762932932612",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:3",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-315936875005671560093754083051011296956685286201647333762932932613",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:3",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-315936875005671560093754083051011296956685286201647333762932932614",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:3",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-315936875005671560093754083051011296956685286201647333762932932615",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:3",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-315936875005671560093754083051011296956685286201647333762932932616",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:3",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-315936875005671560093754083051011296956685286201647333762932932617",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:3",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-315936875005671560093754083051011296956685286201647333762932932618",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:3",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-315936875005671560093754083051011296956685286201647333762932932686",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:3",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-315936875005671560093754083051011296956685286201647333762932932949",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:3",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-315936875005671560093754083051011296956685286201647333762932933047",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:3",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-315936875005671560093754083051011296956685286201647333762932933078",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:3",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-315936875005671560093754083051011296956685286201647333762932933158",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:3",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-315936875005671560093754083051011296956685286201647333762932933185",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:3",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-384",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-398",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-4",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-421249166674228746791672110734681729275580381602196445017243910145",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:4",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-421249166674228746791672110734681729275580381602196445017243910146",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:4",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-421249166674228746791672110734681729275580381602196445017243910147",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:4",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-421249166674228746791672110734681729275580381602196445017243910148",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:4",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-421249166674228746791672110734681729275580381602196445017243910149",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:4",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-421249166674228746791672110734681729275580381602196445017243910150",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:4",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-421249166674228746791672110734681729275580381602196445017243910151",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:4",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-421249166674228746791672110734681729275580381602196445017243910152",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:4",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-421249166674228746791672110734681729275580381602196445017243910153",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:4",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-421249166674228746791672110734681729275580381602196445017243910154",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:4",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-421249166674228746791672110734681729275580381602196445017243910235",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:4",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-421249166674228746791672110734681729275580381602196445017243910467",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:4",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-421249166674228746791672110734681729275580381602196445017243910579",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:4",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-421249166674228746791672110734681729275580381602196445017243910594",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:4",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-421249166674228746791672110734681729275580381602196445017243910669",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:4",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-421249166674228746791672110734681729275580381602196445017243910695",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:4",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-466",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-495",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-5",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-526561458342785933489590138418352161594475477002745556271554887681",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:5",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-526561458342785933489590138418352161594475477002745556271554887682",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:5",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-526561458342785933489590138418352161594475477002745556271554887683",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:5",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-526561458342785933489590138418352161594475477002745556271554887684",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:5",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-526561458342785933489590138418352161594475477002745556271554887685",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:5",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-526561458342785933489590138418352161594475477002745556271554887686",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:5",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-526561458342785933489590138418352161594475477002745556271554887687",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:5",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-526561458342785933489590138418352161594475477002745556271554887688",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:5",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-526561458342785933489590138418352161594475477002745556271554887689",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:5",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-526561458342785933489590138418352161594475477002745556271554887690",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:5",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-526561458342785933489590138418352161594475477002745556271554887766",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:5",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-526561458342785933489590138418352161594475477002745556271554888011",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:5",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-526561458342785933489590138418352161594475477002745556271554888122",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:5",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-526561458342785933489590138418352161594475477002745556271554888140",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:5",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-526561458342785933489590138418352161594475477002745556271554888218",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:5",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-526561458342785933489590138418352161594475477002745556271554888267",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:5",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-526561458342785933489590138418352161594475477002745556271554888295",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:5",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-6",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-7",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-8",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-82",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x17eefc20521695476f2c2c6633d10692fd803013-9",
+      "urn": "urn:decentraland:matic:collections-v2:0x17eefc20521695476f2c2c6633d10692fd803013:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x1aa2e6de4a6d727f85ddae10a52ae6a16789eb2f-15",
+      "urn": "urn:decentraland:matic:collections-v2:0x1aa2e6de4a6d727f85ddae10a52ae6a16789eb2f:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x1aa2e6de4a6d727f85ddae10a52ae6a16789eb2f-16",
+      "urn": "urn:decentraland:matic:collections-v2:0x1aa2e6de4a6d727f85ddae10a52ae6a16789eb2f:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x1afe7712b3f7684ff8472323237b8e760eec44bc-47",
+      "urn": "urn:decentraland:matic:collections-v2:0x1afe7712b3f7684ff8472323237b8e760eec44bc:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x1ea351ab1410a85558670c3d95cc1a649f034b84-16",
+      "urn": "urn:decentraland:matic:collections-v2:0x1ea351ab1410a85558670c3d95cc1a649f034b84:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x1fe5ab42e423b11d5680b1fdbff181b2c23cf399-105312291668557186697918027683670432318895095400549111254310977917",
+      "urn": "urn:decentraland:matic:collections-v2:0x1fe5ab42e423b11d5680b1fdbff181b2c23cf399:1",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x1fe5ab42e423b11d5680b1fdbff181b2c23cf399-105312291668557186697918027683670432318895095400549111254310977918",
+      "urn": "urn:decentraland:matic:collections-v2:0x1fe5ab42e423b11d5680b1fdbff181b2c23cf399:1",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x1fe5ab42e423b11d5680b1fdbff181b2c23cf399-105312291668557186697918027683670432318895095400549111254310977919",
+      "urn": "urn:decentraland:matic:collections-v2:0x1fe5ab42e423b11d5680b1fdbff181b2c23cf399:1",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x1fe5ab42e423b11d5680b1fdbff181b2c23cf399-105312291668557186697918027683670432318895095400549111254310977920",
+      "urn": "urn:decentraland:matic:collections-v2:0x1fe5ab42e423b11d5680b1fdbff181b2c23cf399:1",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x1fe5ab42e423b11d5680b1fdbff181b2c23cf399-105312291668557186697918027683670432318895095400549111254310977921",
+      "urn": "urn:decentraland:matic:collections-v2:0x1fe5ab42e423b11d5680b1fdbff181b2c23cf399:1",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x1fe5ab42e423b11d5680b1fdbff181b2c23cf399-352",
+      "urn": "urn:decentraland:matic:collections-v2:0x1fe5ab42e423b11d5680b1fdbff181b2c23cf399:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x1fe5ab42e423b11d5680b1fdbff181b2c23cf399-353",
+      "urn": "urn:decentraland:matic:collections-v2:0x1fe5ab42e423b11d5680b1fdbff181b2c23cf399:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x1fe5ab42e423b11d5680b1fdbff181b2c23cf399-354",
+      "urn": "urn:decentraland:matic:collections-v2:0x1fe5ab42e423b11d5680b1fdbff181b2c23cf399:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x1fe5ab42e423b11d5680b1fdbff181b2c23cf399-355",
+      "urn": "urn:decentraland:matic:collections-v2:0x1fe5ab42e423b11d5680b1fdbff181b2c23cf399:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x1fe5ab42e423b11d5680b1fdbff181b2c23cf399-356",
+      "urn": "urn:decentraland:matic:collections-v2:0x1fe5ab42e423b11d5680b1fdbff181b2c23cf399:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x20963133d0ada0d3f768f7557abb37d0917f0ecb-91",
+      "urn": "urn:decentraland:matic:collections-v2:0x20963133d0ada0d3f768f7557abb37d0917f0ecb:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-1017",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-1290",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-1298",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-1307",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-1312",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-1334",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-1336",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-1353",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-1356",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-1357",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-1360",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-1381",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-1382",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-1383",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-1385",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-1386",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-1391",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-1398",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-1540",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-1602",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-1612",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-1679",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-1694",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-1701",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-1705",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-1708",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-1735",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-1744",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-1772",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-1799",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-1807",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-1886",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-1887",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-1890",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-1895",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-1968",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-1978",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-1991",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-1999",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-2011",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-2012",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-2019",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-2023",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-2024",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-2030",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-2034",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-2036",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-2141",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-2142",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-2153",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-2227",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-2269",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-2273",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-2278",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-2279",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-2281",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-2341",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-2361",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-2362",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-2387",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-2424",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-2440",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-2443",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-2473",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-2474",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-2492",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-2612",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-2620",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-2643",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-2667",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-2717",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-2737",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-2786",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-2800",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-2825",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-2883",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-2919",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-313",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-314",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-315",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-316",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-317",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-318",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-319",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-320",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-321",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-322",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-323",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-324",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-325",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-3257",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-326",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-327",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-3275",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-328",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-329",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-330",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-331",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-333",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-334",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-335",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-336",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-337",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-3373",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-338",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-339",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-340",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-341",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-342",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-343",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-344",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-345",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-346",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-347",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-350",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-351",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-352",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-353",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-354",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-355",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-356",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-358",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-359",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-3591",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-360",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-361",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-362",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-3654",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-3732",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-3800",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-3987",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-4042",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-4348",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-4569",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-4609",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-4803",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-4846",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-4854",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-4867",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-5014",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-5112",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-5202",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-5219",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-5272",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-5293",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-5304",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-5360",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-5374",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-5383",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-5430",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2097389da7dd64e237eb92fc5ceadcdcc03213d3-915",
+      "urn": "urn:decentraland:matic:collections-v2:0x2097389da7dd64e237eb92fc5ceadcdcc03213d3:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x21c83e786fbb013727f2f4bde04fa0827cdd598f-2",
+      "urn": "urn:decentraland:matic:collections-v2:0x21c83e786fbb013727f2f4bde04fa0827cdd598f:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x224d4f37472fb9f1e428a16f7b09e4b38199f372-30",
+      "urn": "urn:decentraland:matic:collections-v2:0x224d4f37472fb9f1e428a16f7b09e4b38199f372:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2519a9e8ca938682b53d870163264b79ff026b23-40",
+      "urn": "urn:decentraland:matic:collections-v2:0x2519a9e8ca938682b53d870163264b79ff026b23:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x26676a456bca88e418f9ea4b33a707364c0b5876-105312291668557186697918027683670432318895095400549111254310989951",
+      "urn": "urn:decentraland:matic:collections-v2:0x26676a456bca88e418f9ea4b33a707364c0b5876:1",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x26676a456bca88e418f9ea4b33a707364c0b5876-7413",
+      "urn": "urn:decentraland:matic:collections-v2:0x26676a456bca88e418f9ea4b33a707364c0b5876:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x289f3374440eae1224910bad726b6421fc0be66d-1",
+      "urn": "urn:decentraland:matic:collections-v2:0x289f3374440eae1224910bad726b6421fc0be66d:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x289f3374440eae1224910bad726b6421fc0be66d-1325",
+      "urn": "urn:decentraland:matic:collections-v2:0x289f3374440eae1224910bad726b6421fc0be66d:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x289f3374440eae1224910bad726b6421fc0be66d-1425",
+      "urn": "urn:decentraland:matic:collections-v2:0x289f3374440eae1224910bad726b6421fc0be66d:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x289f3374440eae1224910bad726b6421fc0be66d-1448",
+      "urn": "urn:decentraland:matic:collections-v2:0x289f3374440eae1224910bad726b6421fc0be66d:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x289f3374440eae1224910bad726b6421fc0be66d-1499",
+      "urn": "urn:decentraland:matic:collections-v2:0x289f3374440eae1224910bad726b6421fc0be66d:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x289f3374440eae1224910bad726b6421fc0be66d-1514",
+      "urn": "urn:decentraland:matic:collections-v2:0x289f3374440eae1224910bad726b6421fc0be66d:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x289f3374440eae1224910bad726b6421fc0be66d-1520",
+      "urn": "urn:decentraland:matic:collections-v2:0x289f3374440eae1224910bad726b6421fc0be66d:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x289f3374440eae1224910bad726b6421fc0be66d-1526",
+      "urn": "urn:decentraland:matic:collections-v2:0x289f3374440eae1224910bad726b6421fc0be66d:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x289f3374440eae1224910bad726b6421fc0be66d-1532",
+      "urn": "urn:decentraland:matic:collections-v2:0x289f3374440eae1224910bad726b6421fc0be66d:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x289f3374440eae1224910bad726b6421fc0be66d-1535",
+      "urn": "urn:decentraland:matic:collections-v2:0x289f3374440eae1224910bad726b6421fc0be66d:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x289f3374440eae1224910bad726b6421fc0be66d-1563",
+      "urn": "urn:decentraland:matic:collections-v2:0x289f3374440eae1224910bad726b6421fc0be66d:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x289f3374440eae1224910bad726b6421fc0be66d-1589",
+      "urn": "urn:decentraland:matic:collections-v2:0x289f3374440eae1224910bad726b6421fc0be66d:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x289f3374440eae1224910bad726b6421fc0be66d-1593",
+      "urn": "urn:decentraland:matic:collections-v2:0x289f3374440eae1224910bad726b6421fc0be66d:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x289f3374440eae1224910bad726b6421fc0be66d-1614",
+      "urn": "urn:decentraland:matic:collections-v2:0x289f3374440eae1224910bad726b6421fc0be66d:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x289f3374440eae1224910bad726b6421fc0be66d-1617",
+      "urn": "urn:decentraland:matic:collections-v2:0x289f3374440eae1224910bad726b6421fc0be66d:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x289f3374440eae1224910bad726b6421fc0be66d-162",
+      "urn": "urn:decentraland:matic:collections-v2:0x289f3374440eae1224910bad726b6421fc0be66d:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x289f3374440eae1224910bad726b6421fc0be66d-1636",
+      "urn": "urn:decentraland:matic:collections-v2:0x289f3374440eae1224910bad726b6421fc0be66d:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x289f3374440eae1224910bad726b6421fc0be66d-1638",
+      "urn": "urn:decentraland:matic:collections-v2:0x289f3374440eae1224910bad726b6421fc0be66d:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x289f3374440eae1224910bad726b6421fc0be66d-1643",
+      "urn": "urn:decentraland:matic:collections-v2:0x289f3374440eae1224910bad726b6421fc0be66d:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x289f3374440eae1224910bad726b6421fc0be66d-1654",
+      "urn": "urn:decentraland:matic:collections-v2:0x289f3374440eae1224910bad726b6421fc0be66d:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x289f3374440eae1224910bad726b6421fc0be66d-1656",
+      "urn": "urn:decentraland:matic:collections-v2:0x289f3374440eae1224910bad726b6421fc0be66d:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x289f3374440eae1224910bad726b6421fc0be66d-1661",
+      "urn": "urn:decentraland:matic:collections-v2:0x289f3374440eae1224910bad726b6421fc0be66d:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x289f3374440eae1224910bad726b6421fc0be66d-1683",
+      "urn": "urn:decentraland:matic:collections-v2:0x289f3374440eae1224910bad726b6421fc0be66d:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x289f3374440eae1224910bad726b6421fc0be66d-1695",
+      "urn": "urn:decentraland:matic:collections-v2:0x289f3374440eae1224910bad726b6421fc0be66d:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x289f3374440eae1224910bad726b6421fc0be66d-1768",
+      "urn": "urn:decentraland:matic:collections-v2:0x289f3374440eae1224910bad726b6421fc0be66d:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x289f3374440eae1224910bad726b6421fc0be66d-1777",
+      "urn": "urn:decentraland:matic:collections-v2:0x289f3374440eae1224910bad726b6421fc0be66d:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x289f3374440eae1224910bad726b6421fc0be66d-1778",
+      "urn": "urn:decentraland:matic:collections-v2:0x289f3374440eae1224910bad726b6421fc0be66d:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x289f3374440eae1224910bad726b6421fc0be66d-1794",
+      "urn": "urn:decentraland:matic:collections-v2:0x289f3374440eae1224910bad726b6421fc0be66d:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x289f3374440eae1224910bad726b6421fc0be66d-200",
+      "urn": "urn:decentraland:matic:collections-v2:0x289f3374440eae1224910bad726b6421fc0be66d:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x289f3374440eae1224910bad726b6421fc0be66d-31",
+      "urn": "urn:decentraland:matic:collections-v2:0x289f3374440eae1224910bad726b6421fc0be66d:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x289f3374440eae1224910bad726b6421fc0be66d-693",
+      "urn": "urn:decentraland:matic:collections-v2:0x289f3374440eae1224910bad726b6421fc0be66d:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x289f3374440eae1224910bad726b6421fc0be66d-824",
+      "urn": "urn:decentraland:matic:collections-v2:0x289f3374440eae1224910bad726b6421fc0be66d:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x289f3374440eae1224910bad726b6421fc0be66d-853",
+      "urn": "urn:decentraland:matic:collections-v2:0x289f3374440eae1224910bad726b6421fc0be66d:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2e28f39a564ed7477cca4ab07cfda3dc50d5c689-1659",
+      "urn": "urn:decentraland:matic:collections-v2:0x2e28f39a564ed7477cca4ab07cfda3dc50d5c689:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x2f6763f3240ab1510562c5e40a3d03378a5c9afe-39",
+      "urn": "urn:decentraland:matic:collections-v2:0x2f6763f3240ab1510562c5e40a3d03378a5c9afe:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x3081a64774426eb4de8fa8d70c3cd742a885327a-1",
+      "urn": "urn:decentraland:matic:collections-v2:0x3081a64774426eb4de8fa8d70c3cd742a885327a:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x3081a64774426eb4de8fa8d70c3cd742a885327a-105312291668557186697918027683670432318895095400549111254310977537",
+      "urn": "urn:decentraland:matic:collections-v2:0x3081a64774426eb4de8fa8d70c3cd742a885327a:1",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x3081a64774426eb4de8fa8d70c3cd742a885327a-210624583337114373395836055367340864637790190801098222508621955073",
+      "urn": "urn:decentraland:matic:collections-v2:0x3081a64774426eb4de8fa8d70c3cd742a885327a:2",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x3081a64774426eb4de8fa8d70c3cd742a885327a-3",
+      "urn": "urn:decentraland:matic:collections-v2:0x3081a64774426eb4de8fa8d70c3cd742a885327a:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x3081a64774426eb4de8fa8d70c3cd742a885327a-315936875005671560093754083051011296956685286201647333762932932609",
+      "urn": "urn:decentraland:matic:collections-v2:0x3081a64774426eb4de8fa8d70c3cd742a885327a:3",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x3081a64774426eb4de8fa8d70c3cd742a885327a-4",
+      "urn": "urn:decentraland:matic:collections-v2:0x3081a64774426eb4de8fa8d70c3cd742a885327a:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x3081a64774426eb4de8fa8d70c3cd742a885327a-421249166674228746791672110734681729275580381602196445017243910145",
+      "urn": "urn:decentraland:matic:collections-v2:0x3081a64774426eb4de8fa8d70c3cd742a885327a:4",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x3081a64774426eb4de8fa8d70c3cd742a885327a-421249166674228746791672110734681729275580381602196445017243910440",
+      "urn": "urn:decentraland:matic:collections-v2:0x3081a64774426eb4de8fa8d70c3cd742a885327a:4",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x3081a64774426eb4de8fa8d70c3cd742a885327a-526561458342785933489590138418352161594475477002745556271554887681",
+      "urn": "urn:decentraland:matic:collections-v2:0x3081a64774426eb4de8fa8d70c3cd742a885327a:5",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x3081a64774426eb4de8fa8d70c3cd742a885327a-631873750011343120187508166102022593913370572403294667525865865217",
+      "urn": "urn:decentraland:matic:collections-v2:0x3081a64774426eb4de8fa8d70c3cd742a885327a:6",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x3081a64774426eb4de8fa8d70c3cd742a885327a-631873750011343120187508166102022593913370572403294667525865865222",
+      "urn": "urn:decentraland:matic:collections-v2:0x3081a64774426eb4de8fa8d70c3cd742a885327a:6",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x3081a64774426eb4de8fa8d70c3cd742a885327a-631873750011343120187508166102022593913370572403294667525865865223",
+      "urn": "urn:decentraland:matic:collections-v2:0x3081a64774426eb4de8fa8d70c3cd742a885327a:6",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x3081a64774426eb4de8fa8d70c3cd742a885327a-737186041679900306885426193785693026232265667803843778780176842753",
+      "urn": "urn:decentraland:matic:collections-v2:0x3081a64774426eb4de8fa8d70c3cd742a885327a:7",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x3081a64774426eb4de8fa8d70c3cd742a885327a-737186041679900306885426193785693026232265667803843778780176842757",
+      "urn": "urn:decentraland:matic:collections-v2:0x3081a64774426eb4de8fa8d70c3cd742a885327a:7",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x3081a64774426eb4de8fa8d70c3cd742a885327a-737186041679900306885426193785693026232265667803843778780176842761",
+      "urn": "urn:decentraland:matic:collections-v2:0x3081a64774426eb4de8fa8d70c3cd742a885327a:7",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x3081a64774426eb4de8fa8d70c3cd742a885327a-842498333348457493583344221469363458551160763204392890034487820289",
+      "urn": "urn:decentraland:matic:collections-v2:0x3081a64774426eb4de8fa8d70c3cd742a885327a:8",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x3081a64774426eb4de8fa8d70c3cd742a885327a-842498333348457493583344221469363458551160763204392890034487820312",
+      "urn": "urn:decentraland:matic:collections-v2:0x3081a64774426eb4de8fa8d70c3cd742a885327a:8",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x3081a64774426eb4de8fa8d70c3cd742a885327a-842498333348457493583344221469363458551160763204392890034487820313",
+      "urn": "urn:decentraland:matic:collections-v2:0x3081a64774426eb4de8fa8d70c3cd742a885327a:8",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x3081a64774426eb4de8fa8d70c3cd742a885327a-842498333348457493583344221469363458551160763204392890034487820314",
+      "urn": "urn:decentraland:matic:collections-v2:0x3081a64774426eb4de8fa8d70c3cd742a885327a:8",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x3081a64774426eb4de8fa8d70c3cd742a885327a-842498333348457493583344221469363458551160763204392890034487820315",
+      "urn": "urn:decentraland:matic:collections-v2:0x3081a64774426eb4de8fa8d70c3cd742a885327a:8",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x3081a64774426eb4de8fa8d70c3cd742a885327a-842498333348457493583344221469363458551160763204392890034487820316",
+      "urn": "urn:decentraland:matic:collections-v2:0x3081a64774426eb4de8fa8d70c3cd742a885327a:8",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x3081a64774426eb4de8fa8d70c3cd742a885327a-842498333348457493583344221469363458551160763204392890034487820317",
+      "urn": "urn:decentraland:matic:collections-v2:0x3081a64774426eb4de8fa8d70c3cd742a885327a:8",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x3081a64774426eb4de8fa8d70c3cd742a885327a-947810625017014680281262249153033890870055858604942001288798797825",
+      "urn": "urn:decentraland:matic:collections-v2:0x3081a64774426eb4de8fa8d70c3cd742a885327a:9",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x3081a64774426eb4de8fa8d70c3cd742a885327a-947810625017014680281262249153033890870055858604942001288798797848",
+      "urn": "urn:decentraland:matic:collections-v2:0x3081a64774426eb4de8fa8d70c3cd742a885327a:9",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x3081a64774426eb4de8fa8d70c3cd742a885327a-947810625017014680281262249153033890870055858604942001288798797849",
+      "urn": "urn:decentraland:matic:collections-v2:0x3081a64774426eb4de8fa8d70c3cd742a885327a:9",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x3081a64774426eb4de8fa8d70c3cd742a885327a-947810625017014680281262249153033890870055858604942001288798797850",
+      "urn": "urn:decentraland:matic:collections-v2:0x3081a64774426eb4de8fa8d70c3cd742a885327a:9",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x3081a64774426eb4de8fa8d70c3cd742a885327a-947810625017014680281262249153033890870055858604942001288798797851",
+      "urn": "urn:decentraland:matic:collections-v2:0x3081a64774426eb4de8fa8d70c3cd742a885327a:9",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x3081a64774426eb4de8fa8d70c3cd742a885327a-947810625017014680281262249153033890870055858604942001288798797853",
+      "urn": "urn:decentraland:matic:collections-v2:0x3081a64774426eb4de8fa8d70c3cd742a885327a:9",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x312ddfd7ec16436a96105be34f5c9fb23c77900a-100",
+      "urn": "urn:decentraland:matic:collections-v2:0x312ddfd7ec16436a96105be34f5c9fb23c77900a:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x312ddfd7ec16436a96105be34f5c9fb23c77900a-15",
+      "urn": "urn:decentraland:matic:collections-v2:0x312ddfd7ec16436a96105be34f5c9fb23c77900a:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x33ab8db939a24325b38ed29b2832f6327cca15ac-184",
+      "urn": "urn:decentraland:matic:collections-v2:0x33ab8db939a24325b38ed29b2832f6327cca15ac:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x395ab8d889d3075ce56003ceee159dd4f99de08b-1",
+      "urn": "urn:decentraland:matic:collections-v2:0x395ab8d889d3075ce56003ceee159dd4f99de08b:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x395ab8d889d3075ce56003ceee159dd4f99de08b-2",
+      "urn": "urn:decentraland:matic:collections-v2:0x395ab8d889d3075ce56003ceee159dd4f99de08b:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x395ab8d889d3075ce56003ceee159dd4f99de08b-3",
+      "urn": "urn:decentraland:matic:collections-v2:0x395ab8d889d3075ce56003ceee159dd4f99de08b:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x3ddbf98e516b77ff0ac42ac16ad1855c9bb64e22-218",
+      "urn": "urn:decentraland:matic:collections-v2:0x3ddbf98e516b77ff0ac42ac16ad1855c9bb64e22:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x40a047cbe550d108aa32d8987dbfd67fbdc8fe37-105312291668557186697918027683670432318895095400549111254310977584",
+      "urn": "urn:decentraland:matic:collections-v2:0x40a047cbe550d108aa32d8987dbfd67fbdc8fe37:1",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x41a024a66c9c30421991a1ddfef1f0c011fdf629-1",
+      "urn": "urn:decentraland:matic:collections-v2:0x41a024a66c9c30421991a1ddfef1f0c011fdf629:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x41a024a66c9c30421991a1ddfef1f0c011fdf629-10",
+      "urn": "urn:decentraland:matic:collections-v2:0x41a024a66c9c30421991a1ddfef1f0c011fdf629:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x41a024a66c9c30421991a1ddfef1f0c011fdf629-11",
+      "urn": "urn:decentraland:matic:collections-v2:0x41a024a66c9c30421991a1ddfef1f0c011fdf629:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x41a024a66c9c30421991a1ddfef1f0c011fdf629-12",
+      "urn": "urn:decentraland:matic:collections-v2:0x41a024a66c9c30421991a1ddfef1f0c011fdf629:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x41a024a66c9c30421991a1ddfef1f0c011fdf629-13",
+      "urn": "urn:decentraland:matic:collections-v2:0x41a024a66c9c30421991a1ddfef1f0c011fdf629:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x41a024a66c9c30421991a1ddfef1f0c011fdf629-14",
+      "urn": "urn:decentraland:matic:collections-v2:0x41a024a66c9c30421991a1ddfef1f0c011fdf629:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x41a024a66c9c30421991a1ddfef1f0c011fdf629-15",
+      "urn": "urn:decentraland:matic:collections-v2:0x41a024a66c9c30421991a1ddfef1f0c011fdf629:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x41a024a66c9c30421991a1ddfef1f0c011fdf629-16",
+      "urn": "urn:decentraland:matic:collections-v2:0x41a024a66c9c30421991a1ddfef1f0c011fdf629:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x41a024a66c9c30421991a1ddfef1f0c011fdf629-17",
+      "urn": "urn:decentraland:matic:collections-v2:0x41a024a66c9c30421991a1ddfef1f0c011fdf629:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x41a024a66c9c30421991a1ddfef1f0c011fdf629-18",
+      "urn": "urn:decentraland:matic:collections-v2:0x41a024a66c9c30421991a1ddfef1f0c011fdf629:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x41a024a66c9c30421991a1ddfef1f0c011fdf629-19",
+      "urn": "urn:decentraland:matic:collections-v2:0x41a024a66c9c30421991a1ddfef1f0c011fdf629:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x41a024a66c9c30421991a1ddfef1f0c011fdf629-2",
+      "urn": "urn:decentraland:matic:collections-v2:0x41a024a66c9c30421991a1ddfef1f0c011fdf629:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x41a024a66c9c30421991a1ddfef1f0c011fdf629-20",
+      "urn": "urn:decentraland:matic:collections-v2:0x41a024a66c9c30421991a1ddfef1f0c011fdf629:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x41a024a66c9c30421991a1ddfef1f0c011fdf629-21",
+      "urn": "urn:decentraland:matic:collections-v2:0x41a024a66c9c30421991a1ddfef1f0c011fdf629:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x41a024a66c9c30421991a1ddfef1f0c011fdf629-22",
+      "urn": "urn:decentraland:matic:collections-v2:0x41a024a66c9c30421991a1ddfef1f0c011fdf629:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x41a024a66c9c30421991a1ddfef1f0c011fdf629-23",
+      "urn": "urn:decentraland:matic:collections-v2:0x41a024a66c9c30421991a1ddfef1f0c011fdf629:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x41a024a66c9c30421991a1ddfef1f0c011fdf629-24",
+      "urn": "urn:decentraland:matic:collections-v2:0x41a024a66c9c30421991a1ddfef1f0c011fdf629:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x41a024a66c9c30421991a1ddfef1f0c011fdf629-25",
+      "urn": "urn:decentraland:matic:collections-v2:0x41a024a66c9c30421991a1ddfef1f0c011fdf629:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x41a024a66c9c30421991a1ddfef1f0c011fdf629-26",
+      "urn": "urn:decentraland:matic:collections-v2:0x41a024a66c9c30421991a1ddfef1f0c011fdf629:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x41a024a66c9c30421991a1ddfef1f0c011fdf629-27",
+      "urn": "urn:decentraland:matic:collections-v2:0x41a024a66c9c30421991a1ddfef1f0c011fdf629:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x41a024a66c9c30421991a1ddfef1f0c011fdf629-28",
+      "urn": "urn:decentraland:matic:collections-v2:0x41a024a66c9c30421991a1ddfef1f0c011fdf629:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x41a024a66c9c30421991a1ddfef1f0c011fdf629-29",
+      "urn": "urn:decentraland:matic:collections-v2:0x41a024a66c9c30421991a1ddfef1f0c011fdf629:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x41a024a66c9c30421991a1ddfef1f0c011fdf629-3",
+      "urn": "urn:decentraland:matic:collections-v2:0x41a024a66c9c30421991a1ddfef1f0c011fdf629:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x41a024a66c9c30421991a1ddfef1f0c011fdf629-30",
+      "urn": "urn:decentraland:matic:collections-v2:0x41a024a66c9c30421991a1ddfef1f0c011fdf629:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x41a024a66c9c30421991a1ddfef1f0c011fdf629-31",
+      "urn": "urn:decentraland:matic:collections-v2:0x41a024a66c9c30421991a1ddfef1f0c011fdf629:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x41a024a66c9c30421991a1ddfef1f0c011fdf629-32",
+      "urn": "urn:decentraland:matic:collections-v2:0x41a024a66c9c30421991a1ddfef1f0c011fdf629:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x41a024a66c9c30421991a1ddfef1f0c011fdf629-33",
+      "urn": "urn:decentraland:matic:collections-v2:0x41a024a66c9c30421991a1ddfef1f0c011fdf629:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x41a024a66c9c30421991a1ddfef1f0c011fdf629-34",
+      "urn": "urn:decentraland:matic:collections-v2:0x41a024a66c9c30421991a1ddfef1f0c011fdf629:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x41a024a66c9c30421991a1ddfef1f0c011fdf629-35",
+      "urn": "urn:decentraland:matic:collections-v2:0x41a024a66c9c30421991a1ddfef1f0c011fdf629:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x41a024a66c9c30421991a1ddfef1f0c011fdf629-36",
+      "urn": "urn:decentraland:matic:collections-v2:0x41a024a66c9c30421991a1ddfef1f0c011fdf629:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x41a024a66c9c30421991a1ddfef1f0c011fdf629-37",
+      "urn": "urn:decentraland:matic:collections-v2:0x41a024a66c9c30421991a1ddfef1f0c011fdf629:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x41a024a66c9c30421991a1ddfef1f0c011fdf629-38",
+      "urn": "urn:decentraland:matic:collections-v2:0x41a024a66c9c30421991a1ddfef1f0c011fdf629:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x41a024a66c9c30421991a1ddfef1f0c011fdf629-39",
+      "urn": "urn:decentraland:matic:collections-v2:0x41a024a66c9c30421991a1ddfef1f0c011fdf629:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x41a024a66c9c30421991a1ddfef1f0c011fdf629-4",
+      "urn": "urn:decentraland:matic:collections-v2:0x41a024a66c9c30421991a1ddfef1f0c011fdf629:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x41a024a66c9c30421991a1ddfef1f0c011fdf629-40",
+      "urn": "urn:decentraland:matic:collections-v2:0x41a024a66c9c30421991a1ddfef1f0c011fdf629:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x41a024a66c9c30421991a1ddfef1f0c011fdf629-41",
+      "urn": "urn:decentraland:matic:collections-v2:0x41a024a66c9c30421991a1ddfef1f0c011fdf629:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x41a024a66c9c30421991a1ddfef1f0c011fdf629-42",
+      "urn": "urn:decentraland:matic:collections-v2:0x41a024a66c9c30421991a1ddfef1f0c011fdf629:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x41a024a66c9c30421991a1ddfef1f0c011fdf629-43",
+      "urn": "urn:decentraland:matic:collections-v2:0x41a024a66c9c30421991a1ddfef1f0c011fdf629:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x41a024a66c9c30421991a1ddfef1f0c011fdf629-44",
+      "urn": "urn:decentraland:matic:collections-v2:0x41a024a66c9c30421991a1ddfef1f0c011fdf629:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x41a024a66c9c30421991a1ddfef1f0c011fdf629-45",
+      "urn": "urn:decentraland:matic:collections-v2:0x41a024a66c9c30421991a1ddfef1f0c011fdf629:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x41a024a66c9c30421991a1ddfef1f0c011fdf629-46",
+      "urn": "urn:decentraland:matic:collections-v2:0x41a024a66c9c30421991a1ddfef1f0c011fdf629:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x41a024a66c9c30421991a1ddfef1f0c011fdf629-47",
+      "urn": "urn:decentraland:matic:collections-v2:0x41a024a66c9c30421991a1ddfef1f0c011fdf629:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x41a024a66c9c30421991a1ddfef1f0c011fdf629-48",
+      "urn": "urn:decentraland:matic:collections-v2:0x41a024a66c9c30421991a1ddfef1f0c011fdf629:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x41a024a66c9c30421991a1ddfef1f0c011fdf629-49",
+      "urn": "urn:decentraland:matic:collections-v2:0x41a024a66c9c30421991a1ddfef1f0c011fdf629:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x41a024a66c9c30421991a1ddfef1f0c011fdf629-5",
+      "urn": "urn:decentraland:matic:collections-v2:0x41a024a66c9c30421991a1ddfef1f0c011fdf629:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x41a024a66c9c30421991a1ddfef1f0c011fdf629-50",
+      "urn": "urn:decentraland:matic:collections-v2:0x41a024a66c9c30421991a1ddfef1f0c011fdf629:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x41a024a66c9c30421991a1ddfef1f0c011fdf629-6",
+      "urn": "urn:decentraland:matic:collections-v2:0x41a024a66c9c30421991a1ddfef1f0c011fdf629:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x41a024a66c9c30421991a1ddfef1f0c011fdf629-7",
+      "urn": "urn:decentraland:matic:collections-v2:0x41a024a66c9c30421991a1ddfef1f0c011fdf629:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x41a024a66c9c30421991a1ddfef1f0c011fdf629-8",
+      "urn": "urn:decentraland:matic:collections-v2:0x41a024a66c9c30421991a1ddfef1f0c011fdf629:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x41a024a66c9c30421991a1ddfef1f0c011fdf629-9",
+      "urn": "urn:decentraland:matic:collections-v2:0x41a024a66c9c30421991a1ddfef1f0c011fdf629:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x42a7ec7dd3ebbf25f29d2edfdfa1a44700e90651-25",
+      "urn": "urn:decentraland:matic:collections-v2:0x42a7ec7dd3ebbf25f29d2edfdfa1a44700e90651:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x437fd5ae50e59b1a5e80ba1873b1f157a5ff50c9-11",
+      "urn": "urn:decentraland:matic:collections-v2:0x437fd5ae50e59b1a5e80ba1873b1f157a5ff50c9:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x467b984ba64c79efcb1baf53c435096a1c1baf27-77",
+      "urn": "urn:decentraland:matic:collections-v2:0x467b984ba64c79efcb1baf53c435096a1c1baf27:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x467b984ba64c79efcb1baf53c435096a1c1baf27-78",
+      "urn": "urn:decentraland:matic:collections-v2:0x467b984ba64c79efcb1baf53c435096a1c1baf27:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x467b984ba64c79efcb1baf53c435096a1c1baf27-79",
+      "urn": "urn:decentraland:matic:collections-v2:0x467b984ba64c79efcb1baf53c435096a1c1baf27:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x467b984ba64c79efcb1baf53c435096a1c1baf27-80",
+      "urn": "urn:decentraland:matic:collections-v2:0x467b984ba64c79efcb1baf53c435096a1c1baf27:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x493711707a4a396c4f58ec446348452f845bfe96-123",
+      "urn": "urn:decentraland:matic:collections-v2:0x493711707a4a396c4f58ec446348452f845bfe96:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-233",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-234",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-235",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-236",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-237",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-238",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-239",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-240",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-241",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-242",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-243",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-244",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-245",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-246",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-247",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-248",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-249",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-250",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-251",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-252",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-253",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-254",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-255",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-256",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-257",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-258",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-259",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-260",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-261",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-262",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-263",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-264",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-265",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-266",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-267",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-268",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-269",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-270",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-271",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-272",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-273",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-274",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-275",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-276",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-277",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-278",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-279",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-280",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-281",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-282",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-283",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-284",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-285",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-286",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-287",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-288",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-289",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-290",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-291",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-292",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-293",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-294",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-295",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-296",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-297",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-298",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-299",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-300",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-301",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-302",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-303",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-304",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-305",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-306",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-307",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-308",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-309",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-310",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-311",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-312",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-313",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-314",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-315",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-316",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-317",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-318",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-319",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-320",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-321",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-322",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-323",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-324",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-325",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-326",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-327",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-328",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-329",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-330",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-331",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-332",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-333",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-334",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-335",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-336",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-338",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-339",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-340",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-341",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-343",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-345",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-346",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-347",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-348",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-350",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-351",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-352",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-353",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-354",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-356",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-357",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-358",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-359",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-360",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-361",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-362",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-363",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-364",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-365",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-366",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-368",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-369",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-370",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-372",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-374",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-376",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-377",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-378",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8-381",
+      "urn": "urn:decentraland:matic:collections-v2:0x495a16cd69571c14ee2e7cf08a5e7a2489d471a8:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x4ccaa8278edab598f5358143681e13a87f15840d-105312291668557186697918027683670432318895095400549111254310977540",
+      "urn": "urn:decentraland:matic:collections-v2:0x4ccaa8278edab598f5358143681e13a87f15840d:1",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x4ccaa8278edab598f5358143681e13a87f15840d-315936875005671560093754083051011296956685286201647333762932932616",
+      "urn": "urn:decentraland:matic:collections-v2:0x4ccaa8278edab598f5358143681e13a87f15840d:3",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x4ccaa8278edab598f5358143681e13a87f15840d-526561458342785933489590138418352161594475477002745556271554887685",
+      "urn": "urn:decentraland:matic:collections-v2:0x4ccaa8278edab598f5358143681e13a87f15840d:5",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x4ccaa8278edab598f5358143681e13a87f15840d-6",
+      "urn": "urn:decentraland:matic:collections-v2:0x4ccaa8278edab598f5358143681e13a87f15840d:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x4ccaa8278edab598f5358143681e13a87f15840d-737186041679900306885426193785693026232265667803843778780176842755",
+      "urn": "urn:decentraland:matic:collections-v2:0x4ccaa8278edab598f5358143681e13a87f15840d:7",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x4ccaa8278edab598f5358143681e13a87f15840d-737186041679900306885426193785693026232265667803843778780176842757",
+      "urn": "urn:decentraland:matic:collections-v2:0x4ccaa8278edab598f5358143681e13a87f15840d:7",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x4d75e0be12dcce26f5b6361f87bf1a1d7c796b84-362",
+      "urn": "urn:decentraland:matic:collections-v2:0x4d75e0be12dcce26f5b6361f87bf1a1d7c796b84:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334-1",
+      "urn": "urn:decentraland:matic:collections-v2:0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334-1248",
+      "urn": "urn:decentraland:matic:collections-v2:0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334-245",
+      "urn": "urn:decentraland:matic:collections-v2:0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334-246",
+      "urn": "urn:decentraland:matic:collections-v2:0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334-247",
+      "urn": "urn:decentraland:matic:collections-v2:0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334-248",
+      "urn": "urn:decentraland:matic:collections-v2:0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334-249",
+      "urn": "urn:decentraland:matic:collections-v2:0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334-250",
+      "urn": "urn:decentraland:matic:collections-v2:0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334-251",
+      "urn": "urn:decentraland:matic:collections-v2:0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334-252",
+      "urn": "urn:decentraland:matic:collections-v2:0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334-253",
+      "urn": "urn:decentraland:matic:collections-v2:0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334-254",
+      "urn": "urn:decentraland:matic:collections-v2:0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334-255",
+      "urn": "urn:decentraland:matic:collections-v2:0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334-256",
+      "urn": "urn:decentraland:matic:collections-v2:0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334-257",
+      "urn": "urn:decentraland:matic:collections-v2:0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334-258",
+      "urn": "urn:decentraland:matic:collections-v2:0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334-259",
+      "urn": "urn:decentraland:matic:collections-v2:0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334-260",
+      "urn": "urn:decentraland:matic:collections-v2:0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334-261",
+      "urn": "urn:decentraland:matic:collections-v2:0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334-262",
+      "urn": "urn:decentraland:matic:collections-v2:0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334-263",
+      "urn": "urn:decentraland:matic:collections-v2:0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334-264",
+      "urn": "urn:decentraland:matic:collections-v2:0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334-265",
+      "urn": "urn:decentraland:matic:collections-v2:0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334-266",
+      "urn": "urn:decentraland:matic:collections-v2:0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334-267",
+      "urn": "urn:decentraland:matic:collections-v2:0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334-268",
+      "urn": "urn:decentraland:matic:collections-v2:0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334-269",
+      "urn": "urn:decentraland:matic:collections-v2:0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334-270",
+      "urn": "urn:decentraland:matic:collections-v2:0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334-271",
+      "urn": "urn:decentraland:matic:collections-v2:0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334-272",
+      "urn": "urn:decentraland:matic:collections-v2:0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334-273",
+      "urn": "urn:decentraland:matic:collections-v2:0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334:0",
+      "collection": {
+        "isApproved": true
+      }
+    },
+    {
+      "id": "0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334-274",
+      "urn": "urn:decentraland:matic:collections-v2:0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334:0",
+      "collection": {
+        "isApproved": true
+      }
+    }
+  ]
+}

--- a/lambdas/test/__fixtures__/wearables-by-owner-matic-p2.json
+++ b/lambdas/test/__fixtures__/wearables-by-owner-matic-p2.json
@@ -1,0 +1,11 @@
+{
+  "nfts": [
+    {
+      "id": "0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334-275",
+      "urn": "urn:decentraland:matic:collections-v2:0x4f0a8e5f8e0e22137833bf708b98ae77aeb03334:0",
+      "collection": {
+        "isApproved": true
+      }
+    }
+  ]
+}

--- a/lambdas/test/utils/the-graph-client.spec.ts
+++ b/lambdas/test/utils/the-graph-client.spec.ts
@@ -1,0 +1,32 @@
+import { TheGraphClient } from '../../src/utils/TheGraphClient'
+import { Fetcher } from 'dcl-catalyst-commons'
+import sinon from 'sinon'
+
+describe('The Graph Client', () => {
+  it('should iterate until all assets have been fetched', async () => {
+    const stub = sinon.stub()
+    stub.withArgs('collectionsSubgraph', sinon.match.any, sinon.match.any).resolves({
+      nfts: []
+    })
+    stub
+      .withArgs('maticCollectionsSubgraph', sinon.match.any, sinon.match.any)
+      .onFirstCall()
+      .resolves(require('../__fixtures__/wearables-by-owner-matic-p1.json'))
+      .onSecondCall()
+      .resolves(require('../__fixtures__/wearables-by-owner-matic-p2.json'))
+
+    const fetcher = new Fetcher()
+    fetcher.queryGraph = stub
+
+    let urls = {
+      ensSubgraph: 'ensSubgraph',
+      collectionsSubgraph: 'collectionsSubgraph',
+      maticCollectionsSubgraph: 'maticCollectionsSubgraph',
+      thirdPartyRegistrySubgraph: 'thirdPartyRegistrySubgraph'
+    }
+    const theGraphClient = new TheGraphClient(urls, fetcher)
+    const assets = await theGraphClient.findWearablesByOwner('0x6a77883ed4E65a1DF591FdA2f5252FD7c548f198')
+
+    expect(assets).toHaveLength(1001)
+  })
+})


### PR DESCRIPTION
Given the hard restriction from TheGraph that doesn't support pagination beyond 5000 records, this PR implements the alternative approach suggested [here](https://thegraph.com/docs/en/developer/graphql-api/#example-using-and-2
).
