### PR TITLE
refactor: remove pointer_history and last_deployed_pointers tables

### DIFF
--- a/content/src/migrations/scripts/1657560713689_drop_pointer_history_table.ts
+++ b/content/src/migrations/scripts/1657560713689_drop_pointer_history_table.ts
@@ -1,0 +1,21 @@
+import { MigrationBuilder } from 'node-pg-migrate'
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropTable('pointer_history')
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.createTable(
+    'pointer_history',
+    {
+      pointer: { type: 'text', notNull: true },
+      entity_type: { type: 'text', notNull: true },
+      deployment: { type: 'integer', references: 'deployments', notNull: true }
+    },
+    {
+      constraints: {
+        unique: ['pointer', 'entity_type', 'deployment']
+      }
+    }
+  )
+}

--- a/content/src/migrations/scripts/1657560812218_drop_last_deployed_pointers_table.ts
+++ b/content/src/migrations/scripts/1657560812218_drop_last_deployed_pointers_table.ts
@@ -1,0 +1,21 @@
+import { MigrationBuilder } from 'node-pg-migrate'
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropTable('last_deployed_pointers')
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.createTable(
+    'last_deployed_pointers',
+    {
+      pointer: { type: 'text', notNull: true },
+      entity_type: { type: 'text', notNull: true },
+      deployment: { type: 'integer', references: 'deployments', notNull: true }
+    },
+    {
+      constraints: {
+        unique: ['pointer', 'entity_type']
+      }
+    }
+  )
+}


### PR DESCRIPTION
Third and last part of #1112.

This PR contains 2 migration steps to remove the `pointer_history` and `last_deployed_pointers` tables respectively.
