### PR TITLE
fix: remove stacktrace when synced deployment fails

### DIFF
--- a/content/src/service/ServiceImpl.ts
+++ b/content/src/service/ServiceImpl.ts
@@ -133,7 +133,7 @@ export class ServiceImpl implements MetaverseContentService {
         })
         return InvalidResult({ errors: ['An internal server error occurred. This will raise an automatic alarm.'] })
       } else if (isInvalidDeployment(storeResult)) {
-        ServiceImpl.LOGGER.error(`Error deploying entity`, {
+        ServiceImpl.LOGGER.warn(`Error deploying entity`, {
           entityId,
           pointers: entity.pointers.join(' '),
           errors: storeResult.errors.join(' ')


### PR DESCRIPTION
## Description

This change will prevent printing stack trace when a synced deployment fails while the content server bootstraps. Since the message error we are logging is good enough to realized what happened during the deployment, we want to avoid flooding logs with redundant information.

[Fixes # 984](https://github.com/decentraland/catalyst/issues/984)

## Changes

- Call LOGGER.warn instead of LOGGER.error function to avoid printing stack trace on failures

## Types of changes

What types of changes does your code introduce? Remove the lines that don't that apply:

- Bug fix (non-breaking change which fixes an issue)