### PR TITLE
refactor: implement unshared functions after removing them from shared client

### DIFF
--- a/content/package.json
+++ b/content/package.json
@@ -34,7 +34,7 @@
     "bloom-filters": "^3.0.0",
     "compression": "1.7.4",
     "cors": "2.8.5",
-    "dcl-catalyst-client": "^13.0.13",
+    "dcl-catalyst-client": "^14.0.1",
     "eth-connect": "^6.0.3",
     "express": "4.18.1",
     "express-openapi-validator": "4.13.8",

--- a/content/src/service/Server.ts
+++ b/content/src/service/Server.ts
@@ -85,7 +85,7 @@ export class Server implements IBaseComponent {
     } else {
       this.registerRoute('/entities', controller, controller.createEntity, HttpMethod.POST, upload.any())
     }
-    this.registerRoute('/entities/:type', controller, controller.getEntities) // TODO: Deprecate
+    this.registerRoute('/entities/:type', controller, controller.getEntities, HttpMethod.GET) // TODO: Deprecate
     this.registerRoute('/entities/active/collections/:collectionUrn', controller, controller.filterByUrn)
     this.registerRoute('/entities/active', controller, controller.getActiveEntities, HttpMethod.POST)
     this.registerRoute('/contents/:hashId', controller, controller.headContent, HttpMethod.HEAD) // Register before GET

--- a/content/test/integration/TestProgram.ts
+++ b/content/test/integration/TestProgram.ts
@@ -1,7 +1,6 @@
 import { Entity, EntityType } from '@dcl/schemas'
 import { ILoggerComponent, Lifecycle } from '@well-known-components/interfaces'
 import { ContentClient, DeploymentData } from 'dcl-catalyst-client'
-import { ServerStatus } from 'dcl-catalyst-commons'
 import fetch from 'node-fetch'
 import { EnvironmentConfig } from '../../src/Environment'
 import { FailedDeployment } from '../../src/ports/failedDeploymentsCache'
@@ -61,7 +60,7 @@ export class TestProgram {
     }
   }
 
-  async deploy(deployData: DeploymentData, fix: boolean = false): Promise<number> {
+  async deployEntity(deployData: DeploymentData, fix: boolean = false): Promise<number> {
     this.logger.info('Deploying entity ' + deployData.entityId)
     const returnValue = await this.client.deployEntity(deployData, fix)
     if (isInvalidDeployment(returnValue)) {
@@ -76,19 +75,15 @@ export class TestProgram {
   }
 
   getEntitiesByPointers(type: EntityType, pointers: string[]): Promise<Entity[]> {
-    return this.client.fetchEntitiesByPointers(type, pointers)
-  }
-
-  getStatus(): Promise<ServerStatus> {
-    return this.client.fetchContentStatus()
+    return this.client.fetchEntitiesByPointers(pointers)
   }
 
   getEntitiesByIds(type: EntityType, ...ids: string[]): Promise<Entity[]> {
-    return this.client.fetchEntitiesByIds(type, ids)
+    return this.client.fetchEntitiesByIds(ids)
   }
 
   getEntityById(type: EntityType, id: string): Promise<Entity> {
-    return this.client.fetchEntityById(type, id)
+    return this.client.fetchEntityById(id)
   }
 
   downloadContent(fileHash: string): Promise<Buffer> {
@@ -96,7 +91,7 @@ export class TestProgram {
   }
 
   async getAuditInfo(entity: Entity): Promise<AuditInfo> {
-    const legacyAuditInfo = await this.client.fetchAuditInfo(entity.type, entity.id)
+    const legacyAuditInfo = (await fetch(`${this.getUrl()}/audit/${entity.type}/${entity.id}`)).json()
     return { ...legacyAuditInfo, localTimestamp: 0 }
   }
 

--- a/content/test/integration/controller/active-entities.spec.ts
+++ b/content/test/integration/controller/active-entities.spec.ts
@@ -33,7 +33,7 @@ loadStandaloneTestEnvironment()('Integration - Get Active Entities', (testEnv) =
     })
 
     // Deploy entity
-    await server.deploy(deployResult.deployData)
+    await server.deployEntity(deployResult.deployData)
 
     const result = await fetchActiveEntityByIds(server, deployResult.entity.id)
     expect(result).toHaveLength(1)
@@ -53,7 +53,7 @@ loadStandaloneTestEnvironment()('Integration - Get Active Entities', (testEnv) =
     })
 
     // Deploy entity
-    await server.deploy(deployResult.deployData)
+    await server.deployEntity(deployResult.deployData)
 
     const result = await fetchActiveEntityByPointers(server, ...deployResult.entity.pointers)
 
@@ -75,7 +75,7 @@ loadStandaloneTestEnvironment()('Integration - Get Active Entities', (testEnv) =
     })
 
     // Deploy entity
-    await server.deploy(deployResult.deployData)
+    await server.deployEntity(deployResult.deployData)
 
     const newDeployResult = await buildDeployData(['0,0', '0,1'], {
       metadata: {
@@ -85,7 +85,7 @@ loadStandaloneTestEnvironment()('Integration - Get Active Entities', (testEnv) =
     })
 
     // Deploy newer entity
-    await server.deploy(newDeployResult.deployData)
+    await server.deployEntity(newDeployResult.deployData)
 
     const result = await fetchActiveEntityByIds(server, newDeployResult.entity.id)
     expect(result).toHaveLength(1)
@@ -105,7 +105,7 @@ loadStandaloneTestEnvironment()('Integration - Get Active Entities', (testEnv) =
     })
 
     // Deploy entity
-    await server.deploy(deployResult.deployData)
+    await server.deployEntity(deployResult.deployData)
 
     const deployResult2 = await buildDeployData(['2,0', '2,1'], {
       metadata: { a: 'this is just some metadata' },
@@ -113,7 +113,7 @@ loadStandaloneTestEnvironment()('Integration - Get Active Entities', (testEnv) =
     })
 
     // Deploy other entity
-    await server.deploy(deployResult2.deployData)
+    await server.deployEntity(deployResult2.deployData)
 
     const result = await fetchActiveEntityByIds(server, deployResult.entity.id, deployResult2.entity.id)
     expect(result).toHaveLength(2)
@@ -134,7 +134,7 @@ loadStandaloneTestEnvironment()('Integration - Get Active Entities', (testEnv) =
     })
 
     // Deploy entity
-    await server.deploy(deployResult.deployData)
+    await server.deployEntity(deployResult.deployData)
 
     const result = await fetchActiveEntityByIds(server, deployResult.entity.id, deployResult.entity.id)
     expect(result).toHaveLength(1)
@@ -155,7 +155,7 @@ loadStandaloneTestEnvironment()('Integration - Get Active Entities', (testEnv) =
     })
 
     // Deploy entity
-    await server.deploy(deployResult.deployData)
+    await server.deployEntity(deployResult.deployData)
     const resultWithId = await fetchActiveEntityByIds(server, deployResult.entity.id)
     const resultWithPointers = await fetchActiveEntityByPointers(server, ...pointers)
 
@@ -174,7 +174,7 @@ loadStandaloneTestEnvironment()('Integration - Get Active Entities', (testEnv) =
       })
 
       // Deploy entity
-      await server.deploy(deployResult.deployData)
+      await server.deployEntity(deployResult.deployData)
       await fetchActiveEntityByIds(server, deployResult.entity.id)
 
       const zeroZeroActiveEntityId = server.components.activeEntities.getCachedEntity('0,0')
@@ -223,14 +223,14 @@ loadStandaloneTestEnvironment()('Integration - Get Active Entities', (testEnv) =
       })
 
       // Deploy entity with pointers ['0,0', '0,1']
-      await server.deploy(deployData)
+      await server.deployEntity(deployData)
 
       const { deployData: secondDeployData } = await buildDeployData(['0,1'], {
         metadata: { a: 'this is just some metadata' },
         contentPaths: ['test/integration/resources/some-binary-file.png']
       })
       // Deploy entity with pointer ['0,1']
-      await server.deploy(secondDeployData) // Override entity and invalidate pointer ['0,0']
+      await server.deployEntity(secondDeployData) // Override entity and invalidate pointer ['0,0']
 
       const result = await fetchActiveEntityByPointers(server, '0,0')
       expect(result).toHaveLength(0)
@@ -251,7 +251,7 @@ loadStandaloneTestEnvironment()('Integration - Get Active Entities', (testEnv) =
       })
 
       // Deploy entity with pointers ['0,0', '0,1']
-      await server.deploy(deployData)
+      await server.deployEntity(deployData)
 
       const result = await fetchActiveEntityByPointers(server, '0,0', '0,1')
       expect(result).toHaveLength(1)
@@ -269,7 +269,7 @@ loadStandaloneTestEnvironment()('Integration - Get Active Entities', (testEnv) =
         contentPaths: ['test/integration/resources/some-binary-file.png']
       })
       // Deploy new entity with pointers ['0,0', '0,1']
-      await server.deploy(secondDeployData)
+      await server.deployEntity(secondDeployData)
       const newEntityId = activeEntities.getCachedEntity('0,0')
       expect(newEntityId).toBeDefined()
       expect(newEntityId).not.toBe(entityId)
@@ -298,8 +298,8 @@ loadStandaloneTestEnvironment()('Integration - Get Active Entities', (testEnv) =
         contentPaths: ['test/integration/resources/some-binary-file.png']
       })
 
-      await server.deploy(deployData)
-      await server.deploy(secondDeployData)
+      await server.deployEntity(deployData)
+      await server.deployEntity(secondDeployData)
 
       const result = await fetchActiveEntityByPointers(server, ...firstPointers, ...secondPointers)
       expect(result).toHaveLength(2)
@@ -336,14 +336,14 @@ loadStandaloneTestEnvironment()('Integration - Get Active Entities', (testEnv) =
       })
 
       // Deploy entity with pointers ['0,0', '0,1']
-      await server.deploy(deployData)
+      await server.deployEntity(deployData)
 
       const { deployData: secondDeployData } = await buildDeployData(['0,1'], {
         metadata: { a: 'this is just some metadata' },
         contentPaths: ['test/integration/resources/some-binary-file.png']
       })
       // Deploy entity with pointer ['0,1']
-      await server.deploy(secondDeployData) // Override entity and invalidate pointer ['0,0']
+      await server.deployEntity(secondDeployData) // Override entity and invalidate pointer ['0,0']
 
       // given one active entity and one non active entity cached, check getDeployments is not being called
       const serviceSpy = jest.spyOn(deployments, 'getDeployments')
@@ -373,7 +373,7 @@ loadStandaloneTestEnvironment()('Integration - Get Active Entities', (testEnv) =
 
       const response = await fetch(
         server.getUrl() +
-        `/entities/active/collections/urn:decentraland:ethereum:collections-v1:0x32b7495895264ac9d0b12d32afd435453458b1c6`,
+          `/entities/active/collections/urn:decentraland:ethereum:collections-v1:0x32b7495895264ac9d0b12d32afd435453458b1c6`,
         {
           method: 'GET',
           headers: { 'Content-Type': 'application/json' }
@@ -394,7 +394,7 @@ loadStandaloneTestEnvironment()('Integration - Get Active Entities', (testEnv) =
       })
 
       // Deploy entity
-      await server.deploy(deployResult.deployData)
+      await server.deployEntity(deployResult.deployData)
       const response = await fetchActiveEntityByUrnPrefix(
         server,
         'urn:decentraland:mumbai:collections-thirdparty:aThirdParty:winterCollection:1'
@@ -417,7 +417,7 @@ loadStandaloneTestEnvironment()('Integration - Get Active Entities', (testEnv) =
       })
 
       // Deploy entity
-      await server.deploy(deployResult.deployData)
+      await server.deployEntity(deployResult.deployData)
       const response = await fetchActiveEntityByUrnPrefix(
         server,
         'urn:decentraland:mumbai:collections-thirdparty:aThirdParty:winterCollection'
@@ -440,7 +440,7 @@ loadStandaloneTestEnvironment()('Integration - Get Active Entities', (testEnv) =
       })
 
       // Deploy entity
-      await server.deploy(deployResult.deployData)
+      await server.deployEntity(deployResult.deployData)
       const response = await fetchActiveEntityByUrnPrefix(
         server,
         'urn:decentraland:mumbai:collections-thirdparty:aThirdParty'
@@ -462,7 +462,7 @@ loadStandaloneTestEnvironment()('Integration - Get Active Entities', (testEnv) =
       })
 
       // Deploy entity
-      await server.deploy(deployResult.deployData)
+      await server.deployEntity(deployResult.deployData)
       const response = await fetchActiveEntityByUrnPrefix(
         server,
         'urn:decentraland:mumbai:collections-thirdparty:aThirdParty:winterCollection'
@@ -487,8 +487,8 @@ loadStandaloneTestEnvironment()('Integration - Get Active Entities', (testEnv) =
       })
 
       // Deploy entity
-      await server.deploy(firstDeploy.deployData)
-      await server.deploy(secondDeploy.deployData)
+      await server.deployEntity(firstDeploy.deployData)
+      await server.deployEntity(secondDeploy.deployData)
       const response = await fetchActiveEntityByUrnPrefix(
         server,
         'urn:decentraland:mumbai:collections-thirdparty:aThirdParty:winterCollection'

--- a/content/test/integration/controller/active-entity-by-content-hash.spec.ts
+++ b/content/test/integration/controller/active-entity-by-content-hash.spec.ts
@@ -28,18 +28,18 @@ loadStandaloneTestEnvironment()('Integration - Get Active Entities By Content Ha
     await server.startProgram()
 
     const deployResult = await buildDeployData(['0,0', '0,1'], {
-      metadata: {a:'this is just some metadata'},
+      metadata: { a: 'this is just some metadata' },
       contentPaths: ['test/integration/resources/some-binary-file.png']
     })
 
     const secondDeployResult = await buildDeployData(['0,3', '0,2'], {
-      metadata: {a:'this is just some metadata'},
+      metadata: { a: 'this is just some metadata' },
       contentPaths: ['test/integration/resources/some-binary-file.png']
     })
 
     // Deploy entity
-    await server.deploy(deployResult.deployData)
-    await server.deploy(secondDeployResult.deployData)
+    await server.deployEntity(deployResult.deployData)
+    await server.deployEntity(secondDeployResult.deployData)
 
     const result = await fetchActiveEntity(
       server,

--- a/content/test/integration/controller/deployment-fields.spec.ts
+++ b/content/test/integration/controller/deployment-fields.spec.ts
@@ -25,7 +25,7 @@ loadStandaloneTestEnvironment()('Integration - Deployment Fields', (testEnv) => 
     })
 
     // Deploy entity
-    await server.deploy(deployData)
+    await server.deployEntity(deployData)
 
     // Fetch deployments
     const withAudit = await fetchDeployment(DeploymentField.AUDIT_INFO)

--- a/content/test/integration/controller/deployment-pagination.spec.ts
+++ b/content/test/integration/controller/deployment-pagination.spec.ts
@@ -224,7 +224,7 @@ loadStandaloneTestEnvironment()('Integration - Deployment Pagination', (testEnv)
   async function deploy(...entities: EntityCombo[]): Promise<number[]> {
     const timestamps: number[] = []
     for (const { deployData } of entities) {
-      const deploymentResult = await server.deploy(deployData)
+      const deploymentResult = await server.deployEntity(deployData)
       timestamps.push(deploymentResult)
     }
     return timestamps

--- a/content/test/integration/logic/delete-unreferenced-files.spec.ts
+++ b/content/test/integration/logic/delete-unreferenced-files.spec.ts
@@ -12,92 +12,98 @@ import { getIntegrationResourcePathFor } from '../resources/get-resource-path'
 
 const tmpRootDir = mkdtempSync(path.join(os.tmpdir(), 'delete-unreferenced-files-'))
 
-loadStandaloneTestEnvironment({ [EnvironmentConfig.STORAGE_ROOT_FOLDER]: tmpRootDir })('Delete unreferenced files - ', (testEnv) => {
-  const fileContent = Buffer.from("some random content")
-  beforeEach(() => mkdirSync(tmpRootDir, { recursive: true }))
-  afterEach(() => rmSync(tmpRootDir, { recursive: true, force: false }))
+loadStandaloneTestEnvironment({ [EnvironmentConfig.STORAGE_ROOT_FOLDER]: tmpRootDir })(
+  'Delete unreferenced files - ',
+  (testEnv) => {
+    const fileContent = Buffer.from('some random content')
+    beforeEach(() => mkdirSync(tmpRootDir, { recursive: true }))
+    afterEach(() => rmSync(tmpRootDir, { recursive: true, force: false }))
 
-  testCaseWithComponents(
-    testEnv,
-    'should delete unreferenced snapshot',
-    async (components) => {
+    testCaseWithComponents(testEnv, 'should delete unreferenced snapshot', async (components) => {
       const unreferencedFileHash = 'a-hash'
       await components.storage.storeStream(unreferencedFileHash, bufferToStream(fileContent))
       expect(await components.storage.exist(unreferencedFileHash)).toBeTruthy()
       await deleteUnreferencedFiles(components)
       expect(await components.storage.exist(unreferencedFileHash)).toBeFalsy()
-    }
-  )
-
-  it('should not delete entity file', async () => {
-    const server = await testEnv.configServer()
-      .withConfig(EnvironmentConfig.DISABLE_SYNCHRONIZATION, true)
-      .andBuild()
-    const components = server.components
-    makeNoopValidator(components)
-    await server.startProgram()
-    const deployResult = await buildDeployData(['0,0', '0,1'], {
-      metadata: { a: 'this is just some metadata' }
     })
 
-    await server.deploy(deployResult.deployData)
+    it('should not delete entity file', async () => {
+      const server = await testEnv.configServer().withConfig(EnvironmentConfig.DISABLE_SYNCHRONIZATION, true).andBuild()
+      const components = server.components
+      makeNoopValidator(components)
+      await server.startProgram()
+      const deployResult = await buildDeployData(['0,0', '0,1'], {
+        metadata: { a: 'this is just some metadata' }
+      })
 
-    const contentsByHash: Map<string, Uint8Array> = await ServiceImpl.hashFiles(deployResult.deployData.files, deployResult.deployData.entityId)
-    const contentFileHashes = Array.from(contentsByHash.keys())
+      await server.deployEntity(deployResult.deployData)
 
-    await deleteUnreferencedFiles(components)
-    // There should be only one file, the entity file. Because it was deployed with no content files associated
-    expect(contentFileHashes.length).toBe(1)
-    expect(await components.storage.exist(contentFileHashes[0])).toBeTruthy()
-  })
+      const contentsByHash: Map<string, Uint8Array> = await ServiceImpl.hashFiles(
+        deployResult.deployData.files,
+        deployResult.deployData.entityId
+      )
+      const contentFileHashes = Array.from(contentsByHash.keys())
 
-  it('should not delete entity file and its content file', async () => {
-    const server = await testEnv.configServer().withConfig(EnvironmentConfig.DISABLE_SYNCHRONIZATION, true).andBuild()
-    const components = server.components
-    makeNoopValidator(components)
-    await server.startProgram()
-    const deployResult = await buildDeployData(['0,0', '0,1'], {
-      metadata: { a: 'this is just some metadata' },
-      contentPaths: [getIntegrationResourcePathFor('some-binary-file.png')]
+      await deleteUnreferencedFiles(components)
+      // There should be only one file, the entity file. Because it was deployed with no content files associated
+      expect(contentFileHashes.length).toBe(1)
+      expect(await components.storage.exist(contentFileHashes[0])).toBeTruthy()
     })
 
-    await server.deploy(deployResult.deployData)
+    it('should not delete entity file and its content file', async () => {
+      const server = await testEnv.configServer().withConfig(EnvironmentConfig.DISABLE_SYNCHRONIZATION, true).andBuild()
+      const components = server.components
+      makeNoopValidator(components)
+      await server.startProgram()
+      const deployResult = await buildDeployData(['0,0', '0,1'], {
+        metadata: { a: 'this is just some metadata' },
+        contentPaths: [getIntegrationResourcePathFor('some-binary-file.png')]
+      })
 
-    const contentsByHash: Map<string, Uint8Array> = await ServiceImpl.hashFiles(deployResult.deployData.files, deployResult.deployData.entityId)
-    const contentFileHashes = Array.from(contentsByHash.keys())
+      await server.deployEntity(deployResult.deployData)
 
-    await deleteUnreferencedFiles(components)
-    // There should be two files, the entity file and its content file.
-    expect(contentFileHashes.length).toBe(2)
-    for (const usedHash of contentFileHashes) {
-      expect(await components.storage.exist(usedHash)).toBeTruthy()
-    }
-  })
+      const contentsByHash: Map<string, Uint8Array> = await ServiceImpl.hashFiles(
+        deployResult.deployData.files,
+        deployResult.deployData.entityId
+      )
+      const contentFileHashes = Array.from(contentsByHash.keys())
 
-  it('should delete unreferenced files and not referenced ones', async () => {
-    const server = await testEnv.configServer().withConfig(EnvironmentConfig.DISABLE_SYNCHRONIZATION, true).andBuild()
-    const components = server.components
-    makeNoopValidator(components)
-    await server.startProgram()
-    const deployResult = await buildDeployData(['0,0', '0,1'], {
-      metadata: { a: 'this is just some metadata' },
-      contentPaths: [getIntegrationResourcePathFor('some-binary-file.png')]
+      await deleteUnreferencedFiles(components)
+      // There should be two files, the entity file and its content file.
+      expect(contentFileHashes.length).toBe(2)
+      for (const usedHash of contentFileHashes) {
+        expect(await components.storage.exist(usedHash)).toBeTruthy()
+      }
     })
 
-    await server.deploy(deployResult.deployData)
+    it('should delete unreferenced files and not referenced ones', async () => {
+      const server = await testEnv.configServer().withConfig(EnvironmentConfig.DISABLE_SYNCHRONIZATION, true).andBuild()
+      const components = server.components
+      makeNoopValidator(components)
+      await server.startProgram()
+      const deployResult = await buildDeployData(['0,0', '0,1'], {
+        metadata: { a: 'this is just some metadata' },
+        contentPaths: [getIntegrationResourcePathFor('some-binary-file.png')]
+      })
 
-    const contentsByHash: Map<string, Uint8Array> = await ServiceImpl.hashFiles(deployResult.deployData.files, deployResult.deployData.entityId)
-    const contentFileHashes = Array.from(contentsByHash.keys())
+      await server.deployEntity(deployResult.deployData)
 
-    const unreferencedFileHash = 'a-hash'
-    await components.storage.storeStream(unreferencedFileHash, bufferToStream(fileContent))
+      const contentsByHash: Map<string, Uint8Array> = await ServiceImpl.hashFiles(
+        deployResult.deployData.files,
+        deployResult.deployData.entityId
+      )
+      const contentFileHashes = Array.from(contentsByHash.keys())
 
-    await deleteUnreferencedFiles(components)
-    // There should be two files, the entity file and its content file.
-    expect(contentFileHashes.length).toBe(2)
-    for (const usedHash of contentFileHashes) {
-      expect(await components.storage.exist(usedHash)).toBeTruthy()
-    }
-    expect(await components.storage.exist(unreferencedFileHash)).toBeFalsy()
-  })
-})
+      const unreferencedFileHash = 'a-hash'
+      await components.storage.storeStream(unreferencedFileHash, bufferToStream(fileContent))
+
+      await deleteUnreferencedFiles(components)
+      // There should be two files, the entity file and its content file.
+      expect(contentFileHashes.length).toBe(2)
+      for (const usedHash of contentFileHashes) {
+        expect(await components.storage.exist(usedHash)).toBeTruthy()
+      }
+      expect(await components.storage.exist(unreferencedFileHash)).toBeFalsy()
+    })
+  }
+)

--- a/content/test/integration/syncronization/cluster-synchronization.spec.ts
+++ b/content/test/integration/syncronization/cluster-synchronization.spec.ts
@@ -39,7 +39,7 @@ loadTestEnvironment()('End 2 end synchronization tests', function (testEnv) {
     await assertDeploymentsAreReported(server2)
 
     // Deploy the entity to server 1
-    const deploymentTimestamp = await server1.deploy(deployData)
+    const deploymentTimestamp = await server1.deployEntity(deployData)
     const deployment = buildDeployment(deployData, entityBeingDeployed, deploymentTimestamp)
 
     // Assert that the entity was deployed on server 1
@@ -69,14 +69,14 @@ loadTestEnvironment()('End 2 end synchronization tests', function (testEnv) {
     )
 
     // Deploy entity 1 on server 1
-    const deploymentTimestamp1 = await server1.deploy(deployData1)
+    const deploymentTimestamp1 = await server1.deployEntity(deployData1)
     const deployment1 = buildDeployment(deployData1, entityBeingDeployed1, deploymentTimestamp1)
 
     // Wait for servers to sync
     await awaitUntil(() => assertDeploymentsAreReported(server2, deployment1))
 
     // Deploy entity 2 on server 2
-    const deploymentTimestamp2 = await server2.deploy(deployData2)
+    const deploymentTimestamp2 = await server2.deployEntity(deployData2)
     const deployment2 = buildDeployment(deployData2, entityBeingDeployed2, deploymentTimestamp2)
 
     // Assert that the entities were deployed on the servers
@@ -116,7 +116,7 @@ loadTestEnvironment()('End 2 end synchronization tests', function (testEnv) {
     )
 
     // Deploy entity 2
-    const deploymentTimestamp2 = await server2.deploy(deployData2)
+    const deploymentTimestamp2 = await server2.deployEntity(deployData2)
     const deployment2 = buildDeployment(deployData2, entity2, deploymentTimestamp2)
     await awaitUntil(() => assertDeploymentsAreReported(server2, deployment2))
 
@@ -128,10 +128,10 @@ loadTestEnvironment()('End 2 end synchronization tests', function (testEnv) {
     await Promise.all([server1.startProgram(), server3.startProgram()])
 
     // Deploy entities 1 and 3
-    const deploymentTimestamp1 = await server1.deploy(deployData1)
+    const deploymentTimestamp1 = await server1.deployEntity(deployData1)
     const deployment1 = buildDeployment(deployData1, entity1, deploymentTimestamp1)
 
-    const deploymentTimestamp3 = await server3.deploy(deployData3)
+    const deploymentTimestamp3 = await server3.deployEntity(deployData3)
     const deployment3 = buildDeployment(deployData3, entity3, deploymentTimestamp3)
 
     // Wait for servers 1 and 3 to sync

--- a/content/test/integration/syncronization/error-handling.spec.ts
+++ b/content/test/integration/syncronization/error-handling.spec.ts
@@ -60,7 +60,7 @@ loadTestEnvironment()('End 2 end - Error handling', (testEnv) => {
     })
 
     // Deploy entity 1
-    await server1.deploy(deployData1)
+    await server1.deployEntity(deployData1)
 
     // Cause sync failure
     // TODO!: Add sync failure
@@ -76,10 +76,10 @@ loadTestEnvironment()('End 2 end - Error handling', (testEnv) => {
     )
 
     // Deploy entity 2 on server 2
-    await server2.deploy(deployData2)
+    await server2.deployEntity(deployData2)
 
     // Fix entity 1 on server 2
-    await server2.deploy(deployData1, true)
+    await server2.deployEntity(deployData1, true)
 
     // Assert there are no more failed deployments
     const newFailedDeployments: FailedDeployment[] = await server2.getFailedDeployments()
@@ -100,7 +100,7 @@ loadTestEnvironment()('End 2 end - Error handling', (testEnv) => {
     const { deployData, controllerEntity } = await buildDeployData(['0,0', '0,1'], { metadata: { a: 'metadata' } })
 
     // Try to deploy the entity, and fail
-    await server1.deploy(deployData, true)
+    await server1.deployEntity(deployData, true)
 
     // asser that the entity got deployed
     await assertEntitiesAreActiveOnServer(server1, controllerEntity)
@@ -114,10 +114,10 @@ loadTestEnvironment()('End 2 end - Error handling', (testEnv) => {
     const { deployData } = await buildDeployData(['0,0', '0,1'], { metadata: { a: 'metadata' } })
 
     // Deploy the entity
-    const firstDeploymentDatetime = await server1.deploy(deployData)
+    const firstDeploymentDatetime = await server1.deployEntity(deployData)
 
     // Try to fix the entity, and fail
-    const fixDatetime = await server1.deploy(deployData, true)
+    const fixDatetime = await server1.deployEntity(deployData, true)
 
     // expect idempotent operation to return the datetime of the deploy
     expect(firstDeploymentDatetime).toEqual(fixDatetime)
@@ -138,7 +138,7 @@ loadTestEnvironment()('End 2 end - Error handling', (testEnv) => {
     })
 
     // Deploy the entity
-    const deploymentTimestamp = await server1.deploy(deployData)
+    const deploymentTimestamp = await server1.deployEntity(deployData)
 
     // Cause failure
     await causeOfFailure(entityBeingDeployed)
@@ -160,7 +160,7 @@ loadTestEnvironment()('End 2 end - Error handling', (testEnv) => {
     if (removeCauseOfFailure) await removeCauseOfFailure()
 
     // Fix the entity
-    await server2.deploy(deployData, true)
+    await server2.deployEntity(deployData, true)
 
     // Assert there are no more failed deployments
     const newFailedDeployments: FailedDeployment[] = await server2.getFailedDeployments()

--- a/content/test/integration/syncronization/failed-deployments.spec.ts
+++ b/content/test/integration/syncronization/failed-deployments.spec.ts
@@ -10,10 +10,10 @@ loadTestEnvironment()('Errors during sync', (testEnv) => {
   describe('Deploy an entity on server 1', function () {
     beforeEach(async function () {
       this.identity = createIdentity()
-        ;[this.server1, this.server2] = await testEnv
-          .configServer('2s')
-          .withConfig(EnvironmentConfig.DECENTRALAND_ADDRESS, this.identity.address)
-          .andBuildMany(2)
+      ;[this.server1, this.server2] = await testEnv
+        .configServer('2s')
+        .withConfig(EnvironmentConfig.DECENTRALAND_ADDRESS, this.identity.address)
+        .andBuildMany(2)
 
       // Start server1
       await this.server1.startProgram()
@@ -38,7 +38,7 @@ loadTestEnvironment()('Errors during sync', (testEnv) => {
       this.controllerEntity = entityCombo.controllerEntity
 
       // Deploy the entity
-      await this.server1.deploy(this.deployData)
+      await this.server1.deployEntity(this.deployData)
       await awaitUntil(() => assertEntitiesAreActiveOnServer(this.server1, this.controllerEntity))
 
       // Start server2
@@ -64,7 +64,7 @@ loadTestEnvironment()('Errors during sync', (testEnv) => {
         )
 
         // Fix the entity
-        await this.server2.deploy(this.deployData, true)
+        await this.server2.deployEntity(this.deployData, true)
       })
 
       it('is correctly deployed', async function () {
@@ -90,11 +90,11 @@ loadTestEnvironment()('Errors during sync', (testEnv) => {
           metadata: { a: 'metadata2' }
         })
         // Deploy entity 2 on server 2
-        await this.server2.deploy(this.anotherEntityCombo.deployData)
+        await this.server2.deployEntity(this.anotherEntityCombo.deployData)
         await awaitUntil(() => assertEntitiesAreActiveOnServer(this.server2, this.anotherEntityCombo.controllerEntity))
 
         // Fix the entity
-        await this.server2.deploy(this.deployData, true)
+        await this.server2.deployEntity(this.deployData, true)
       })
 
       it('the active entity is not modified', async function () {
@@ -116,7 +116,7 @@ loadTestEnvironment()('Errors during sync', (testEnv) => {
           metadata: { a: 'metadata2' }
         })
         // Deploy entity 2 on server 2
-        await this.server2.deploy(this.anotherEntityCombo.deployData)
+        await this.server2.deployEntity(this.anotherEntityCombo.deployData)
         await awaitUntil(() => assertEntitiesAreActiveOnServer(this.server2, this.anotherEntityCombo.controllerEntity))
         await awaitUntil(() =>
           assertDeploymentFailed(this.server2, FailureReason.DEPLOYMENT_ERROR, this.controllerEntity)
@@ -169,7 +169,7 @@ loadTestEnvironment()('Errors during sync', (testEnv) => {
 
     it('fails', async function () {
       await assertDeploymentFailsWith(
-        () => this.server1.deploy(this.deployData, true),
+        () => this.server1.deployEntity(this.deployData, true),
         'You are trying to fix an entity that is not marked as failed'
       )
     })

--- a/content/test/integration/syncronization/node-onboarding.spec.ts
+++ b/content/test/integration/syncronization/node-onboarding.spec.ts
@@ -39,11 +39,11 @@ loadTestEnvironment()('End 2 end - Node onboarding', function (testEnv) {
     )
 
     // Deploy entity1 on server 1
-    const deploymentTimestamp1 = await server1.deploy(deployData1)
+    const deploymentTimestamp1 = await server1.deployEntity(deployData1)
     const deployment1 = buildDeployment(deployData1, entity1, deploymentTimestamp1)
 
     // Deploy entity2 on server 2
-    const deploymentTimestamp2 = await server2.deploy(deployData2)
+    const deploymentTimestamp2 = await server2.deployEntity(deployData2)
     const deployment2 = buildDeployment(deployData2, entity2, deploymentTimestamp2)
 
     // Wait for servers to sync and assert servers 1 and 2 are synced
@@ -75,7 +75,7 @@ loadTestEnvironment()('End 2 end - Node onboarding', function (testEnv) {
     const entityContentHash = entity.content![0].hash
 
     // Deploy entity on server 1
-    const deploymentTimestamp = await server1.deploy(deployData)
+    const deploymentTimestamp = await server1.deployEntity(deployData)
     const deployment = buildDeployment(deployData, entity, deploymentTimestamp)
 
     // Wait for sync and assert servers 1 and 2 are synced

--- a/content/test/integration/upload-and-download.spec.ts
+++ b/content/test/integration/upload-and-download.spec.ts
@@ -22,14 +22,16 @@ loadStandaloneTestEnvironment()('End 2 end deploy test', (testEnv) => {
 
   it('When a user tries to deploy the same entity twice, then an exception is thrown', async () => {
     // Build data for deployment
-    const { deployData } = await buildDeployData([POINTER0, POINTER1], { metadata: { a: 'this is just some metadata"' } })
+    const { deployData } = await buildDeployData([POINTER0, POINTER1], {
+      metadata: { a: 'this is just some metadata"' }
+    })
 
     // Execute first deploy
-    const ret1 = await server.deploy(deployData)
+    const ret1 = await server.deployEntity(deployData)
 
     await sleep(100)
 
-    const ret2 = await server.deploy(deployData)
+    const ret2 = await server.deployEntity(deployData)
 
     // Try to re deploy, and don't fail since it is an idempotent operation
     expect(ret1).toEqual(ret2)
@@ -44,7 +46,7 @@ loadStandaloneTestEnvironment()('End 2 end deploy test', (testEnv) => {
       contentPaths: ['test/integration/resources/some-binary-file.png', 'test/integration/resources/some-text-file.txt']
     })
 
-    const creationTimestamp = await server.deploy(deployData)
+    const creationTimestamp = await server.deployEntity(deployData)
     const deployment = buildDeployment(deployData, entityBeingDeployed, creationTimestamp)
     const deltaTimestamp = Date.now() - creationTimestamp
     expect(deltaTimestamp).toBeLessThanOrEqual(100)

--- a/lambdas/package.json
+++ b/lambdas/package.json
@@ -24,7 +24,7 @@
     "@well-known-components/thegraph-component": "^1.4.1",
     "compression": "1.7.4",
     "cors": "2.8.5",
-    "dcl-catalyst-client": "^13.0.13",
+    "dcl-catalyst-client": "^14.0.1",
     "destroy": "1.2.0",
     "eth-connect": "^6.0.3",
     "express": "4.18.1",

--- a/lambdas/src/apis/collections/controllers/collections.ts
+++ b/lambdas/src/apis/collections/controllers/collections.ts
@@ -1,13 +1,4 @@
-import {
-  BodyShape,
-  ChainId,
-  Emote,
-  Entity,
-  EntityType,
-  StandardProps,
-  Wearable,
-  WearableRepresentation
-} from '@dcl/schemas'
+import { BodyShape, ChainId, Emote, Entity, StandardProps, Wearable, WearableRepresentation } from '@dcl/schemas'
 import { Request, Response } from 'express'
 import { SmartContentClient } from '../../../utils/SmartContentClient'
 import { TheGraphClient } from '../../../utils/TheGraphClient'
@@ -189,7 +180,7 @@ async function internalContents(
 }
 
 async function fetchEntity(client: SmartContentClient, urn: string): Promise<Entity | undefined> {
-  const entities: Entity[] = await client.fetchEntitiesByPointers(EntityType.WEARABLE, [urn])
+  const entities: Entity[] = await client.fetchEntitiesByPointers([urn])
   return entities && entities.length > 0 && entities[0].metadata ? entities[0] : undefined
 }
 

--- a/lambdas/src/apis/collections/controllers/emotes.ts
+++ b/lambdas/src/apis/collections/controllers/emotes.ts
@@ -1,4 +1,3 @@
-import { EntityType } from '@dcl/schemas'
 import { Request, Response } from 'express'
 import log4js from 'log4js'
 import { findThirdPartyItemUrns } from '../../../logic/third-party-urn-finder'
@@ -167,7 +166,7 @@ async function fetchEmotes(emoteUrns: string[], client: SmartContentClient): Pro
   if (emoteUrns.length === 0) {
     return []
   }
-  const entities = await client.fetchEntitiesByPointers(EntityType.EMOTE, emoteUrns)
+  const entities = await client.fetchEntitiesByPointers(emoteUrns)
   const emotes = entities.map((entity) => translateEntityIntoEmote(client, entity))
   return emotes.sort((emote1, emote2) => emote1.id.toLowerCase().localeCompare(emote2.id.toLowerCase()))
 }

--- a/lambdas/src/apis/collections/controllers/wearables.ts
+++ b/lambdas/src/apis/collections/controllers/wearables.ts
@@ -1,4 +1,3 @@
-import { EntityType } from '@dcl/schemas'
 import { Request, Response } from 'express'
 import log4js from 'log4js'
 import { findThirdPartyItemUrns } from '../../../logic/third-party-urn-finder'
@@ -201,7 +200,7 @@ async function fetchWearables(wearableUrns: string[], client: SmartContentClient
     return []
   }
 
-  const entities = await client.fetchEntitiesByPointers(EntityType.WEARABLE, wearableUrns)
+  const entities = await client.fetchEntitiesByPointers(wearableUrns)
   const wearables = entities
     .map((entity) => translateEntityIntoWearable(client, entity))
     .filter((wearable): wearable is LambdasWearable => !!wearable)

--- a/lambdas/src/apis/collections/off-chain/OffChainWearablesManager.ts
+++ b/lambdas/src/apis/collections/off-chain/OffChainWearablesManager.ts
@@ -1,4 +1,3 @@
-import { EntityType } from '@dcl/schemas'
 import { SmartContentClient } from '../../../utils/SmartContentClient'
 import { TimeRefreshedDataHolder } from '../../../utils/TimeRefreshedDataHolder'
 import { ItemFilters, LambdasWearable, WearableId } from '../types'
@@ -61,7 +60,8 @@ export class OffChainWearablesManager {
     const localDefinitions: LocalOffChainWearables = []
 
     for (const [collectionId, wearableIds] of Object.entries(collections)) {
-      const entities = await client.fetchEntitiesByPointers(EntityType.WEARABLE, wearableIds)
+      const entities = await client.fetchEntitiesByPointers(wearableIds)
+
       entities
         .map((entity) => translateEntityIntoWearable(client, entity))
         .filter((wearable): wearable is LambdasWearable => !!wearable)

--- a/lambdas/src/apis/explore/controllers/explore.ts
+++ b/lambdas/src/apis/explore/controllers/explore.ts
@@ -1,4 +1,4 @@
-import { Entity, EntityType, EthAddress } from '@dcl/schemas'
+import { Entity, EthAddress } from '@dcl/schemas'
 import { Request, Response } from 'express'
 import fetch from 'node-fetch'
 import { DAOCache } from '../../../service/dao/DAOCache'
@@ -143,7 +143,7 @@ async function fetchHotScenesData(daoCache: DAOCache, contentClient: SmartConten
   const tiles = getOccupiedTiles(statuses)
 
   if (tiles.length > 0) {
-    const scenes = await contentClient.fetchEntitiesByPointers(EntityType.SCENE as any, tiles)
+    const scenes = await contentClient.fetchEntitiesByPointers(tiles)
 
     const hotScenes: HotSceneInfo[] = scenes.map((scene) =>
       getHotSceneRecordFor(scene, contentClient.getExternalContentServerUrl())

--- a/lambdas/src/apis/profiles/controllers/profiles.ts
+++ b/lambdas/src/apis/profiles/controllers/profiles.ts
@@ -1,5 +1,5 @@
 import { EthAddress } from '@dcl/crypto'
-import { Entity, EntityType, Profile } from '@dcl/schemas'
+import { Entity, Profile } from '@dcl/schemas'
 import { NextFunction, Request, RequestHandler, Response } from 'express'
 import log4js from 'log4js'
 import { ThirdPartyAssetFetcher } from '../../../ports/third-party/third-party-fetcher'
@@ -178,7 +178,7 @@ export async function fetchProfiles(
   ifModifiedSinceTimestamp?: number | undefined
 ): Promise<ProfileMetadata[] | undefined> {
   try {
-    const profilesEntities: Entity[] = await contentClient.fetchEntitiesByPointers(EntityType.PROFILE, ethAddresses)
+    const profilesEntities: Entity[] = await contentClient.fetchEntitiesByPointers(ethAddresses)
 
     // Avoid querying profiles if there wasn't any new deployment
     if (

--- a/lambdas/src/apis/status/health.ts
+++ b/lambdas/src/apis/status/health.ts
@@ -1,4 +1,3 @@
-import { EntityType } from '@dcl/schemas'
 import { Logger } from 'log4js'
 import ms from 'ms'
 import { SmartContentClient } from '../../utils/SmartContentClient'
@@ -47,7 +46,7 @@ export async function refreshContentServerStatus(
 
 async function timeContentDeployments(contentService: SmartContentClient): Promise<number> {
   const startingTime = Date.now()
-  await contentService.fetchEntitiesByPointers(EntityType.SCENE, ['0,0'])
+  await contentService.fetchEntitiesByPointers(['0,0'])
   const endingTime = Date.now()
 
   return endingTime - startingTime

--- a/lambdas/src/utils/SmartContentClient.ts
+++ b/lambdas/src/utils/SmartContentClient.ts
@@ -7,13 +7,7 @@ import {
   DeploymentData,
   DeploymentPreparationData
 } from 'dcl-catalyst-client'
-import {
-  AvailableContentResult,
-  CompleteRequestOptions,
-  Fetcher,
-  RequestOptions,
-  ServerStatus
-} from 'dcl-catalyst-commons'
+import { CompleteRequestOptions, Fetcher, RequestOptions, ServerStatus } from 'dcl-catalyst-commons'
 import future, { IFuture } from 'fp-future'
 import log4js from 'log4js'
 /**
@@ -28,19 +22,19 @@ export class SmartContentClient implements ContentAPI {
 
   constructor(private readonly externalContentServerUrl: string) {}
 
-  async fetchEntitiesByPointers(type: EntityType, pointers: string[], options?: RequestOptions): Promise<Entity[]> {
+  async fetchEntitiesByPointers(pointers: string[], options?: RequestOptions): Promise<Entity[]> {
     const client = await this.getClient()
-    return client.fetchEntitiesByPointers(type, pointers, options)
+    return client.fetchEntitiesByPointers(pointers, options)
   }
 
-  async fetchEntitiesByIds(type: EntityType, ids: string[], options?: RequestOptions): Promise<Entity[]> {
+  async fetchEntitiesByIds(ids: string[], options?: RequestOptions): Promise<Entity[]> {
     const client = await this.getClient()
-    return client.fetchEntitiesByIds(type, ids, options)
+    return client.fetchEntitiesByIds(ids, options)
   }
 
-  async fetchEntityById(type: EntityType, id: string, options?: RequestOptions): Promise<Entity> {
+  async fetchEntityById(id: string, options?: RequestOptions): Promise<Entity> {
     const client = await this.getClient()
-    return client.fetchEntityById(type, id, options)
+    return client.fetchEntityById(id, options)
   }
 
   async fetchAuditInfo(type: EntityType, id: string, options?: RequestOptions) {
@@ -95,12 +89,6 @@ export class SmartContentClient implements ContentAPI {
     const contentUrl = (await this.getClient()).getContentUrl()
     const fetcher = new Fetcher()
     return this.onlyKnownHeaders(await fetcher.fetchPipe(`${contentUrl}/contents/${contentHash}`, responseTo, options))
-  }
-
-  async isContentAvailable(cids: string[], options?: RequestOptions): Promise<AvailableContentResult> {
-    // TODO: Upgrade catalyst-client package to avoid implementing this
-    // To be done as soon as the PR on catalyst-client is merged
-    throw new Error('New deployments are currently not supported')
   }
 
   deployEntity(deployData: DeploymentData, fix?: boolean, options?: RequestOptions): Promise<number> {

--- a/lambdas/test/apis/collections/controller/wearables/wearables.spec.ts
+++ b/lambdas/test/apis/collections/controller/wearables/wearables.spec.ts
@@ -54,7 +54,7 @@ it(`When on-chain ids are requested, then content servers is queried, but subgra
 
   expectWearablesToBe(response, OFF_CHAIN_WEARABLE_ID, ON_CHAIN_WEARABLE_ID)
   expect(response.lastId).toBeUndefined()
-  verify(contentServerMock.fetchEntitiesByPointers(EntityType.WEARABLE, deepEqual([ON_CHAIN_WEARABLE_ID]))).once()
+  verify(contentServerMock.fetchEntitiesByPointers(deepEqual([ON_CHAIN_WEARABLE_ID]))).once()
   verify(graphClientMock.findWearableUrnsByFilters(anything(), anything())).never()
 })
 
@@ -113,7 +113,7 @@ it(`When there is more data than the one returned, then last id is included`, as
   expect(response.lastId).toEqual(OFF_CHAIN_WEARABLE_ID)
   verify(offChainMock.find(filters, undefined)).once()
   verify(graphClientMock.findWearableUrnsByFilters(filters, deepEqual({ limit: 0, lastId: undefined }))).once()
-  verify(contentServerMock.fetchEntitiesByPointers(EntityType.WEARABLE, deepEqual([ON_CHAIN_WEARABLE_ID]))).once()
+  verify(contentServerMock.fetchEntitiesByPointers(deepEqual([ON_CHAIN_WEARABLE_ID]))).once()
 })
 
 function emptyContentServer() {
@@ -156,7 +156,7 @@ function contentServerThatReturns(id?: WearableId) {
     }
   }
   const mockedClient = mock(SmartContentClient)
-  when(mockedClient.fetchEntitiesByPointers(anything(), anything())).thenResolve(id ? [entity] : [])
+  when(mockedClient.fetchEntitiesByPointers(anything())).thenResolve(id ? [entity] : [])
   return { instance: instance(mockedClient), mock: mockedClient }
 }
 

--- a/lambdas/test/apis/collections/off-chain/OffChainWearablesManager.spec.ts
+++ b/lambdas/test/apis/collections/off-chain/OffChainWearablesManager.spec.ts
@@ -15,7 +15,6 @@ const COLLECTIONS = {
 }
 
 describe('OffChainWearablesManager', () => {
-
   beforeEach(() => jest.useFakeTimers())
 
   afterAll(() => jest.useRealTimers())
@@ -54,11 +53,15 @@ describe('OffChainWearablesManager', () => {
     const t1 = 1
     const t2 = 2
 
-    when(contentClientMock.fetchEntitiesByPointers(anything(), objectContaining([WEARABLE_ID_3])))
+    when(contentClientMock.fetchEntitiesByPointers(objectContaining([WEARABLE_ID_3])))
       .thenResolve([buildEntityWithTimestampInMetadata(WEARABLE_ID_3, t1)])
       .thenResolve([buildEntityWithTimestampInMetadata(WEARABLE_ID_3, t2)])
 
-    const manager = new OffChainWearablesManager({ client: contentClient, collections: { [COLLECTION_ID_2]: [WEARABLE_ID_3] }, refreshTime: '2s' })
+    const manager = new OffChainWearablesManager({
+      client: contentClient,
+      collections: { [COLLECTION_ID_2]: [WEARABLE_ID_3] },
+      refreshTime: '2s'
+    })
 
     const firstWearables = await manager.find({ collectionIds: [COLLECTION_ID_2] })
     expect(firstWearables.length).toBe(1)
@@ -131,12 +134,12 @@ function assertReturnWearablesAre(wearables: LambdasWearable[], ...ids: Wearable
 }
 
 function assertContentServerWasCalledOnceWithIds(contentClient: SmartContentClient, ...ids: WearableId[]) {
-  verify(contentClient.fetchEntitiesByPointers(EntityType.WEARABLE, deepEqual(ids))).once()
+  verify(contentClient.fetchEntitiesByPointers(deepEqual(ids))).once()
 }
 
 function contentServer() {
   const mockedClient = mock(SmartContentClient)
-  when(mockedClient.fetchEntitiesByPointers(anything(), anything())).thenCall((_, ids) =>
+  when(mockedClient.fetchEntitiesByPointers(anything())).thenCall((ids) =>
     Promise.resolve(ids.map((id) => buildEntity(id)))
   )
   return { instance: instance(mockedClient), mock: mockedClient }

--- a/lambdas/test/apis/profiles/controller/profiles.spec.ts
+++ b/lambdas/test/apis/profiles/controller/profiles.spec.ts
@@ -30,7 +30,15 @@ describe('profiles', () => {
     const wearablesOwnership = ownedNFTs(WearablesOwnership, SOME_ADDRESS, WEARABLE_ID_1)
     const emotesOwnership = ownedNFTs(EmotesOwnership, SOME_ADDRESS, WEARABLE_ID_1)
 
-    const profiles = (await pfs.fetchProfiles([SOME_ADDRESS], theGraphClient, client, ensOwnership, wearablesOwnership, emotesOwnership, thirdPartyFetcher))!
+    const profiles = (await pfs.fetchProfiles(
+      [SOME_ADDRESS],
+      theGraphClient,
+      client,
+      ensOwnership,
+      wearablesOwnership,
+      emotesOwnership,
+      thirdPartyFetcher
+    ))!
 
     expect(profiles.length).toEqual(1)
     expect(profiles[0]).toEqual(metadata)
@@ -43,7 +51,15 @@ describe('profiles', () => {
     const wearablesOwnership = noNFTs(WearablesOwnership)
     const emotesOwnership = ownedNFTs(EmotesOwnership, SOME_ADDRESS, WEARABLE_ID_1)
 
-    const profiles = (await pfs.fetchProfiles([SOME_ADDRESS], theGraphClient, client, ensOwnership, wearablesOwnership, emotesOwnership, thirdPartyFetcher))!
+    const profiles = (await pfs.fetchProfiles(
+      [SOME_ADDRESS],
+      theGraphClient,
+      client,
+      ensOwnership,
+      wearablesOwnership,
+      emotesOwnership,
+      thirdPartyFetcher
+    ))!
 
     expect(profiles.length).toEqual(1)
     expect(profiles[0].avatars[0].name).toEqual(SOME_NAME)
@@ -57,7 +73,15 @@ describe('profiles', () => {
     const wearablesOwnership = noNFTs(WearablesOwnership)
     const emotesOwnership = ownedNFTs(EmotesOwnership, SOME_ADDRESS, WEARABLE_ID_1)
 
-    const profiles = (await pfs.fetchProfiles([SOME_ADDRESS], theGraphClient, client, ensOwnership, wearablesOwnership, emotesOwnership, thirdPartyFetcher))!
+    const profiles = (await pfs.fetchProfiles(
+      [SOME_ADDRESS],
+      theGraphClient,
+      client,
+      ensOwnership,
+      wearablesOwnership,
+      emotesOwnership,
+      thirdPartyFetcher
+    ))!
 
     expect(profiles.length).toEqual(1)
     expect(profiles[0].avatars[0].avatar.wearables.length).toEqual(0)
@@ -72,7 +96,15 @@ describe('profiles', () => {
     tpWearablesOwnership.mockReturnValue(Promise.resolve(new Map([[SOME_ADDRESS, [TPW_ID]]])))
     const emotesOwnership = ownedNFTs(EmotesOwnership, SOME_ADDRESS, WEARABLE_ID_1)
 
-    const profiles = (await pfs.fetchProfiles([SOME_ADDRESS], theGraphClient, client, ensOwnership, wearablesOwnership, emotesOwnership, thirdPartyFetcher))!
+    const profiles = (await pfs.fetchProfiles(
+      [SOME_ADDRESS],
+      theGraphClient,
+      client,
+      ensOwnership,
+      wearablesOwnership,
+      emotesOwnership,
+      thirdPartyFetcher
+    ))!
 
     expect(profiles.length).toEqual(1)
     expect(profiles[0]).toEqual(metadata)
@@ -90,7 +122,15 @@ describe('profiles', () => {
     tpUrnFinderMock.mockReturnValue(Promise.resolve([TPW_ID]))
     const emotesOwnership = ownedNFTs(EmotesOwnership, SOME_ADDRESS, WEARABLE_ID_1)
 
-    const profiles = (await pfs.fetchProfiles([SOME_ADDRESS], theGraphClient, client, ensOwnership, wearablesOwnership, emotesOwnership, thirdPartyFetcher))!
+    const profiles = (await pfs.fetchProfiles(
+      [SOME_ADDRESS],
+      theGraphClient,
+      client,
+      ensOwnership,
+      wearablesOwnership,
+      emotesOwnership,
+      thirdPartyFetcher
+    ))!
 
     expect(profiles.length).toEqual(1)
     metadata.avatars[0].avatar.wearables = [TPW_ID]
@@ -106,7 +146,15 @@ describe('profiles', () => {
     tpWearablesOwnership.mockReturnValue(Promise.resolve(new Map()))
     const emotesOwnership = ownedNFTs(EmotesOwnership, SOME_ADDRESS, WEARABLE_ID_1)
 
-    const profiles = (await pfs.fetchProfiles([SOME_ADDRESS], theGraphClient, client, ensOwnership, wearablesOwnership, emotesOwnership, thirdPartyFetcher))!
+    const profiles = (await pfs.fetchProfiles(
+      [SOME_ADDRESS],
+      theGraphClient,
+      client,
+      ensOwnership,
+      wearablesOwnership,
+      emotesOwnership,
+      thirdPartyFetcher
+    ))!
 
     expect(profiles.length).toEqual(1)
     expect(profiles[0].avatars[0].avatar.wearables.length).toEqual(0)
@@ -118,7 +166,15 @@ describe('profiles', () => {
     const wearablesOwnership = noNFTs(WearablesOwnership)
     const emotesOwnership = ownedNFTs(EmotesOwnership, SOME_ADDRESS, WEARABLE_ID_1)
 
-    const profiles = (await pfs.fetchProfiles([SOME_ADDRESS], theGraphClient, client, ensOwnership, wearablesOwnership, emotesOwnership, thirdPartyFetcher))!
+    const profiles = (await pfs.fetchProfiles(
+      [SOME_ADDRESS],
+      theGraphClient,
+      client,
+      ensOwnership,
+      wearablesOwnership,
+      emotesOwnership,
+      thirdPartyFetcher
+    ))!
 
     expect(profiles.length).toEqual(0)
   })
@@ -130,7 +186,15 @@ describe('profiles', () => {
     const wearablesOwnership = noNFTs(WearablesOwnership)
     const emotesOwnership = ownedNFTs(EmotesOwnership, SOME_ADDRESS, WEARABLE_ID_1)
 
-    const profiles = (await pfs.fetchProfiles([SOME_ADDRESS], theGraphClient, client, ensOwnership, wearablesOwnership, emotesOwnership, thirdPartyFetcher))!
+    const profiles = (await pfs.fetchProfiles(
+      [SOME_ADDRESS],
+      theGraphClient,
+      client,
+      ensOwnership,
+      wearablesOwnership,
+      emotesOwnership,
+      thirdPartyFetcher
+    ))!
 
     expect(profiles.length).toEqual(1)
     expect(profiles[0].avatars[0].avatar.snapshots.aKey).toEqual(`${EXTERNAL_URL}/contents/aHash`)
@@ -146,7 +210,15 @@ describe('profiles', () => {
     const wearablesOwnership = noNFTs(WearablesOwnership)
     const emotesOwnership = ownedNFTs(EmotesOwnership, SOME_ADDRESS, WEARABLE_ID_1)
 
-    const profiles = (await pfs.fetchProfiles([SOME_ADDRESS], theGraphClient, client, ensOwnership, wearablesOwnership, emotesOwnership, thirdPartyFetcher))!
+    const profiles = (await pfs.fetchProfiles(
+      [SOME_ADDRESS],
+      theGraphClient,
+      client,
+      ensOwnership,
+      wearablesOwnership,
+      emotesOwnership,
+      thirdPartyFetcher
+    ))!
 
     expect(profiles.length).toEqual(1)
     expect(profiles[0].avatars[0].avatar.snapshots.aKey).toEqual(`${EXTERNAL_URL}/contents/fileHash`)
@@ -159,8 +231,30 @@ describe('profiles', () => {
     const wearablesOwnership = ownedNFTs(WearablesOwnership, SOME_ADDRESS, WEARABLE_ID_1)
     const emotesOwnership = ownedNFTs(EmotesOwnership, SOME_ADDRESS, WEARABLE_ID_1)
 
-    expect(await pfs.fetchProfiles([SOME_ADDRESS], theGraphClient, client, ensOwnership, wearablesOwnership, emotesOwnership, thirdPartyFetcher, 2000)).toBe(undefined)
-    expect(await pfs.fetchProfiles([SOME_ADDRESS], theGraphClient, client, ensOwnership, wearablesOwnership, emotesOwnership, thirdPartyFetcher, 3000)).toBe(undefined)
+    expect(
+      await pfs.fetchProfiles(
+        [SOME_ADDRESS],
+        theGraphClient,
+        client,
+        ensOwnership,
+        wearablesOwnership,
+        emotesOwnership,
+        thirdPartyFetcher,
+        2000
+      )
+    ).toBe(undefined)
+    expect(
+      await pfs.fetchProfiles(
+        [SOME_ADDRESS],
+        theGraphClient,
+        client,
+        ensOwnership,
+        wearablesOwnership,
+        emotesOwnership,
+        thirdPartyFetcher,
+        3000
+      )
+    ).toBe(undefined)
   })
 })
 
@@ -171,7 +265,7 @@ function profileWith(
     wearables?: string[]
     snapshots?: Record<string, string>
     content?: { file: string; hash: string }
-    emotes?: { slot: number, urn: string }[]
+    emotes?: { slot: number; urn: string }[]
   }
 ): { entity: Entity; metadata: pfs.ProfileMetadata } {
   const metadata = {
@@ -210,7 +304,7 @@ function profileWith(
 
 function contentServerThatReturns(profile?: Entity): SmartContentClient {
   const mockedClient = mock(SmartContentClient)
-  when(mockedClient.fetchEntitiesByPointers(anything(), anything())).thenResolve(profile ? [profile] : [])
+  when(mockedClient.fetchEntitiesByPointers(anything())).thenResolve(profile ? [profile] : [])
   when(mockedClient.getExternalContentServerUrl()).thenReturn(EXTERNAL_URL)
   return instance(mockedClient)
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -371,10 +371,19 @@
     eth-connect "^6.0.3"
     ethereum-cryptography "^1.0.3"
 
-"@dcl/hashing@1.1.1", "@dcl/hashing@^1.0.0", "@dcl/hashing@^1.1.0", "@dcl/hashing@^1.1.1":
+"@dcl/hashing@1.1.1", "@dcl/hashing@^1.0.0", "@dcl/hashing@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@dcl/hashing/-/hashing-1.1.1.tgz#4ecbe9fba3e4f34eebed097eb0080c673a90d3fc"
   integrity sha512-0IjZMuJij09P61C1BZkMZKJVDuCbzkINjkM6jRNqy/tuypa4hyzF/v0SoI8Ob7WvZmZ6VJuSmfnY1cPBfEykcg==
+  dependencies:
+    ethereum-cryptography "^1.0.3"
+    ipfs-unixfs-importer "^7.0.3"
+    multiformats "^9.6.3"
+
+"@dcl/hashing@^1.1.0":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@dcl/hashing/-/hashing-1.1.2.tgz#f72334eae2fdafac8b69299b297ff6a0c37b5544"
+  integrity sha512-edCbqZH4ZEHpacY6LIn/D+qRx2cSmRAjfJIgSNifURLKXQ0LWXc8bVzfhlM3R9D+RLyQIgddWObCCXoa6YS+eA==
   dependencies:
     ethereum-cryptography "^1.0.3"
     ipfs-unixfs-importer "^7.0.3"
@@ -2692,10 +2701,10 @@ date-format@^4.0.10, date-format@^4.0.13:
   resolved "https://registry.yarnpkg.com/date-format/-/date-format-4.0.13.tgz#87c3aab3a4f6f37582c5f5f63692d2956fa67890"
   integrity sha512-bnYCwf8Emc3pTD8pXnre+wfnjGtfi5ncMDKy7+cWZXbmRAsdWkOQHrfC1yz/KiwP5thDp2kCHWYWKBX4HP1hoQ==
 
-dcl-catalyst-client@^13.0.13:
-  version "13.0.13"
-  resolved "https://registry.yarnpkg.com/dcl-catalyst-client/-/dcl-catalyst-client-13.0.13.tgz#51fab9f7d76b768a0fe98e9a3a34a3c83c3533cc"
-  integrity sha512-U7fX4QlYx7PN7gI8TGf+O3OegFHMuAWfbignd/P8Mwlim8t/uJ3hAMf2yV3iCEZyUg0O266oHZUkOlVyPWj+bQ==
+dcl-catalyst-client@^14.0.1:
+  version "14.0.1"
+  resolved "https://registry.yarnpkg.com/dcl-catalyst-client/-/dcl-catalyst-client-14.0.1.tgz#b00219e2e8c399df5ecefaa222fc52c71914f247"
+  integrity sha512-ImHRvHmGZKG61w0ijyEvbnT38hXr0+Qt7EtGxHxZWQaGzyzHAAUHmFWjz5VkxH5hI/jXfZK9owWGvVvDiWmB7A==
   dependencies:
     "@dcl/catalyst-contracts" "^3.0.0"
     "@dcl/hashing" "^1.1.0"
@@ -2706,9 +2715,9 @@ dcl-catalyst-client@^13.0.13:
     form-data "^4.0.0"
 
 dcl-catalyst-commons@^9.0.6:
-  version "9.0.13"
-  resolved "https://registry.yarnpkg.com/dcl-catalyst-commons/-/dcl-catalyst-commons-9.0.13.tgz#5525ab6d0d95219b7d8c6b73cdb98852eb135b3d"
-  integrity sha512-FXX92KhRu7En6ryo/V57V4Ti6KnZB1v5eG1VjxSX6NmH5f1W9qWLLPUFyZ1KBh1GcZgJz9+GdDwaO1ErSW5b8w==
+  version "9.0.14"
+  resolved "https://registry.yarnpkg.com/dcl-catalyst-commons/-/dcl-catalyst-commons-9.0.14.tgz#f781e5ab8a83fbc329ad6ce9d88d2cdda96bf9b1"
+  integrity sha512-2XtbUEJJiN79oiKRlXCNZQP9ZlN3TPkX150p2p4Yci0MRsGvs5/9bokXeKw4KcBIbprmyI5oP0RVZLGu3YoXNw==
   dependencies:
     "@dcl/schemas" "^5.4.2"
     abort-controller "^3.0.0"


### PR DESCRIPTION
## Description

This PR relates to [Issue (#1119)](https://github.com/decentraland/catalyst/issues/1119) and [Catalyst-Client PR](https://github.com/decentraland/catalyst-client/pull/295). It implements the functions removed from the shared client exposed by `Catalyst Client` since they are only being used in this project.

This depends on the version upgrade to be done once the PR on Catalyst-Client is merged.

[Issue (#1119)](https://github.com/decentraland/catalyst/issues/1119) 

## Changes

- No behavior changes expected.
