### PR TITLE
fix: pointers and ids retrieval from content by normalizing cases

### DIFF
--- a/content/src/ports/activeEntities.ts
+++ b/content/src/ports/activeEntities.ts
@@ -246,8 +246,8 @@ export const createActiveEntitiesComponent = (
     clear,
 
     getCachedEntity: (idOrPointer) => {
-      if (cache.has(idOrPointer)) {
-        const cachedEntity = cache.get(idOrPointer)
+      if (cache.has(idOrPointer.toLowerCase())) {
+        const cachedEntity = cache.get(idOrPointer.toLowerCase())
         return isEntityPresent(cachedEntity) ? cachedEntity.id : cachedEntity
       }
       return entityIdByPointers.get(idOrPointer.toLowerCase())

--- a/content/src/ports/activeEntities.ts
+++ b/content/src/ports/activeEntities.ts
@@ -80,15 +80,15 @@ export const createActiveEntitiesComponent = (
   }
 
   const setPreviousEntityAsNone = (pointer: string): void => {
-    if (entityIdByPointers.has(pointer.toLowerCase())) {
+    if (entityIdByPointers.has(pointer)) {
       // pointer now have a different active entity, let's update the old one
-      const entityId = entityIdByPointers.get(pointer.toLowerCase())
+      const entityId = entityIdByPointers.get(pointer)
       if (isPointingToEntity(entityId)) {
         const entity = cache.get(entityId) // it should be present
         if (isEntityPresent(entity)) {
           cache.set(entityId, 'NOT_ACTIVE_ENTITY')
           for (const pointer of entity.pointers) {
-            entityIdByPointers.set(pointer.toLowerCase(), 'NOT_ACTIVE_ENTITY')
+            entityIdByPointers.set(pointer, 'NOT_ACTIVE_ENTITY')
           }
         }
       }
@@ -104,9 +104,9 @@ export const createActiveEntitiesComponent = (
    * useful to retrieve entities by pointers
    */
   const update = async (pointers: string[], entity: Entity | NotActiveEntity): Promise<void> => {
-    for (const pointer of pointers) {
+    for (const pointer of pointers.map((pointer) => pointer.toLowerCase())) {
       setPreviousEntityAsNone(pointer)
-      entityIdByPointers.set(pointer.toLowerCase(), isEntityPresent(entity) ? entity.id : entity)
+      entityIdByPointers.set(pointer, isEntityPresent(entity) ? entity.id : entity)
     }
     if (isEntityPresent(entity)) {
       cache.set(entity.id, entity)
@@ -133,8 +133,8 @@ export const createActiveEntitiesComponent = (
         (pointer) => !entities.some((entity) => entity.pointers.includes(pointer))
       )
 
-      for (const pointer of pointersWithoutActiveEntity) {
-        entityIdByPointers.set(pointer.toLowerCase(), 'NOT_ACTIVE_ENTITY')
+      for (const pointer of pointersWithoutActiveEntity.map((pointer) => pointer.toLowerCase())) {
+        entityIdByPointers.set(pointer, 'NOT_ACTIVE_ENTITY')
         logger.debug('pointer has no active entity', { pointer })
       }
     } else if (entityIds) {
@@ -142,7 +142,7 @@ export const createActiveEntitiesComponent = (
         (entityId) => !entities.some((entity) => entity.id === entityId)
       )
 
-      for (const entityId of entityIdsWithoutActiveEntity) {
+      for (const entityId of entityIdsWithoutActiveEntity.map((pointer) => pointer.toLowerCase())) {
         cache.set(entityId, 'NOT_ACTIVE_ENTITY')
         logger.debug('entityId has no active entity', { entityId })
       }
@@ -176,7 +176,7 @@ export const createActiveEntitiesComponent = (
    */
   const withIds = async (entityIds: string[]): Promise<Entity[]> => {
     // check what is on the cache
-    const uniqueEntityIds = new Set(entityIds)
+    const uniqueEntityIds = new Set(entityIds.map((entityId) => entityId.toLowerCase()))
     const onCache: (Entity | NotActiveEntity)[] = []
     const remaining: string[] = []
     for (const entityId of uniqueEntityIds) {
@@ -202,13 +202,13 @@ export const createActiveEntitiesComponent = (
    * Retrieve active entities that are pointed by the given pointers
    */
   const withPointers = async (pointers: string[]) => {
-    const uniquePointers = new Set(pointers)
+    const uniquePointers = new Set(pointers.map((pointer) => pointer.toLowerCase()))
     const uniqueEntityIds = new Set<string>() // entityIds that are associated to the given pointers
     const remaining: string[] = [] // pointers that are not associated to any entity
 
     // get associated entity ids to pointers or save for later
     for (const pointer of uniquePointers) {
-      const entityId = entityIdByPointers.get(pointer.toLowerCase())
+      const entityId = entityIdByPointers.get(pointer)
       if (!entityId) {
         logger.debug('Entity with given pointer not found on cache', { pointer })
         remaining.push(pointer)

--- a/content/src/ports/activeEntities.ts
+++ b/content/src/ports/activeEntities.ts
@@ -104,7 +104,7 @@ export const createActiveEntitiesComponent = (
    * useful to retrieve entities by pointers
    */
   const update = async (pointers: string[], entity: Entity | NotActiveEntity): Promise<void> => {
-    for (const pointer of pointers.map((pointer) => pointer.toLowerCase())) {
+    for (const pointer of pointers.map(normalizeKey)) {
       setPreviousEntityAsNone(pointer)
       entityIdByPointers.set(pointer, isEntityPresent(entity) ? entity.id : entity)
     }
@@ -133,7 +133,7 @@ export const createActiveEntitiesComponent = (
         (pointer) => !entities.some((entity) => entity.pointers.includes(pointer))
       )
 
-      for (const pointer of pointersWithoutActiveEntity.map((pointer) => pointer.toLowerCase())) {
+      for (const pointer of pointersWithoutActiveEntity.map(normalizeKey)) {
         entityIdByPointers.set(pointer, 'NOT_ACTIVE_ENTITY')
         logger.debug('pointer has no active entity', { pointer })
       }
@@ -142,7 +142,7 @@ export const createActiveEntitiesComponent = (
         (entityId) => !entities.some((entity) => entity.id === entityId)
       )
 
-      for (const entityId of entityIdsWithoutActiveEntity.map((pointer) => pointer.toLowerCase())) {
+      for (const entityId of entityIdsWithoutActiveEntity.map(normalizeKey)) {
         cache.set(entityId, 'NOT_ACTIVE_ENTITY')
         logger.debug('entityId has no active entity', { entityId })
       }
@@ -176,7 +176,7 @@ export const createActiveEntitiesComponent = (
    */
   const withIds = async (entityIds: string[]): Promise<Entity[]> => {
     // check what is on the cache
-    const uniqueEntityIds = new Set(entityIds.map((entityId) => entityId.toLowerCase()))
+    const uniqueEntityIds = new Set(entityIds.map(normalizeKey))
     const onCache: (Entity | NotActiveEntity)[] = []
     const remaining: string[] = []
     for (const entityId of uniqueEntityIds) {
@@ -202,7 +202,7 @@ export const createActiveEntitiesComponent = (
    * Retrieve active entities that are pointed by the given pointers
    */
   const withPointers = async (pointers: string[]) => {
-    const uniquePointers = new Set(pointers.map((pointer) => pointer.toLowerCase()))
+    const uniquePointers = new Set(pointers.map(normalizeKey))
     const uniqueEntityIds = new Set<string>() // entityIds that are associated to the given pointers
     const remaining: string[] = [] // pointers that are not associated to any entity
 
@@ -235,8 +235,10 @@ export const createActiveEntitiesComponent = (
    * Retrieve active entities that are pointed by pointers that match the urn prefix
    */
   const withPrefix = async (collectionUrn: string) => {
-    return getActiveDeploymentsByUrnPrefix({ database: components.database }, collectionUrn.toLowerCase())
+    return getActiveDeploymentsByUrnPrefix({ database: components.database }, normalizeKey(collectionUrn))
   }
+
+  const normalizeKey = (key: string) => key.toLowerCase()
 
   return {
     withIds,
@@ -246,11 +248,11 @@ export const createActiveEntitiesComponent = (
     clear,
 
     getCachedEntity: (idOrPointer) => {
-      if (cache.has(idOrPointer.toLowerCase())) {
-        const cachedEntity = cache.get(idOrPointer.toLowerCase())
+      if (cache.has(normalizeKey(idOrPointer))) {
+        const cachedEntity = cache.get(normalizeKey(idOrPointer))
         return isEntityPresent(cachedEntity) ? cachedEntity.id : cachedEntity
       }
-      return entityIdByPointers.get(idOrPointer.toLowerCase())
+      return entityIdByPointers.get(normalizeKey(idOrPointer))
     }
   }
 }

--- a/content/test/unit/service/Service.spec.ts
+++ b/content/test/unit/service/Service.spec.ts
@@ -1,7 +1,7 @@
 import { Authenticator } from '@dcl/crypto'
 import { hashV1 } from '@dcl/hashing'
 import { Entity, EntityType, EthAddress } from '@dcl/schemas'
-import { createConfigComponent } from "@well-known-components/env-config-provider"
+import { createConfigComponent } from '@well-known-components/env-config-provider'
 import { createLogComponent } from '@well-known-components/logger'
 import { createTestMetricsComponent } from '@well-known-components/metrics'
 import assert from 'assert'
@@ -14,22 +14,22 @@ import * as deploymentLogic from '../../../src/logic/deployments'
 import { metricsDeclaration } from '../../../src/metrics'
 import { createActiveEntitiesComponent } from '../../../src/ports/activeEntities'
 import { Denylist } from '../../../src/ports/denylist'
-import { createDeployedEntitiesBloomFilter } from '../../../src/ports/deployedEntitiesBloomFilter'
 import { createDeployRateLimiter } from '../../../src/ports/deployRateLimiterComponent'
+import { createDeployedEntitiesBloomFilter } from '../../../src/ports/deployedEntitiesBloomFilter'
 import { createFailedDeploymentsCache } from '../../../src/ports/failedDeploymentsCache'
 import { createTestDatabaseComponent } from '../../../src/ports/postgres'
 import { createSequentialTaskExecutor } from '../../../src/ports/sequecuentialTaskExecutor'
+import {
+  DeploymentContext,
+  DeploymentResult,
+  LocalDeploymentAuditInfo,
+  isInvalidDeployment
+} from '../../../src/service/Service'
+import { ServiceImpl } from '../../../src/service/ServiceImpl'
 import { ContentAuthenticator } from '../../../src/service/auth/Authenticator'
 import * as deployments from '../../../src/service/deployments/deployments'
 import { Deployment } from '../../../src/service/deployments/types'
 import { DELTA_POINTER_RESULT } from '../../../src/service/pointers/PointerManager'
-import {
-  DeploymentContext,
-  DeploymentResult,
-  isInvalidDeployment,
-  LocalDeploymentAuditInfo
-} from '../../../src/service/Service'
-import { ServiceImpl } from '../../../src/service/ServiceImpl'
 import { EntityVersion } from '../../../src/types'
 import { buildEntityAndFile } from '../../helpers/service/EntityTestFactory'
 import { NoOpServerValidator, NoOpValidator } from '../../helpers/service/validations/NoOpValidator'
@@ -52,17 +52,15 @@ describe('Service', function () {
   // starts the variables
   beforeAll(async () => {
     randomFileHash = await hashV1(randomFile)
-      ;[entity, entityFile] = await buildEntityAndFile(
-        EntityType.SCENE,
-        POINTERS,
-        Date.now(),
-        new Map([['file', randomFileHash]]),
-        { 'metadata': 'metadata' }
-      )
-
-    jest.spyOn(pointers, 'updateActiveDeployments').mockImplementation(() =>
-      Promise.resolve()
+    ;[entity, entityFile] = await buildEntityAndFile(
+      EntityType.SCENE,
+      POINTERS,
+      Date.now(),
+      new Map([['file', randomFileHash]]),
+      { metadata: 'metadata' }
     )
+
+    jest.spyOn(pointers, 'updateActiveDeployments').mockImplementation(() => Promise.resolve())
   })
 
   it(`When no file matches the given entity id, then deployment fails`, async () => {
@@ -124,16 +122,20 @@ describe('Service', function () {
     expect(storeSpy).not.toHaveBeenCalledWith(randomFileHash, expect.anything())
   })
 
-  it(`When the same pointer is asked twice, then the second time cached the result is returned`, async () => {
+  it(`When the same pointer is asked twice, then the second time cached the result in lowercase and is returned`, async () => {
     const service = await buildService()
-    const serviceSpy = jest.spyOn(deployments, 'getDeploymentsForActiveEntities').mockImplementation(() =>
-      Promise.resolve([fakeDeployment()])
-    )
+    const serviceSpy = jest
+      .spyOn(deployments, 'getDeploymentsForActiveEntities')
+      .mockImplementation(() => Promise.resolve([fakeDeployment()]))
 
     // Call the first time
     await service.components.activeEntities.withPointers(POINTERS)
     // When a pointer is asked the first time, then the database is reached
-    expect(serviceSpy).toHaveBeenCalledWith(expect.anything(), undefined, POINTERS)
+    expect(serviceSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      undefined,
+      POINTERS.map((pointer) => pointer.toLowerCase())
+    )
 
     // Reset spy and call again
     serviceSpy.mockReset()
@@ -141,16 +143,20 @@ describe('Service', function () {
     expect(serviceSpy).not.toHaveBeenCalled()
   })
 
-  it(`Given a pointer with no deployment, when is asked twice, then the second time cached the result is returned`, async () => {
+  it(`Given a pointer with no deployment, when is asked twice, then the second time cached the result is returned using lowercases`, async () => {
     const service = await buildService()
-    const serviceSpy = jest.spyOn(deployments, 'getDeploymentsForActiveEntities').mockImplementation(() =>
-      Promise.resolve([fakeDeployment()])
-    )
+    const serviceSpy = jest
+      .spyOn(deployments, 'getDeploymentsForActiveEntities')
+      .mockImplementation(() => Promise.resolve([fakeDeployment()]))
 
     // Call the first time
     await service.components.activeEntities.withPointers(POINTERS)
 
-    expect(serviceSpy).toHaveBeenCalledWith(expect.anything(), undefined, POINTERS)
+    expect(serviceSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      undefined,
+      POINTERS.map((pointer) => pointer.toLowerCase())
+    )
 
     // Reset spy and call again
     serviceSpy.mockReset()
@@ -158,7 +164,7 @@ describe('Service', function () {
     expect(serviceSpy).not.toHaveBeenCalled()
   })
 
-  it(`When a pointer is affected by a deployment, then it is updated in the cache`, async () => {
+  it(`When a pointer is affected by a deployment, then it is updated in the cache using lowercases`, async () => {
     const service = await buildService()
     jest.spyOn(service.components.pointerManager, 'referenceEntityFromPointers').mockImplementation(() =>
       Promise.resolve(
@@ -169,16 +175,20 @@ describe('Service', function () {
       )
     )
 
-    let serviceSpy = jest.spyOn(deployments, 'getDeploymentsForActiveEntities').mockImplementation(() =>
-      Promise.resolve([fakeDeployment()])
-    )
+    let serviceSpy = jest
+      .spyOn(deployments, 'getDeploymentsForActiveEntities')
+      .mockImplementation(() => Promise.resolve([fakeDeployment()]))
 
     jest.spyOn(deploymentLogic, 'saveDeploymentAndContentFiles').mockImplementation(() => Promise.resolve(1))
     jest.spyOn(deploymentQueries, 'setEntitiesAsOverwritten').mockImplementation(() => Promise.resolve())
 
     // Call the first time
     await service.components.activeEntities.withPointers(POINTERS)
-    expect(serviceSpy).toHaveBeenCalledWith(expect.anything(), undefined, POINTERS)
+    expect(serviceSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      undefined,
+      POINTERS.map((pointer) => pointer.toLowerCase())
+    )
 
     // Make deployment that should update the cache
     await service.deployEntity([entityFile, randomFile], entity.id, auditInfo, DeploymentContext.LOCAL)
@@ -186,9 +196,9 @@ describe('Service', function () {
     // Reset spy and call again
     serviceSpy.mockReset()
 
-    serviceSpy = jest.spyOn(deployments, 'getDeploymentsForActiveEntities').mockImplementation(() =>
-      Promise.resolve([fakeDeployment('QmSQc2mGpzanz1DDtTf2ZCFnwTpJvAbcwzsS4An5PXaTqg')])
-    )
+    serviceSpy = jest
+      .spyOn(deployments, 'getDeploymentsForActiveEntities')
+      .mockImplementation(() => Promise.resolve([fakeDeployment('QmSQc2mGpzanz1DDtTf2ZCFnwTpJvAbcwzsS4An5PXaTqg')]))
     await service.components.activeEntities.withPointers(POINTERS)
 
     // expect(serviceSpy).toHaveBeenCalledWith(expect.anything(), ['QmSQc2mGpzanz1DDtTf2ZCFnwTpJvAbcwzsS4An5PXaTqg'], undefined)
@@ -217,7 +227,10 @@ describe('Service', function () {
     const failedDeploymentsCache = createFailedDeploymentsCache({ metrics })
     const storage = new MockedStorage()
     const pointerManager = NoOpPointerManager.build()
-    const authenticator = new ContentAuthenticator(new HTTPProvider("https://rpc.decentraland.org/mainnet?project=catalyst-ci"), DECENTRALAND_ADDRESS)
+    const authenticator = new ContentAuthenticator(
+      new HTTPProvider('https://rpc.decentraland.org/mainnet?project=catalyst-ci'),
+      DECENTRALAND_ADDRESS
+    )
     const deployedEntitiesBloomFilter = createDeployedEntitiesBloomFilter({ database, logs })
     env.setConfig(EnvironmentConfig.ENTITIES_CACHE_SIZE, DEFAULT_ENTITIES_CACHE_SIZE)
     const denylist: Denylist = { isDenylisted: () => false }


### PR DESCRIPTION
## Description

It fixes how the content server stores and retrieves Entities by Ids or Pointers.

Reason of the issue: we had keys mixing uppercases and lowercases on the cache.

Also, it fixes a corner case where on (`/content/entities/active` endpoint):
* If you try to get an entity by Id, the client needs to send that Id always in lowercases
* If the client at some point miss parsing the Id to lowercase and send it with at least one letter in uppercase, then the cache breaks
* Now the client can send the id in lower or uppercases and the content server internally will treat them as they were always in lowercases, so the cache should not break again because of this