### PR TITLE
fix: normalize pointers on cache for active entities

### DIFF
--- a/content/src/ports/activeEntities.ts
+++ b/content/src/ports/activeEntities.ts
@@ -106,7 +106,7 @@ export const createActiveEntitiesComponent = (
   const update = async (pointers: string[], entity: Entity | NotActiveEntity): Promise<void> => {
     for (const pointer of pointers) {
       setPreviousEntityAsNone(pointer)
-      entityIdByPointers.set(pointer, isEntityPresent(entity) ? entity.id : entity)
+      entityIdByPointers.set(normalizePointer(pointer), isEntityPresent(entity) ? entity.id : entity)
     }
     if (isEntityPresent(entity)) {
       cache.set(entity.id, entity)
@@ -198,6 +198,8 @@ export const createActiveEntitiesComponent = (
     return [...onCache.filter(isEntityPresent), ...remainingEntities]
   }
 
+  const normalizePointer = (pointer: string) => pointer.toLowerCase()
+
   /**
    * Retrieve active entities that are pointed by the given pointers
    */
@@ -208,7 +210,7 @@ export const createActiveEntitiesComponent = (
 
     // get associated entity ids to pointers or save for later
     for (const pointer of uniquePointers) {
-      const entityId = entityIdByPointers.get(pointer)
+      const entityId = entityIdByPointers.get(normalizePointer(pointer))
       if (!entityId) {
         logger.debug('Entity with given pointer not found on cache', { pointer })
         remaining.push(pointer)

--- a/content/test/unit/ports/activeEntities.spec.ts
+++ b/content/test/unit/ports/activeEntities.spec.ts
@@ -1,0 +1,340 @@
+import { Authenticator } from '@dcl/crypto'
+import { EntityType, EthAddress } from '@dcl/schemas'
+import { createConfigComponent } from '@well-known-components/env-config-provider'
+import { createLogComponent } from '@well-known-components/logger'
+import { createTestMetricsComponent } from '@well-known-components/metrics'
+import { HTTPProvider } from 'eth-connect'
+import ms from 'ms'
+import { DEFAULT_ENTITIES_CACHE_SIZE, Environment, EnvironmentConfig } from '../../../src/Environment'
+import { metricsDeclaration } from '../../../src/metrics'
+import { createActiveEntitiesComponent } from '../../../src/ports/activeEntities'
+import { Denylist } from '../../../src/ports/denylist'
+import { createDeployRateLimiter } from '../../../src/ports/deployRateLimiterComponent'
+import { createDeployedEntitiesBloomFilter } from '../../../src/ports/deployedEntitiesBloomFilter'
+import { createFailedDeploymentsCache } from '../../../src/ports/failedDeploymentsCache'
+import { createTestDatabaseComponent } from '../../../src/ports/postgres'
+import { createSequentialTaskExecutor } from '../../../src/ports/sequecuentialTaskExecutor'
+import { ServiceImpl } from '../../../src/service/ServiceImpl'
+import { ContentAuthenticator } from '../../../src/service/auth/Authenticator'
+import * as deployments from '../../../src/service/deployments/deployments'
+import { Deployment } from '../../../src/service/deployments/types'
+import { EntityVersion } from '../../../src/types'
+import { NoOpServerValidator, NoOpValidator } from '../../helpers/service/validations/NoOpValidator'
+import { MockedStorage } from '../ports/contentStorage/MockedStorage'
+import { NoOpPointerManager } from '../service/pointers/NoOpPointerManager'
+
+export const DECENTRALAND_ADDRESS: EthAddress = '0x1337e0507eb4ab47e08a179573ed4533d9e22a7b'
+
+describe('activeEntities', () => {
+  const fakeDeployment: Deployment = {
+    entityVersion: EntityVersion.V3,
+    entityType: EntityType.SCENE,
+    entityId: 'someId',
+    entityTimestamp: 10,
+    deployedBy: '',
+    pointers: ['apointer'],
+    auditInfo: {
+      authChain: Authenticator.createSimpleAuthChain('entityId', 'ethAddress', 'signature'),
+      version: EntityVersion.V3,
+      localTimestamp: 10
+    }
+  }
+
+  /** Mock of deployments.getDeploymentsForActiveEntities*/
+  const sut = jest
+    .spyOn(deployments, 'getDeploymentsForActiveEntities')
+    .mockImplementation(() => Promise.resolve([fakeDeployment]))
+
+  describe('withPointers should', () => {
+    const pointersToUseByCases = {
+      lowercase: ['apointer'],
+      uppercase: ['APointer']
+    }
+
+    beforeEach(() => {
+      sut.mockClear()
+    })
+
+    it(`return a cached result on second retrieval when the same pointer is asked twice using the same case`, async () => {
+      const service = await buildService()
+      sut.mockImplementation(() => Promise.resolve([{ ...fakeDeployment, pointers: pointersToUseByCases.lowercase }]))
+
+      const firstResult = await service.components.activeEntities.withPointers(pointersToUseByCases.lowercase)
+      expect(sut).toHaveBeenCalledWith(expect.anything(), undefined, pointersToUseByCases.lowercase)
+
+      sut.mockClear()
+
+      const secondResult = await service.components.activeEntities.withPointers(pointersToUseByCases.lowercase)
+      expect(sut).not.toHaveBeenCalled()
+
+      expect(firstResult).toMatchObject(secondResult)
+    })
+
+    it(`return a cached result on second retrieval when the same pointer is asked twice using the same case but the pointers retrieved are in different case`, async () => {
+      const service = await buildService()
+      sut.mockImplementation(() => Promise.resolve([{ ...fakeDeployment, pointers: pointersToUseByCases.uppercase }]))
+
+      const firstResult = await service.components.activeEntities.withPointers(pointersToUseByCases.lowercase)
+      expect(sut).toHaveBeenCalledWith(expect.anything(), undefined, pointersToUseByCases.lowercase)
+
+      sut.mockClear()
+
+      const secondResult = await service.components.activeEntities.withPointers(pointersToUseByCases.uppercase)
+      expect(sut).not.toHaveBeenCalled()
+
+      expect(firstResult).toMatchObject(secondResult)
+    })
+
+    it(`return a cached result on second retrieval when the same pointer is asked twice using different cases (1st lower, then upper)`, async () => {
+      const service = await buildService()
+      sut.mockImplementation(() => Promise.resolve([{ ...fakeDeployment, pointers: pointersToUseByCases.lowercase }]))
+
+      const firstResult = await service.components.activeEntities.withPointers(pointersToUseByCases.lowercase)
+      expect(sut).toHaveBeenCalledWith(expect.anything(), undefined, pointersToUseByCases.lowercase)
+
+      sut.mockClear()
+
+      const secondResult = await service.components.activeEntities.withPointers(pointersToUseByCases.uppercase)
+      expect(sut).not.toHaveBeenCalled()
+
+      expect(firstResult).toMatchObject(secondResult)
+    })
+
+    it(`return a cached result on second retrieval when the same pointer is asked twice using different cases (1st upper, then lower)`, async () => {
+      const service = await buildService()
+      sut.mockImplementation(() => Promise.resolve([{ ...fakeDeployment, pointers: pointersToUseByCases.lowercase }]))
+
+      const firstResult = await service.components.activeEntities.withPointers(pointersToUseByCases.uppercase)
+      expect(sut).toHaveBeenCalledWith(expect.anything(), undefined, pointersToUseByCases.uppercase)
+
+      sut.mockClear()
+
+      const secondResult = await service.components.activeEntities.withPointers(pointersToUseByCases.lowercase)
+      expect(sut).not.toHaveBeenCalled()
+
+      expect(firstResult).toMatchObject(secondResult)
+    })
+
+    it(`return a cached result after the first retrieval when the same pointer is asked three times using different cases`, async () => {
+      const service = await buildService()
+      sut.mockImplementation(() => Promise.resolve([{ ...fakeDeployment, pointers: pointersToUseByCases.lowercase }]))
+
+      const firstResult = await service.components.activeEntities.withPointers(pointersToUseByCases.lowercase)
+      expect(sut).toHaveBeenCalledWith(expect.anything(), undefined, pointersToUseByCases.lowercase)
+
+      sut.mockClear()
+
+      const secondResult = await service.components.activeEntities.withPointers(pointersToUseByCases.uppercase)
+      expect(sut).not.toHaveBeenCalled()
+
+      const thirdResult = await service.components.activeEntities.withPointers(pointersToUseByCases.uppercase)
+      expect(sut).not.toHaveBeenCalled()
+
+      expect(firstResult).toMatchObject(secondResult)
+      expect(firstResult).toMatchObject(thirdResult)
+    })
+
+    it(`return a cached result after the first retrieval when the same pointer is asked three times using different cases inverted`, async () => {
+      const service = await buildService()
+      sut.mockImplementation(() => Promise.resolve([{ ...fakeDeployment, pointers: pointersToUseByCases.lowercase }]))
+
+      const firstResult = await service.components.activeEntities.withPointers(pointersToUseByCases.uppercase)
+      expect(sut).toHaveBeenCalledWith(expect.anything(), undefined, pointersToUseByCases.uppercase)
+
+      sut.mockClear()
+
+      const secondResult = await service.components.activeEntities.withPointers(pointersToUseByCases.lowercase)
+      expect(sut).not.toHaveBeenCalled()
+
+      const thirdResult = await service.components.activeEntities.withPointers(pointersToUseByCases.lowercase)
+      expect(sut).not.toHaveBeenCalled()
+
+      expect(firstResult).toMatchObject(secondResult)
+      expect(firstResult).toMatchObject(thirdResult)
+    })
+
+    it(`return a cached result after the first retrieval when the same pointer is asked four times using different cases`, async () => {
+      const service = await buildService()
+      sut.mockImplementation(() => Promise.resolve([{ ...fakeDeployment, pointers: pointersToUseByCases.lowercase }]))
+
+      // Call the first time
+      await service.components.activeEntities.withPointers(pointersToUseByCases.lowercase)
+      // When a pointer is asked the first time, then the database is reached
+      expect(sut).toHaveBeenCalledWith(expect.anything(), undefined, pointersToUseByCases.lowercase)
+
+      // Reset spy and call again
+      sut.mockClear()
+      await service.components.activeEntities.withPointers(pointersToUseByCases.uppercase)
+      expect(sut).not.toHaveBeenCalled()
+
+      await service.components.activeEntities.withPointers(pointersToUseByCases.uppercase)
+      expect(sut).not.toHaveBeenCalled()
+
+      await service.components.activeEntities.withPointers(pointersToUseByCases.lowercase)
+      expect(sut).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('withIds should', () => {
+    const idsToUseByCases = {
+      lowercase: ['anid'],
+      uppercase: ['AnId']
+    }
+
+    beforeEach(() => {
+      sut.mockClear()
+    })
+
+    it(`treat entity id on cache keys as case sensitive, then result changes depending on the cases passed in the id`, async () => {
+      const service = await buildService()
+      sut.mockImplementation(() => Promise.resolve([{ ...fakeDeployment, entityId: idsToUseByCases.lowercase[0] }]))
+
+      const firstResult = await service.components.activeEntities.withIds(idsToUseByCases.lowercase)
+      expect(sut).toHaveBeenCalledWith(expect.anything(), idsToUseByCases.lowercase, undefined)
+
+      sut.mockClear()
+
+      const secondResult = await service.components.activeEntities.withIds(idsToUseByCases.lowercase)
+      expect(sut).not.toHaveBeenCalled()
+
+      expect(firstResult).toMatchObject(secondResult)
+    })
+
+    it(`return a cached result only when the id is equally considering case sensitive (1st lower, 2nd upper, 3rd lower)`, async () => {
+      const service = await buildService()
+      sut.mockImplementationOnce(() => Promise.resolve([{ ...fakeDeployment, entityId: idsToUseByCases.lowercase[0] }]))
+
+      const firstResult = await service.components.activeEntities.withIds(idsToUseByCases.lowercase)
+      expect(sut).toHaveBeenCalledWith(expect.anything(), idsToUseByCases.lowercase, undefined)
+
+      sut.mockClear()
+      sut.mockImplementationOnce(() =>
+        Promise.resolve([
+          { ...fakeDeployment, entityId: idsToUseByCases.uppercase[0], pointers: ['adifferentpointer'] }
+        ])
+      )
+
+      const secondResult = await service.components.activeEntities.withIds(idsToUseByCases.uppercase)
+      expect(sut).toHaveBeenCalledWith(expect.anything(), idsToUseByCases.uppercase, undefined)
+      expect(secondResult).not.toMatchObject(firstResult)
+      expect(secondResult[0].id).toEqual(idsToUseByCases.uppercase[0])
+
+      sut.mockClear()
+
+      const thirdResult = await service.components.activeEntities.withIds(idsToUseByCases.lowercase)
+      expect(sut).not.toHaveBeenCalled()
+      expect(firstResult).toMatchObject(thirdResult)
+    })
+
+    it(`return a cached result only when the id is equally considering case sensitive (1st lower, 2nd upper, 3rd lower, 4th upper)`, async () => {
+      const service = await buildService()
+      sut.mockImplementationOnce(() => Promise.resolve([{ ...fakeDeployment, entityId: idsToUseByCases.lowercase[0] }]))
+
+      const firstResult = await service.components.activeEntities.withIds(idsToUseByCases.lowercase)
+      expect(sut).toHaveBeenCalledWith(expect.anything(), idsToUseByCases.lowercase, undefined)
+
+      sut.mockClear()
+      sut.mockImplementationOnce(() =>
+        Promise.resolve([
+          { ...fakeDeployment, entityId: idsToUseByCases.uppercase[0], pointers: ['adifferentpointer'] }
+        ])
+      )
+
+      const secondResult = await service.components.activeEntities.withIds(idsToUseByCases.uppercase)
+      expect(sut).toHaveBeenCalledWith(expect.anything(), idsToUseByCases.uppercase, undefined)
+      expect(secondResult).not.toMatchObject(firstResult)
+      expect(secondResult[0].id).toEqual(idsToUseByCases.uppercase[0])
+
+      sut.mockClear()
+
+      const thirdResult = await service.components.activeEntities.withIds(idsToUseByCases.lowercase)
+      expect(sut).not.toHaveBeenCalled()
+      expect(firstResult).toMatchObject(thirdResult)
+
+      const fourthResult = await service.components.activeEntities.withIds(idsToUseByCases.uppercase)
+      expect(sut).not.toHaveBeenCalled()
+      expect(secondResult).toMatchObject(fourthResult)
+    })
+
+    it(`return a cached result only when the id is equally considering case sensitive (1st lower, 2nd upper, 3rd lower, 4th lower)`, async () => {
+      const service = await buildService()
+      sut.mockImplementationOnce(() => Promise.resolve([{ ...fakeDeployment, entityId: idsToUseByCases.lowercase[0] }]))
+
+      const firstResult = await service.components.activeEntities.withIds(idsToUseByCases.lowercase)
+      expect(sut).toHaveBeenCalledWith(expect.anything(), idsToUseByCases.lowercase, undefined)
+
+      sut.mockClear()
+      sut.mockImplementationOnce(() =>
+        Promise.resolve([
+          { ...fakeDeployment, entityId: idsToUseByCases.uppercase[0], pointers: ['adifferentpointer'] }
+        ])
+      )
+
+      const secondResult = await service.components.activeEntities.withIds(idsToUseByCases.uppercase)
+      expect(sut).toHaveBeenCalledWith(expect.anything(), idsToUseByCases.uppercase, undefined)
+      expect(secondResult).not.toMatchObject(firstResult)
+      expect(secondResult[0].id).toEqual(idsToUseByCases.uppercase[0])
+
+      sut.mockClear()
+
+      const thirdResult = await service.components.activeEntities.withIds(idsToUseByCases.lowercase)
+      expect(sut).not.toHaveBeenCalled()
+      expect(firstResult).toMatchObject(thirdResult)
+
+      const fourthResult = await service.components.activeEntities.withIds(idsToUseByCases.lowercase)
+      expect(sut).not.toHaveBeenCalled()
+      expect(firstResult).toMatchObject(fourthResult)
+    })
+  })
+})
+
+async function buildService() {
+  const database = createTestDatabaseComponent()
+  database.queryWithValues = () => Promise.resolve({ rows: [], rowCount: 0 })
+  database.transaction = () => Promise.resolve()
+  const env = new Environment()
+  env.setConfig(EnvironmentConfig.STORAGE_ROOT_FOLDER, 'inexistent')
+  env.setConfig(EnvironmentConfig.DENYLIST_FILE_NAME, 'file')
+
+  const validator = new NoOpValidator()
+  const serverValidator = new NoOpServerValidator()
+  const logs = await createLogComponent({
+    config: createConfigComponent({
+      LOG_LEVEL: 'DEBUG'
+    })
+  })
+  const deployRateLimiter = createDeployRateLimiter(
+    { logs },
+    { defaultMax: 300, defaultTtl: ms('1m'), entitiesConfigMax: new Map(), entitiesConfigTtl: new Map() }
+  )
+  const metrics = createTestMetricsComponent(metricsDeclaration)
+  const failedDeploymentsCache = createFailedDeploymentsCache({ metrics })
+  const storage = new MockedStorage()
+  const pointerManager = NoOpPointerManager.build()
+  const authenticator = new ContentAuthenticator(
+    new HTTPProvider('https://rpc.decentraland.org/mainnet?project=catalyst-ci'),
+    DECENTRALAND_ADDRESS
+  )
+  const deployedEntitiesBloomFilter = createDeployedEntitiesBloomFilter({ database, logs })
+  env.setConfig(EnvironmentConfig.ENTITIES_CACHE_SIZE, DEFAULT_ENTITIES_CACHE_SIZE)
+  const denylist: Denylist = { isDenylisted: () => false }
+  const sequentialExecutor = createSequentialTaskExecutor({ logs, metrics })
+  const activeEntities = createActiveEntitiesComponent({ database, logs, env, metrics, denylist, sequentialExecutor })
+
+  return new ServiceImpl({
+    env,
+    pointerManager,
+    failedDeploymentsCache,
+    deployRateLimiter,
+    storage,
+    validator,
+    serverValidator,
+    metrics,
+    logs,
+    authenticator,
+    database,
+    deployedEntitiesBloomFilter: deployedEntitiesBloomFilter,
+    activeEntities,
+    denylist
+  })
+}

--- a/content/test/unit/service/Service.spec.ts
+++ b/content/test/unit/service/Service.spec.ts
@@ -1,7 +1,7 @@
 import { Authenticator } from '@dcl/crypto'
 import { hashV1 } from '@dcl/hashing'
 import { Entity, EntityType, EthAddress } from '@dcl/schemas'
-import { createConfigComponent } from "@well-known-components/env-config-provider"
+import { createConfigComponent } from '@well-known-components/env-config-provider'
 import { createLogComponent } from '@well-known-components/logger'
 import { createTestMetricsComponent } from '@well-known-components/metrics'
 import assert from 'assert'
@@ -14,22 +14,22 @@ import * as deploymentLogic from '../../../src/logic/deployments'
 import { metricsDeclaration } from '../../../src/metrics'
 import { createActiveEntitiesComponent } from '../../../src/ports/activeEntities'
 import { Denylist } from '../../../src/ports/denylist'
-import { createDeployedEntitiesBloomFilter } from '../../../src/ports/deployedEntitiesBloomFilter'
 import { createDeployRateLimiter } from '../../../src/ports/deployRateLimiterComponent'
+import { createDeployedEntitiesBloomFilter } from '../../../src/ports/deployedEntitiesBloomFilter'
 import { createFailedDeploymentsCache } from '../../../src/ports/failedDeploymentsCache'
 import { createTestDatabaseComponent } from '../../../src/ports/postgres'
 import { createSequentialTaskExecutor } from '../../../src/ports/sequecuentialTaskExecutor'
+import {
+  DeploymentContext,
+  DeploymentResult,
+  LocalDeploymentAuditInfo,
+  isInvalidDeployment
+} from '../../../src/service/Service'
+import { ServiceImpl } from '../../../src/service/ServiceImpl'
 import { ContentAuthenticator } from '../../../src/service/auth/Authenticator'
 import * as deployments from '../../../src/service/deployments/deployments'
 import { Deployment } from '../../../src/service/deployments/types'
 import { DELTA_POINTER_RESULT } from '../../../src/service/pointers/PointerManager'
-import {
-  DeploymentContext,
-  DeploymentResult,
-  isInvalidDeployment,
-  LocalDeploymentAuditInfo
-} from '../../../src/service/Service'
-import { ServiceImpl } from '../../../src/service/ServiceImpl'
 import { EntityVersion } from '../../../src/types'
 import { buildEntityAndFile } from '../../helpers/service/EntityTestFactory'
 import { NoOpServerValidator, NoOpValidator } from '../../helpers/service/validations/NoOpValidator'
@@ -52,17 +52,15 @@ describe('Service', function () {
   // starts the variables
   beforeAll(async () => {
     randomFileHash = await hashV1(randomFile)
-      ;[entity, entityFile] = await buildEntityAndFile(
-        EntityType.SCENE,
-        POINTERS,
-        Date.now(),
-        new Map([['file', randomFileHash]]),
-        { 'metadata': 'metadata' }
-      )
-
-    jest.spyOn(pointers, 'updateActiveDeployments').mockImplementation(() =>
-      Promise.resolve()
+    ;[entity, entityFile] = await buildEntityAndFile(
+      EntityType.SCENE,
+      POINTERS,
+      Date.now(),
+      new Map([['file', randomFileHash]]),
+      { metadata: 'metadata' }
     )
+
+    jest.spyOn(pointers, 'updateActiveDeployments').mockImplementation(() => Promise.resolve())
   })
 
   it(`When no file matches the given entity id, then deployment fails`, async () => {
@@ -124,11 +122,12 @@ describe('Service', function () {
     expect(storeSpy).not.toHaveBeenCalledWith(randomFileHash, expect.anything())
   })
 
+  // Here
   it(`When the same pointer is asked twice, then the second time cached the result is returned`, async () => {
     const service = await buildService()
-    const serviceSpy = jest.spyOn(deployments, 'getDeploymentsForActiveEntities').mockImplementation(() =>
-      Promise.resolve([fakeDeployment()])
-    )
+    const serviceSpy = jest
+      .spyOn(deployments, 'getDeploymentsForActiveEntities')
+      .mockImplementation(() => Promise.resolve([fakeDeployment()]))
 
     // Call the first time
     await service.components.activeEntities.withPointers(POINTERS)
@@ -136,16 +135,16 @@ describe('Service', function () {
     expect(serviceSpy).toHaveBeenCalledWith(expect.anything(), undefined, POINTERS)
 
     // Reset spy and call again
-    serviceSpy.mockReset()
+    serviceSpy.mockClear()
     await service.components.activeEntities.withPointers(POINTERS)
     expect(serviceSpy).not.toHaveBeenCalled()
   })
 
   it(`Given a pointer with no deployment, when is asked twice, then the second time cached the result is returned`, async () => {
     const service = await buildService()
-    const serviceSpy = jest.spyOn(deployments, 'getDeploymentsForActiveEntities').mockImplementation(() =>
-      Promise.resolve([fakeDeployment()])
-    )
+    const serviceSpy = jest
+      .spyOn(deployments, 'getDeploymentsForActiveEntities')
+      .mockImplementation(() => Promise.resolve([fakeDeployment()]))
 
     // Call the first time
     await service.components.activeEntities.withPointers(POINTERS)
@@ -153,7 +152,7 @@ describe('Service', function () {
     expect(serviceSpy).toHaveBeenCalledWith(expect.anything(), undefined, POINTERS)
 
     // Reset spy and call again
-    serviceSpy.mockReset()
+    serviceSpy.mockClear()
     await service.components.activeEntities.withPointers(POINTERS)
     expect(serviceSpy).not.toHaveBeenCalled()
   })
@@ -169,9 +168,9 @@ describe('Service', function () {
       )
     )
 
-    let serviceSpy = jest.spyOn(deployments, 'getDeploymentsForActiveEntities').mockImplementation(() =>
-      Promise.resolve([fakeDeployment()])
-    )
+    let serviceSpy = jest
+      .spyOn(deployments, 'getDeploymentsForActiveEntities')
+      .mockImplementation(() => Promise.resolve([fakeDeployment()]))
 
     jest.spyOn(deploymentLogic, 'saveDeploymentAndContentFiles').mockImplementation(() => Promise.resolve(1))
     jest.spyOn(deploymentQueries, 'setEntitiesAsOverwritten').mockImplementation(() => Promise.resolve())
@@ -184,14 +183,86 @@ describe('Service', function () {
     await service.deployEntity([entityFile, randomFile], entity.id, auditInfo, DeploymentContext.LOCAL)
 
     // Reset spy and call again
-    serviceSpy.mockReset()
+    serviceSpy.mockClear()
 
-    serviceSpy = jest.spyOn(deployments, 'getDeploymentsForActiveEntities').mockImplementation(() =>
-      Promise.resolve([fakeDeployment('QmSQc2mGpzanz1DDtTf2ZCFnwTpJvAbcwzsS4An5PXaTqg')])
-    )
+    serviceSpy = jest
+      .spyOn(deployments, 'getDeploymentsForActiveEntities')
+      .mockImplementation(() => Promise.resolve([fakeDeployment('QmSQc2mGpzanz1DDtTf2ZCFnwTpJvAbcwzsS4An5PXaTqg')]))
     await service.components.activeEntities.withPointers(POINTERS)
 
     // expect(serviceSpy).toHaveBeenCalledWith(expect.anything(), ['QmSQc2mGpzanz1DDtTf2ZCFnwTpJvAbcwzsS4An5PXaTqg'], undefined)
+  })
+
+  it(`When the same pointer is asked twice but with different cases, then the second time cached the result is returned`, async () => {
+    const customPointers = {
+      Lowercase: ['apointer'],
+      Uppercase: ['APointer']
+    }
+    const service = await buildService()
+    const serviceSpy = jest
+      .spyOn(deployments, 'getDeploymentsForActiveEntities')
+      .mockImplementation(() => Promise.resolve([{ ...fakeDeployment(), pointers: customPointers.Lowercase }]))
+
+    // Call the first time
+    await service.components.activeEntities.withPointers(customPointers.Lowercase)
+    // When a pointer is asked the first time, then the database is reached
+    expect(serviceSpy).toHaveBeenCalledWith(expect.anything(), undefined, customPointers.Lowercase)
+
+    // Reset spy and call again
+    serviceSpy.mockClear()
+    await service.components.activeEntities.withPointers(customPointers.Uppercase)
+    expect(serviceSpy).not.toHaveBeenCalled()
+  })
+
+  it(`When the same pointer is asked three times but with different cases, then the second time cached the result is returned`, async () => {
+    const customPointers = {
+      Lowercase: ['apointer'],
+      Uppercase: ['APointer']
+    }
+    const service = await buildService()
+    const serviceSpy = jest
+      .spyOn(deployments, 'getDeploymentsForActiveEntities')
+      .mockImplementation(() => Promise.resolve([{ ...fakeDeployment(), pointers: customPointers.Lowercase }]))
+
+    // Call the first time
+    await service.components.activeEntities.withPointers(customPointers.Lowercase)
+    // When a pointer is asked the first time, then the database is reached
+    expect(serviceSpy).toHaveBeenCalledWith(expect.anything(), undefined, customPointers.Lowercase)
+
+    // Reset spy and call again
+    serviceSpy.mockClear()
+    await service.components.activeEntities.withPointers(customPointers.Uppercase)
+    expect(serviceSpy).not.toHaveBeenCalled()
+
+    await service.components.activeEntities.withPointers(customPointers.Uppercase)
+    expect(serviceSpy).not.toHaveBeenCalled()
+  })
+
+  it(`When the same pointer is asked four times but with different cases, then the second time cached the result is returned`, async () => {
+    const customPointers = {
+      Lowercase: ['apointer'],
+      Uppercase: ['APointer']
+    }
+    const service = await buildService()
+    const serviceSpy = jest
+      .spyOn(deployments, 'getDeploymentsForActiveEntities')
+      .mockImplementation(() => Promise.resolve([{ ...fakeDeployment(), pointers: customPointers.Lowercase }]))
+
+    // Call the first time
+    await service.components.activeEntities.withPointers(customPointers.Lowercase)
+    // When a pointer is asked the first time, then the database is reached
+    expect(serviceSpy).toHaveBeenCalledWith(expect.anything(), undefined, customPointers.Lowercase)
+
+    // Reset spy and call again
+    serviceSpy.mockClear()
+    await service.components.activeEntities.withPointers(customPointers.Uppercase)
+    expect(serviceSpy).not.toHaveBeenCalled()
+
+    await service.components.activeEntities.withPointers(customPointers.Uppercase)
+    expect(serviceSpy).not.toHaveBeenCalled()
+
+    await service.components.activeEntities.withPointers(customPointers.Lowercase)
+    expect(serviceSpy).not.toHaveBeenCalled()
   })
 
   async function buildService() {
@@ -217,7 +288,10 @@ describe('Service', function () {
     const failedDeploymentsCache = createFailedDeploymentsCache({ metrics })
     const storage = new MockedStorage()
     const pointerManager = NoOpPointerManager.build()
-    const authenticator = new ContentAuthenticator(new HTTPProvider("https://rpc.decentraland.org/mainnet?project=catalyst-ci"), DECENTRALAND_ADDRESS)
+    const authenticator = new ContentAuthenticator(
+      new HTTPProvider('https://rpc.decentraland.org/mainnet?project=catalyst-ci'),
+      DECENTRALAND_ADDRESS
+    )
     const deployedEntitiesBloomFilter = createDeployedEntitiesBloomFilter({ database, logs })
     env.setConfig(EnvironmentConfig.ENTITIES_CACHE_SIZE, DEFAULT_ENTITIES_CACHE_SIZE)
     const denylist: Denylist = { isDenylisted: () => false }

--- a/content/test/unit/service/Service.spec.ts
+++ b/content/test/unit/service/Service.spec.ts
@@ -122,24 +122,6 @@ describe('Service', function () {
     expect(storeSpy).not.toHaveBeenCalledWith(randomFileHash, expect.anything())
   })
 
-  // Here
-  it(`When the same pointer is asked twice, then the second time cached the result is returned`, async () => {
-    const service = await buildService()
-    const serviceSpy = jest
-      .spyOn(deployments, 'getDeploymentsForActiveEntities')
-      .mockImplementation(() => Promise.resolve([fakeDeployment()]))
-
-    // Call the first time
-    await service.components.activeEntities.withPointers(POINTERS)
-    // When a pointer is asked the first time, then the database is reached
-    expect(serviceSpy).toHaveBeenCalledWith(expect.anything(), undefined, POINTERS)
-
-    // Reset spy and call again
-    serviceSpy.mockClear()
-    await service.components.activeEntities.withPointers(POINTERS)
-    expect(serviceSpy).not.toHaveBeenCalled()
-  })
-
   it(`Given a pointer with no deployment, when is asked twice, then the second time cached the result is returned`, async () => {
     const service = await buildService()
     const serviceSpy = jest
@@ -191,78 +173,6 @@ describe('Service', function () {
     await service.components.activeEntities.withPointers(POINTERS)
 
     // expect(serviceSpy).toHaveBeenCalledWith(expect.anything(), ['QmSQc2mGpzanz1DDtTf2ZCFnwTpJvAbcwzsS4An5PXaTqg'], undefined)
-  })
-
-  it(`When the same pointer is asked twice but with different cases, then the second time cached the result is returned`, async () => {
-    const customPointers = {
-      Lowercase: ['apointer'],
-      Uppercase: ['APointer']
-    }
-    const service = await buildService()
-    const serviceSpy = jest
-      .spyOn(deployments, 'getDeploymentsForActiveEntities')
-      .mockImplementation(() => Promise.resolve([{ ...fakeDeployment(), pointers: customPointers.Lowercase }]))
-
-    // Call the first time
-    await service.components.activeEntities.withPointers(customPointers.Lowercase)
-    // When a pointer is asked the first time, then the database is reached
-    expect(serviceSpy).toHaveBeenCalledWith(expect.anything(), undefined, customPointers.Lowercase)
-
-    // Reset spy and call again
-    serviceSpy.mockClear()
-    await service.components.activeEntities.withPointers(customPointers.Uppercase)
-    expect(serviceSpy).not.toHaveBeenCalled()
-  })
-
-  it(`When the same pointer is asked three times but with different cases, then the second time cached the result is returned`, async () => {
-    const customPointers = {
-      Lowercase: ['apointer'],
-      Uppercase: ['APointer']
-    }
-    const service = await buildService()
-    const serviceSpy = jest
-      .spyOn(deployments, 'getDeploymentsForActiveEntities')
-      .mockImplementation(() => Promise.resolve([{ ...fakeDeployment(), pointers: customPointers.Lowercase }]))
-
-    // Call the first time
-    await service.components.activeEntities.withPointers(customPointers.Lowercase)
-    // When a pointer is asked the first time, then the database is reached
-    expect(serviceSpy).toHaveBeenCalledWith(expect.anything(), undefined, customPointers.Lowercase)
-
-    // Reset spy and call again
-    serviceSpy.mockClear()
-    await service.components.activeEntities.withPointers(customPointers.Uppercase)
-    expect(serviceSpy).not.toHaveBeenCalled()
-
-    await service.components.activeEntities.withPointers(customPointers.Uppercase)
-    expect(serviceSpy).not.toHaveBeenCalled()
-  })
-
-  it(`When the same pointer is asked four times but with different cases, then the second time cached the result is returned`, async () => {
-    const customPointers = {
-      Lowercase: ['apointer'],
-      Uppercase: ['APointer']
-    }
-    const service = await buildService()
-    const serviceSpy = jest
-      .spyOn(deployments, 'getDeploymentsForActiveEntities')
-      .mockImplementation(() => Promise.resolve([{ ...fakeDeployment(), pointers: customPointers.Lowercase }]))
-
-    // Call the first time
-    await service.components.activeEntities.withPointers(customPointers.Lowercase)
-    // When a pointer is asked the first time, then the database is reached
-    expect(serviceSpy).toHaveBeenCalledWith(expect.anything(), undefined, customPointers.Lowercase)
-
-    // Reset spy and call again
-    serviceSpy.mockClear()
-    await service.components.activeEntities.withPointers(customPointers.Uppercase)
-    expect(serviceSpy).not.toHaveBeenCalled()
-
-    await service.components.activeEntities.withPointers(customPointers.Uppercase)
-    expect(serviceSpy).not.toHaveBeenCalled()
-
-    await service.components.activeEntities.withPointers(customPointers.Lowercase)
-    expect(serviceSpy).not.toHaveBeenCalled()
   })
 
   async function buildService() {


### PR DESCRIPTION
## Description

It fixes how the content server stores and retrieves Entities by Ids or Pointers.

Reason of the issue: we had keys mixing uppercases and lowercases on the cache.

## Changes

- Now the entities pointers are saved and retrieved from the cache always using lowercases
- Add 2 tests to verify that the issue is solved
- Also this solves the following edge case while keeping the ids cache key case sensitive:
```
1. If you try to get an entity by Id, the client needs to send that Id always in lowercases
2. If the client at some point miss parsing the Id to lowercase and send it with at least one letter in uppercase, then the cache breaks
3. This fix prevents corrupting the cache when an invalid id is asked to the catalyst, meaning that every time the client sends a valid id the peer answers with the proper object, independently from prior calls
```

## Break-down of prior versions issues

- v5.1.10
    1. Request POST /entities/active
        1. **Body:** { pointers: ["urn:decentraland:off-chain:base-avatars:basefemale"] }
        2. **Response:** Ok
    2. Request POST /entities/active
        1. **Body:** { pointers: ["urn:decentraland:off-chain:base-avatars:BaseFemale"] }
        2. **Response:** Ok
    3. Request POST /entities/active
        1. **Body:** { pointers: ["urn:decentraland:off-chain:base-avatars:BaseFemale"] }
        2. **Response:** Empty
    4. Request POST /entities/active
        1. **Body:** { pointers: ["urn:decentraland:off-chain:base-avatars:basefemale"] }
        2. **Response:** Ok
    - **Conslusion:** Only lowercases are allowed to retrieve entities by pointers
- v5.1.12
    1. Request POST /entities/active
        1. **Body:** { pointers: ["urn:decentraland:off-chain:base-avatars:basefemale"] }
        2. **Response:** Ok
    2. Request POST /entities/active
        1. **Body:** { pointers: ["urn:decentraland:off-chain:base-avatars:BaseFemale"] }
        2. **Response:** Empty
    3. Request POST /entities/active
        1. **Body:** { pointers: ["urn:decentraland:off-chain:base-avatars:BaseFemale"] }
        2. **Response:** Empty
    4. Request POST /entities/active
        1. **Body:** { pointers: ["urn:decentraland:off-chain:base-avatars:basefemale"] }
        2. **Response:** Empty
    5. Request POST /entities/active
        1. **Body:** { pointers: ["urn:decentraland:off-chain:base-avatars:basefemale"] }
        2. **Response:** Empty
    - **Conslusion:** Once a wearable is retrieved with mix cases, even the all lowercases approach won't work afterwards
- v5.1.13
    1. Request POST /entities/active
        1. **Body:** { pointers: ["urn:decentraland:off-chain:base-avatars:basefemale"] }
        2. **Response:** Ok
    2. Request POST /entities/active
        1. **Body:** { pointers: ["urn:decentraland:off-chain:base-avatars:BaseFemale"] }
        2. **Response:** Ok
    3. Request POST /entities/active
        1. **Body:** { pointers: ["urn:decentraland:off-chain:base-avatars:BaseFemale"] }
        2. **Response:** Empty
    4. Request POST /entities/active
        1. **Body:** { pointers: ["urn:decentraland:off-chain:base-avatars:basefemale"] }
        2. **Response:** Ok
     - **Conslusion:** Only lowercases are allowed to retrieve entities by pointers
- This fix
    1. Request POST /entities/active
        1. **Body:** { pointers: ["urn:decentraland:off-chain:base-avatars:basefemale"] }
        2. **Response:** Ok
    2. Request POST /entities/active
        1. **Body:** { pointers: ["urn:decentraland:off-chain:base-avatars:BaseFemale"] }
        2. **Response:** Ok
    3. Request POST /entities/active
        1. **Body:** { pointers: ["urn:decentraland:off-chain:base-avatars:BaseFemale"] }
        2. **Response:** Ok
    4. Request POST /entities/active
        1. **Body:** { pointers: ["urn:decentraland:off-chain:base-avatars:basefemale"] }
        2. **Response:** Ok
    - **Conslusion:** Working as expected