### PR TITLE
fix: revert changes to support syncing old entities

### DIFF
--- a/content/src/logic/hashing.ts
+++ b/content/src/logic/hashing.ts
@@ -1,8 +1,18 @@
-import { hashV1 } from '@dcl/hashing'
+import { hashV0, hashV1 } from '@dcl/hashing'
 
 export async function calculateIPFSHashes<T extends Uint8Array>(files: T[]): Promise<{ hash: string; file: T }[]> {
   const entries = Array.from(files).map(async (file) => ({
     hash: await hashV1(file),
+    file
+  }))
+  return Promise.all(entries)
+}
+
+export async function calculateDeprecatedHashes<T extends Uint8Array>(
+  files: T[]
+): Promise<{ hash: string; file: T }[]> {
+  const entries = Array.from(files).map(async (file) => ({
+    hash: await hashV0(file),
     file
   }))
   return Promise.all(entries)

--- a/content/src/service/EntityFactory.ts
+++ b/content/src/service/EntityFactory.ts
@@ -43,17 +43,13 @@ export class EntityFactory {
       content = this.parseContent(object.content) || []
     }
 
-    if (object.version != 'v3') {
-      throw new Error('Object has an invalid version')
-    }
-
     const type: EntityType = EntityType[object.type.toUpperCase().trim()]
     return {
       id,
       type,
       pointers: object.pointers.map((pointer: string) => pointer.toLowerCase()),
       timestamp: object.timestamp,
-      version: 'v3',
+      version: object.version ?? 'v3',
       content,
       metadata: object.metadata
     }

--- a/content/src/service/ServiceImpl.ts
+++ b/content/src/service/ServiceImpl.ts
@@ -10,7 +10,7 @@ import {
 } from 'dcl-catalyst-commons'
 import { EnvironmentConfig } from '../Environment'
 import { runReportingQueryDurationMetric } from '../instrument'
-import { calculateIPFSHashes } from '../logic/hashing'
+import { calculateDeprecatedHashes, calculateIPFSHashes } from '../logic/hashing'
 import { bufferToStream, ContentItem } from '../ports/contentStorage/contentStorage'
 import { FailedDeployment, FailureReason } from '../ports/failedDeploymentsCache'
 import { Database } from '../repository/Database'
@@ -80,7 +80,7 @@ export class ServiceImpl implements MetaverseContentService {
     }
 
     // Hash all files
-    const hashes: Map<string, Uint8Array> = await ServiceImpl.hashFiles(files)
+    const hashes: Map<string, Uint8Array> = await ServiceImpl.hashFiles(files, entityId)
 
     // Find entity file
     const entityFile = hashes.get(entityId)
@@ -394,11 +394,13 @@ export class ServiceImpl implements MetaverseContentService {
    * They could come hashed because the denylist decorator might have already hashed them for its own validations. In order to avoid re-hashing
    * them in the service (because there might be hundreds of files), we will send the hash result.
    */
-  static async hashFiles(files: DeploymentFiles): Promise<Map<string, Uint8Array>> {
+  static async hashFiles(files: DeploymentFiles, entityId: string): Promise<Map<string, Uint8Array>> {
     if (files instanceof Map) {
       return files
     } else {
-      const hashEntries = await calculateIPFSHashes(files)
+      const hashEntries = this.isIPFSHash(entityId)
+        ? await calculateIPFSHashes(files)
+        : await calculateDeprecatedHashes(files)
       return new Map(hashEntries.map(({ hash, file }) => [hash, file]))
     }
   }

--- a/content/test/integration/logic/delete-unreferenced-files.spec.ts
+++ b/content/test/integration/logic/delete-unreferenced-files.spec.ts
@@ -42,7 +42,7 @@ loadStandaloneTestEnvironment({ [EnvironmentConfig.STORAGE_ROOT_FOLDER]: tmpRoot
 
     await server.deploy(deployResult.deployData)
 
-    const contentsByHash: Map<string, Uint8Array> = await ServiceImpl.hashFiles(deployResult.deployData.files)
+    const contentsByHash: Map<string, Uint8Array> = await ServiceImpl.hashFiles(deployResult.deployData.files, deployResult.deployData.entityId)
     const contentFileHashes = Array.from(contentsByHash.keys())
 
     await deleteUnreferencedFiles(components)
@@ -63,7 +63,7 @@ loadStandaloneTestEnvironment({ [EnvironmentConfig.STORAGE_ROOT_FOLDER]: tmpRoot
 
     await server.deploy(deployResult.deployData)
 
-    const contentsByHash: Map<string, Uint8Array> = await ServiceImpl.hashFiles(deployResult.deployData.files)
+    const contentsByHash: Map<string, Uint8Array> = await ServiceImpl.hashFiles(deployResult.deployData.files, deployResult.deployData.entityId)
     const contentFileHashes = Array.from(contentsByHash.keys())
 
     await deleteUnreferencedFiles(components)
@@ -86,7 +86,7 @@ loadStandaloneTestEnvironment({ [EnvironmentConfig.STORAGE_ROOT_FOLDER]: tmpRoot
 
     await server.deploy(deployResult.deployData)
 
-    const contentsByHash: Map<string, Uint8Array> = await ServiceImpl.hashFiles(deployResult.deployData.files)
+    const contentsByHash: Map<string, Uint8Array> = await ServiceImpl.hashFiles(deployResult.deployData.files, deployResult.deployData.entityId)
     const contentFileHashes = Array.from(contentsByHash.keys())
 
     const unreferencedFileHash = 'a-hash'

--- a/content/test/integration/resources/QmYfCVBv7PJCcBh3AutAzNesdGZVKUEd8KCc8Jh1Y8ba4u
+++ b/content/test/integration/resources/QmYfCVBv7PJCcBh3AutAzNesdGZVKUEd8KCc8Jh1Y8ba4u
@@ -1,0 +1,1 @@
+{"version":"v3","type":"profile","pointers":["0x4CAb2E350499bAd0eC5941aD6B6995a6a20f0130"],"timestamp":1632416205936,"content":[{"file":"aFile-zjxd","hash":"QmbNcPuVAq6Dv821kfFnyaM59Go3xCeBMnSxYRSHEpwWeF"},{"file":"anotherFile-zjxd","hash":"QmbNcPuVAq6Dv821kfFnyaM59Go3xCeBMnSxYRSHEpwWeF"},{"file":"aThirdFile-zjxd","hash":"QmbNcPuVAq6Dv821kfFnyaM59Go3xCeBMnSxYRSHEpwWeF"}]}

--- a/content/test/integration/resources/QmbNcPuVAq6Dv821kfFnyaM59Go3xCeBMnSxYRSHEpwWeF
+++ b/content/test/integration/resources/QmbNcPuVAq6Dv821kfFnyaM59Go3xCeBMnSxYRSHEpwWeF
@@ -1,0 +1,1 @@
+zjxd-5h8gymztig

--- a/content/test/integration/service/deployments/old-entity-synced.spec.ts
+++ b/content/test/integration/service/deployments/old-entity-synced.spec.ts
@@ -1,0 +1,88 @@
+import { AuthLinkType, Entity, EntityType } from "@dcl/schemas";
+import { AuditInfo } from "dcl-catalyst-commons";
+import { createFsComponent } from '../../../../src/ports/fs';
+import { DeploymentContext, DeploymentResult } from "../../../../src/service/Service";
+import { AppComponents } from "../../../../src/types";
+import { makeNoopServerValidator } from "../../../helpers/service/validations/NoOpValidator";
+import { loadStandaloneTestEnvironment, testCaseWithComponents } from "../../E2ETestEnvironment";
+import { EntityCombo } from "../../E2ETestUtils";
+import { getIntegrationResourcePathFor } from '../../resources/get-resource-path';
+
+const fs = createFsComponent()
+
+loadStandaloneTestEnvironment()("Integration - Deployment synced old entity", (testEnv) => {
+
+  testCaseWithComponents(
+    testEnv,
+    "When deploying an old synced entity, it should succeed",
+    async (components) => {
+      makeNoopServerValidator(components);
+
+      const entity: Entity = {
+        "version": "v3",
+        "id": "QmYfCVBv7PJCcBh3AutAzNesdGZVKUEd8KCc8Jh1Y8ba4u",
+        "type": EntityType.PROFILE,
+        "pointers": ["0x4CAb2E350499bAd0eC5941aD6B6995a6a20f0130"],
+        "timestamp": 1632416205936,
+        "content": [
+          {
+            "file": "aFile-zjxd",
+            "hash": "QmbNcPuVAq6Dv821kfFnyaM59Go3xCeBMnSxYRSHEpwWeF"
+          },
+          {
+            "file": "anotherFile-zjxd",
+            "hash": "QmbNcPuVAq6Dv821kfFnyaM59Go3xCeBMnSxYRSHEpwWeF"
+          },
+          {
+            "file": "aThirdFile-zjxd",
+            "hash": "QmbNcPuVAq6Dv821kfFnyaM59Go3xCeBMnSxYRSHEpwWeF"
+          }]
+      }
+
+      const contentFile = await fs.readFile(getIntegrationResourcePathFor('QmbNcPuVAq6Dv821kfFnyaM59Go3xCeBMnSxYRSHEpwWeF'));
+      const entityFile = await fs.readFile(getIntegrationResourcePathFor('QmYfCVBv7PJCcBh3AutAzNesdGZVKUEd8KCc8Jh1Y8ba4u'));
+
+      const E1: EntityCombo = {
+        deployData: {
+          entityId: 'QmYfCVBv7PJCcBh3AutAzNesdGZVKUEd8KCc8Jh1Y8ba4u',
+          files: new Map([
+            ['QmbNcPuVAq6Dv821kfFnyaM59Go3xCeBMnSxYRSHEpwWeF', contentFile],
+            ['QmYfCVBv7PJCcBh3AutAzNesdGZVKUEd8KCc8Jh1Y8ba4u', entityFile]]),
+          authChain: [
+            {
+            "type": AuthLinkType.SIGNER,
+            "payload": "0x4CAb2E350499bAd0eC5941aD6B6995a6a20f0130",
+            "signature": ""
+            },
+            {
+            "type": AuthLinkType.ECDSA_PERSONAL_SIGNED_ENTITY,
+            "payload": "QmYfCVBv7PJCcBh3AutAzNesdGZVKUEd8KCc8Jh1Y8ba4u",
+            "signature": "0x10c80e802b3d5faea8e253c809d254ec2e17a4b36c50ade38e0a4e7766c320e903aa262a5be9458802d57f0c69b283855d3734848fc7b68467d0749f082700b01b"
+            }
+            ]
+        },
+        controllerEntity: entity,
+        entity: entity
+      }
+
+      const deploymentResult = await deployEntity(components, E1)
+
+      expect( typeof deploymentResult === 'number').toBeTruthy();
+    }
+  );
+
+
+  async function deployEntity(
+    components: Pick<AppComponents, "deployer">,
+    entity: EntityCombo,
+    overrideAuditInfo?: Partial<AuditInfo>
+  ): Promise<DeploymentResult> {
+    const newAuditInfo = { version: 'v3', authChain: entity.deployData.authChain, ...overrideAuditInfo };
+    return await components.deployer.deployEntity(
+      Array.from(entity.deployData.files.values()),
+      entity.deployData.entityId,
+      newAuditInfo,
+      DeploymentContext.SYNCED
+    );
+  }
+});


### PR DESCRIPTION
Errors found:

```
2022-06-30T17:24:06.660Z [ERROR] (ServiceImpl): There was an error parsing the entity: Error: Object has an invalid version     “There was an error parsing the entity: Error: Object has an invalid version”
Trace
    at Object.error (/Users/agustina/Documents/dcl/catalyst/node_modules/@well-known-components/logger/dist/helpers.js:53:37)
    at ServiceImpl.deployEntity (/Users/agustina/Documents/dcl/catalyst/content/dist/src/service/ServiceImpl.js:51:32)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async deployDownloadedEntity (/Users/agustina/Documents/dcl/catalyst/content/dist/src/service/synchronization/deployRemoteEntity.js:45:34)
    at async deployEntityFromRemoteServer (/Users/agustina/Documents/dcl/catalyst/content/dist/src/service/synchronization/deployRemoteEntity.js:21:5)
    at async /Users/agustina/Documents/dcl/catalyst/content/dist/src/service/synchronization/batchDeployer.js:71:21
    at async run (/Users/agustina/Documents/dcl/catalyst/node_modules/p-queue/dist/index.js:163:29)
```



```
2022-06-30T17:34:46.559Z [ERROR] (ServiceImpl): There was an error deploying the entity: error: could not extend file “base/16384/16395”: No space left on device    {“entityId”:“QmZLMe7o9uSxEz1VNA6bU8DhuDUuUwSjNR338D8KuJPbAT”}
Trace
    at Object.error (/Users/agustina/Documents/dcl/catalyst/node_modules/@well-known-components/logger/dist/helpers.js:53:37)
    at ServiceImpl.deployEntity (/Users/agustina/Documents/dcl/catalyst/content/dist/src/service/ServiceImpl.js:124:32)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async deployDownloadedEntity (/Users/agustina/Documents/dcl/catalyst/content/dist/src/service/synchronization/deployRemoteEntity.js:45:34)
    at async deployEntityFromRemoteServer (/Users/agustina/Documents/dcl/catalyst/content/dist/src/service/synchronization/deployRemoteEntity.js:21:5)
    at async /Users/agustina/Documents/dcl/catalyst/content/dist/src/service/synchronization/batchDeployer.js:71:21
    at async run (/Users/agustina/Documents/dcl/catalyst/node_modules/p-queue/dist/index.js:163:29)

```