### PR TITLE
chore: type safety for db transaction clients

### DIFF
--- a/content/src/controller/Controller.ts
+++ b/content/src/controller/Controller.ts
@@ -398,7 +398,7 @@ export async function getAudit(
     }
   }
 
-  const { deployments } = await getDeployments(context.components, {
+  const { deployments } = await getDeployments(context.components, context.components.database, {
     fields: [DeploymentField.AUDIT_INFO],
     filters: { entityIds: [entityId], entityTypes: [type] },
     includeDenylisted: true
@@ -495,7 +495,7 @@ export async function getPointerChangesHandler(
   const { pointerChanges, filters, pagination } = await context.components.sequentialExecutor.run(
     'GetPointerChangesEndpoint',
     () =>
-      getPointerChanges(context.components, {
+      getPointerChanges(context.components, context.components.database, {
         filters: requestFilters,
         offset,
         limit,
@@ -646,7 +646,7 @@ export async function getDeploymentsHandler(
 
   const { deployments, filters, pagination } = await context.components.sequentialExecutor.run(
     'GetDeploymentsEndpoint',
-    () => getDeployments(context.components, deploymentOptions)
+    () => getDeployments(context.components, context.components.database, deploymentOptions)
   )
   const controllerDeployments = deployments.map((deployment) =>
     ControllerDeploymentFactory.deployment2ControllerEntity(deployment, enumFields)

--- a/content/src/logic/database-queries/deployments-queries.ts
+++ b/content/src/logic/database-queries/deployments-queries.ts
@@ -2,6 +2,7 @@ import { AuthChain, Authenticator } from '@dcl/crypto'
 import { ContentMapping, Entity, EntityType, SnapshotSyncDeployment } from '@dcl/schemas'
 import pg from 'pg'
 import SQL, { SQLStatement } from 'sql-template-strings'
+import { DatabaseClient, DatabaseTransactionalClient } from 'src/ports/postgres'
 import { AuditInfo, DeploymentFilters, DeploymentSorting, SortingField, SortingOrder } from '../../deployment-types'
 import { AppComponents, DeploymentId } from '../../types'
 
@@ -30,12 +31,7 @@ export interface HistoricalDeploymentsRow {
   overwritten_by?: string
 }
 
-export async function deploymentExists(
-  components: Pick<AppComponents, 'database'>,
-  entityId: string
-): Promise<boolean> {
-  const { database } = components
-
+export async function deploymentExists(database: DatabaseClient, entityId: string): Promise<boolean> {
   const result = await database.queryWithValues(
     SQL`
     SELECT 1
@@ -48,11 +44,7 @@ export async function deploymentExists(
   return result.rowCount > 0
 }
 
-export async function* streamAllEntityIds(
-  components: Pick<AppComponents, 'database'>
-): AsyncIterable<{ entityId: string }> {
-  const { database } = components
-
+export async function* streamAllEntityIds(database: DatabaseClient): AsyncIterable<{ entityId: string }> {
   for await (const row of database.streamQuery(
     SQL`
       SELECT entity_id FROM deployments
@@ -185,7 +177,7 @@ function configureSortWhereClause(
 }
 
 export async function getHistoricalDeployments(
-  components: Pick<AppComponents, 'database' | 'metrics'>,
+  database: DatabaseClient,
   offset: number,
   limit: number,
   filters?: DeploymentFilters,
@@ -194,7 +186,7 @@ export async function getHistoricalDeployments(
 ): Promise<HistoricalDeployment[]> {
   const query = getHistoricalDeploymentsQuery(offset, limit, filters, sortBy, lastId)
 
-  const historicalDeploymentsResponse = await components.database.queryWithValues(query, 'get_historical_deployments')
+  const historicalDeploymentsResponse = await database.queryWithValues(query, 'get_historical_deployments')
 
   const historicalDeployments: HistoricalDeployment[] = historicalDeploymentsResponse.rows.map(
     (row: HistoricalDeploymentsRow): HistoricalDeployment => ({
@@ -250,10 +242,10 @@ export async function getActiveDeploymentsByContentHash(
 }
 
 export async function getEntityById(
-  components: Pick<AppComponents, 'database'>,
+  database: DatabaseClient,
   entityId: string
 ): Promise<{ entityId: string; localTimestamp: number } | undefined> {
-  const queryResult = await components.database.queryWithValues<{ entityId: string; localTimestamp: number }>(
+  const queryResult = await database.queryWithValues<{ entityId: string; localTimestamp: number }>(
     SQL`
     SELECT
       entity_id AS "entityId",
@@ -271,7 +263,7 @@ export async function getEntityById(
 }
 
 export async function saveDeployment(
-  database: AppComponents['database'],
+  database: DatabaseClient,
   entity: Entity,
   auditInfo: AuditInfo,
   overwrittenBy: DeploymentId | null
@@ -292,10 +284,11 @@ export async function saveDeployment(
 }
 
 export async function saveContentFiles(
-  database: AppComponents['database'],
+  database: DatabaseTransactionalClient,
   deploymentId: DeploymentId,
   content: ContentMapping[]
 ): Promise<void> {
+  // TODO why not a big query?
   const queries = content.map(
     (item) =>
       SQL`INSERT INTO content_files (deployment, key, content_hash) VALUES (${deploymentId}, ${item.file}, ${item.hash})`
@@ -306,7 +299,7 @@ export async function saveContentFiles(
 }
 
 export async function getDeployments(
-  database: AppComponents['database'],
+  database: DatabaseClient,
   deploymentIds: Set<number>
 ): Promise<{ id: number; pointers: string[] }[]> {
   if (deploymentIds.size === 0) return []
@@ -319,19 +312,20 @@ export async function getDeployments(
 }
 
 export async function setEntitiesAsOverwritten(
-  database: AppComponents['database'],
+  database: DatabaseTransactionalClient,
   allOverwritten: Set<DeploymentId>,
   overwrittenBy: DeploymentId
 ): Promise<void> {
   const queries = Array.from(allOverwritten.values()).map(
     (overwritten) => SQL`UPDATE deployments SET deleter_deployment = ${overwrittenBy} WHERE id = ${overwritten}`
   )
+  // TODO why not a big query?
   for (const query of queries) {
     await database.queryWithValues(query)
   }
 }
 
-export async function calculateOverwrote(database: AppComponents['database'], entity: Entity): Promise<DeploymentId[]> {
+export async function calculateOverwrote(database: DatabaseClient, entity: Entity): Promise<DeploymentId[]> {
   return (
     await database.queryWithValues<{ id: number }>(
       SQL`
@@ -348,7 +342,7 @@ export async function calculateOverwrote(database: AppComponents['database'], en
 }
 
 export async function calculateOverwrittenByManyFast(
-  database: AppComponents['database'],
+  database: DatabaseClient,
   entity: Entity
 ): Promise<{ id: number }[]> {
   const q = SQL`
@@ -368,10 +362,7 @@ export async function calculateOverwrittenByManyFast(
   return (await database.queryWithValues<{ id: number }>(q)).rows
 }
 
-export async function calculateOverwrittenBySlow(
-  database: AppComponents['database'],
-  entity: Entity
-): Promise<{ id: number }[]> {
+export async function calculateOverwrittenBySlow(database: DatabaseClient, entity: Entity): Promise<{ id: number }[]> {
   return (
     await database.queryWithValues<{ id: number }>(
       SQL`

--- a/content/src/logic/database-queries/pointers-queries.ts
+++ b/content/src/logic/database-queries/pointers-queries.ts
@@ -1,22 +1,21 @@
 import SQL from 'sql-template-strings'
-import { AppComponents } from '../../types'
+import { DatabaseClient } from '../../ports/postgres'
 
 export async function gerUrnsThatMatchCollectionUrnPrefix(
-  components: Pick<AppComponents, 'database'>,
+  database: DatabaseClient,
   collectionUrn: string
 ): Promise<string[]> {
   // sql-template-strings doesn't allow ' in the query string
   const matchingString = `${collectionUrn}%`
   const query = SQL`SELECT pointer FROM active_pointers as p WHERE p.pointer LIKE ${matchingString} ORDER BY pointer DESC;`
 
-  const queryResult = (await components.database.queryWithValues<{ pointer: string }>(query, 'filter_by_urn_prefix'))
-    .rows
+  const queryResult = (await database.queryWithValues<{ pointer: string }>(query, 'filter_by_urn_prefix')).rows
 
   return queryResult.map((row) => row.pointer)
 }
 
 export async function updateActiveDeployments(
-  components: Pick<AppComponents, 'database'>,
+  database: DatabaseClient,
   pointers: string[],
   entityId: string
 ): Promise<void> {
@@ -32,13 +31,10 @@ export async function updateActiveDeployments(
   value_list.forEach((v) => query.append(v))
   query.append(SQL` ON CONFLICT(pointer) DO UPDATE SET entity_id = ${entityId};`)
 
-  await components.database.queryWithValues(query)
+  await database.queryWithValues(query)
 }
 
-export async function removeActiveDeployments(
-  components: Pick<AppComponents, 'database'>,
-  pointers: string[]
-): Promise<void> {
+export async function removeActiveDeployments(database: DatabaseClient, pointers: string[]): Promise<void> {
   const value_list = pointers.map((p, i) => {
     if (i < pointers.length - 1) {
       return SQL`${p},`
@@ -50,5 +46,5 @@ export async function removeActiveDeployments(
   value_list.forEach((v) => query.append(v))
   query.append(`);`)
 
-  await components.database.queryWithValues(query)
+  await database.queryWithValues(query)
 }

--- a/content/src/logic/deployments.ts
+++ b/content/src/logic/deployments.ts
@@ -9,7 +9,7 @@ import {
   PartialDeploymentHistory
 } from '../deployment-types'
 import { FailedDeployment } from '../ports/failedDeployments'
-import { IDatabaseComponent } from '../ports/postgres'
+import { DatabaseClient, DatabaseTransactionalClient } from '../ports/postgres'
 import { deployEntityFromRemoteServer } from '../service/synchronization/deployRemoteEntity'
 import { IGNORING_FIX_ERROR } from '../service/validations/server'
 import { AppComponents, DeploymentId, EntityVersion } from '../types'
@@ -27,14 +27,15 @@ import {
 } from './database-queries/deployments-queries'
 
 export async function isEntityDeployed(
-  components: Pick<AppComponents, 'deployedEntitiesBloomFilter' | 'database' | 'metrics'>,
+  database: DatabaseClient,
+  components: Pick<AppComponents, 'deployedEntitiesBloomFilter' | 'metrics'>,
   entityId: string
 ): Promise<boolean> {
   // this condition should be carefully handled:
   // 1) it first uses the bloom filter to know wheter or not an entity may exist or definitely don't exist (.check)
   // 2) then it checks against the DB (deploymentExists)
   if (await components.deployedEntitiesBloomFilter.check(entityId)) {
-    if (await deploymentExists(components, entityId)) {
+    if (await deploymentExists(database, entityId)) {
       components.metrics.increment('dcl_deployed_entities_bloom_filter_checks_total', { hit: 'true' })
       return true
     } else {
@@ -114,7 +115,7 @@ export function mapDeploymentsToEntities(deployments: Deployment[]): Entity[] {
 }
 
 export async function saveDeploymentAndContentFiles(
-  database: IDatabaseComponent,
+  database: DatabaseTransactionalClient,
   entity: Entity,
   auditInfo: AuditInfo,
   overwrittenBy: DeploymentId | null
@@ -127,7 +128,7 @@ export async function saveDeploymentAndContentFiles(
 }
 
 export async function calculateOverwrites(
-  database: IDatabaseComponent,
+  database: DatabaseClient,
   entity: Entity
 ): Promise<{ overwrote: Set<DeploymentId>; overwrittenBy: DeploymentId | null }> {
   const overwrote = await calculateOverwrote(database, entity)
@@ -159,14 +160,15 @@ export function getCuratedLimit(options?: DeploymentOptions): number {
 }
 
 export async function getDeployments(
-  components: Pick<AppComponents, 'database' | 'denylist' | 'metrics'>,
+  components: Pick<AppComponents, 'denylist' | 'metrics'>,
+  database: DatabaseClient,
   options?: DeploymentOptions
 ): Promise<PartialDeploymentHistory<Deployment>> {
   const curatedOffset = getCuratedOffset(options)
   const curatedLimit = getCuratedLimit(options)
 
   const deploymentsWithExtra = await getHistoricalDeployments(
-    components,
+    database,
     curatedOffset,
     curatedLimit + 1,
     options?.filters,
@@ -180,7 +182,7 @@ export async function getDeployments(
 
   const deploymentIds = deploymentsResult.map(({ deploymentId }) => deploymentId)
 
-  const content = await getContentFiles(components, deploymentIds)
+  const content = await getContentFiles(database, deploymentIds)
 
   if (!options?.includeDenylisted) {
     deploymentsResult = deploymentsResult.filter((result) => !components.denylist.isDenylisted(result.entityId))
@@ -218,7 +220,7 @@ export async function getDeployments(
 }
 
 export async function getDeploymentsForActiveEntities(
-  components: Pick<AppComponents, 'database' | 'denylist' | 'metrics'>,
+  database: DatabaseClient,
   entityIds?: string[],
   pointers?: string[]
 ): Promise<Deployment[]> {
@@ -249,7 +251,7 @@ export async function getDeploymentsForActiveEntities(
       : SQL`dep1.entity_pointers && ${pointers!.map((p) => p.toLowerCase())}`
   )
 
-  const historicalDeploymentsResponse = await components.database.queryWithValues(query, 'get_active_entities')
+  const historicalDeploymentsResponse = await database.queryWithValues(query, 'get_active_entities')
 
   const deploymentsResult: HistoricalDeployment[] = historicalDeploymentsResponse.rows.map(
     (row: HistoricalDeploymentsRow): HistoricalDeployment => ({
@@ -269,7 +271,7 @@ export async function getDeploymentsForActiveEntities(
 
   const deploymentIds = deploymentsResult.map(({ deploymentId }) => deploymentId)
 
-  const content = await getContentFiles(components, deploymentIds)
+  const content = await getContentFiles(database, deploymentIds)
 
   return deploymentsResult.map((result) => ({
     entityVersion: result.version as EntityVersion,

--- a/content/src/ports/deployedEntitiesBloomFilter.ts
+++ b/content/src/ports/deployedEntitiesBloomFilter.ts
@@ -23,7 +23,7 @@ export function createDeployedEntitiesBloomFilter(
     const start = components.clock.now()
     logger.info(`Creating bloom filter`, {})
     let elements = 0
-    for await (const row of streamAllEntityIds(components)) {
+    for await (const row of streamAllEntityIds(components.database)) {
       elements++
       deploymentsBloomFilter.add(row.entityId)
     }

--- a/content/src/ports/processedSnapshotStorage.ts
+++ b/content/src/ports/processedSnapshotStorage.ts
@@ -14,7 +14,7 @@ export function createProcessedSnapshotStorage(
       if (snapshotsInCache.length == snapshotHashes.length) {
         return new Set(snapshotHashes)
       }
-      const processedSnapshots = await getProcessedSnapshots(components, snapshotHashes)
+      const processedSnapshots = await getProcessedSnapshots(components.database, snapshotHashes)
       for (const processedSnapshot of processedSnapshots) {
         processedSnapshotsCache.add(processedSnapshot)
       }

--- a/content/src/ports/snapshotStorage.ts
+++ b/content/src/ports/snapshotStorage.ts
@@ -4,7 +4,7 @@ import { AppComponents } from '../types'
 export function createSnapshotStorage(components: Pick<AppComponents, 'database'>) {
   return {
     async has(snapshotHash: string) {
-      return isOwnSnapshot(components, snapshotHash)
+      return isOwnSnapshot(components.database, snapshotHash)
     }
   }
 }

--- a/content/src/service/garbage-collection/GarbageCollectionManager.ts
+++ b/content/src/service/garbage-collection/GarbageCollectionManager.ts
@@ -49,7 +49,7 @@ export class GarbageCollectionManager {
     this.sweeping = true
     const { end: endTimer } = this.components.metrics.startTimer('dcl_content_garbage_collection_time')
     try {
-      const hashes = await findContentHashesNotBeingUsedAnymore(this.components, this.lastTimeOfCollection)
+      const hashes = await findContentHashesNotBeingUsedAnymore(this.components.database, this.lastTimeOfCollection)
 
       this.components.metrics.increment('dcl_content_garbage_collection_items_total', {}, hashes.length)
 

--- a/content/src/service/pointers/PointerManager.ts
+++ b/content/src/service/pointers/PointerManager.ts
@@ -1,6 +1,6 @@
 import { Entity } from '@dcl/schemas'
 import { getDeployments } from '../../logic/database-queries/deployments-queries'
-import { IDatabaseComponent } from '../../ports/postgres'
+import { DatabaseClient } from '../../ports/postgres'
 import { DeploymentId } from '../../types'
 
 /**
@@ -17,7 +17,7 @@ export class PointerManager {
    * @returns {DeploymentResult} A map where the keys are pointers and the values are a map with before and after value. Before value is the id of the entity deployed before (or undefined) and after is either 'set' or 'cleared'. For e.g. Map(1) { '0x1728f191d246b5a50af7a9494793af74f449a514' => { before: 5199630, after: 'set' }
    */
   async referenceEntityFromPointers(
-    database: IDatabaseComponent,
+    database: DatabaseClient,
     entity: Entity,
     overwrittenDeploymentIds: Set<number>,
     isEntityOverwrittenByAnExistingDeployment: boolean

--- a/content/src/service/pointers/pointers.ts
+++ b/content/src/service/pointers/pointers.ts
@@ -1,4 +1,5 @@
 import { PointerChangesSyncDeployment } from '@dcl/schemas'
+import { DatabaseClient } from 'src/ports/postgres'
 import { PointerChangesOptions } from '../../deployment-types'
 import { getHistoricalDeployments, HistoricalDeployment } from '../../logic/database-queries/deployments-queries'
 import { AppComponents } from '../../types'
@@ -7,14 +8,15 @@ import { DeploymentPointerChanges } from './types'
 const MAX_HISTORY_LIMIT = 500
 
 export async function getPointerChanges(
-  components: Pick<AppComponents, 'database' | 'denylist' | 'metrics'>,
+  components: Pick<AppComponents, 'denylist' | 'metrics'>,
+  database: DatabaseClient,
   options?: PointerChangesOptions
 ): Promise<DeploymentPointerChanges> {
   const curatedOffset = options?.offset && options?.offset >= 0 ? options?.offset : 0
   const curatedLimit =
     options?.limit && options?.limit > 0 && options?.limit <= MAX_HISTORY_LIMIT ? options?.limit : MAX_HISTORY_LIMIT
   let deploymentsWithExtra: HistoricalDeployment[] = await getHistoricalDeployments(
-    components,
+    database,
     curatedOffset,
     curatedLimit + 1,
     options?.filters,

--- a/content/src/service/synchronization/batchDeployer.ts
+++ b/content/src/service/synchronization/batchDeployer.ts
@@ -63,7 +63,7 @@ export function createBatchDeployerComponent(
     if (successfulDeployments.has(entity.entityId)) return true
 
     // ignore entities that are already deployed locally
-    if (await isEntityDeployed(components, entity.entityId)) {
+    if (await isEntityDeployed(components.database, components, entity.entityId)) {
       successfulDeployments.add(entity.entityId)
       return true
     }
@@ -127,7 +127,7 @@ export function createBatchDeployerComponent(
              *  3. The entity failed to be deployed but was successfully persisted as failed deployment
              */
             // 1. The entity is already deployed, early return.
-            if (await isEntityDeployed(components, entity.entityId)) {
+            if (await isEntityDeployed(components.database, components, entity.entityId)) {
               const markAsDeployedFns = deploymentsMap.get(entity.entityId)?.markAsDeployedFns ?? []
               for (const markAsDeployed of markAsDeployedFns) {
                 await markAsDeployed()

--- a/content/test/integration/E2EAssertions.ts
+++ b/content/test/integration/E2EAssertions.ts
@@ -20,7 +20,8 @@ export async function assertEntitiesAreDeployedButNotActive(server: TestProgram,
     assert.equal(
       unexpectedEntities.length,
       0,
-      `Expected not to find entity with id ${entity.id} when checking for pointer ${entity.pointers
+      `Expected not to find entity with id ${entity.id} when checking for pointer ${
+        entity.pointers
       } on server '${server.getUrl()}.'`
     )
     await assertEntityIsOnServer(server, entity)
@@ -79,15 +80,13 @@ export async function assertDeploymentsCount(server: TestProgram, count: number)
   )
 }
 
-export async function assertDeploymentsAreReported(
-  server: TestProgram,
-  ...expectedDeployments: Deployment[]
-) {
-  const { deployments } = await getDeployments(server.components)
+export async function assertDeploymentsAreReported(server: TestProgram, ...expectedDeployments: Deployment[]) {
+  const { deployments } = await getDeployments(server.components, server.components.database)
   assert.equal(
     deployments.length,
     expectedDeployments.length,
-    `Expected to find ${expectedDeployments.length} deployments on server ${server.getUrl()}. Instead, found ${deployments.length
+    `Expected to find ${expectedDeployments.length} deployments on server ${server.getUrl()}. Instead, found ${
+      deployments.length
     }.`
   )
 
@@ -161,11 +160,7 @@ export async function assertFileIsNotOnServer(server: TestProgram, hash: string)
   await assertPromiseIsRejected(() => server.downloadContent(hash))
 }
 
-export async function assertEntityIsOverwrittenBy(
-  server: TestProgram,
-  entity: Entity,
-  overwrittenBy: Entity
-) {
+export async function assertEntityIsOverwrittenBy(server: TestProgram, entity: Entity, overwrittenBy: Entity) {
   // Legacy check
   const auditInfo = await server.getAuditInfo(entity)
   assert.equal(auditInfo.overwrittenBy, overwrittenBy.id)
@@ -205,11 +200,7 @@ export async function assertEntityIsDenylisted(server: TestProgram, entity: Enti
   assert.ok(deployment.auditInfo.isDenylisted)
 }
 
-export async function assertContentNotIsDenylisted(
-  server: TestProgram,
-  entity: Entity,
-  contentHash: string
-) {
+export async function assertContentNotIsDenylisted(server: TestProgram, entity: Entity, contentHash: string) {
   // Legacy check
   const auditInfo = await server.getAuditInfo(entity)
   assert.ok(!auditInfo.denylistedContent || !auditInfo.denylistedContent.includes(contentHash))
@@ -219,11 +210,7 @@ export async function assertContentNotIsDenylisted(
   assert.ok(!deployment.auditInfo.denylistedContent || !deployment.auditInfo.denylistedContent.includes(contentHash))
 }
 
-export async function assertContentIsDenylisted(
-  server: TestProgram,
-  entity: Entity,
-  contentHash: string
-) {
+export async function assertContentIsDenylisted(server: TestProgram, entity: Entity, contentHash: string) {
   // Legacy check
   const auditInfo = await server.getAuditInfo(entity)
   assert.ok(auditInfo.denylistedContent!.includes(contentHash))
@@ -233,11 +220,7 @@ export async function assertContentIsDenylisted(
   assert.ok(deployment.auditInfo.denylistedContent!.includes(contentHash))
 }
 
-export function buildDeployment(
-  deployData: DeploymentData,
-  entity: Entity,
-  deploymentTimestamp: number
-): Deployment {
+export function buildDeployment(deployData: DeploymentData, entity: Entity, deploymentTimestamp: number): Deployment {
   return {
     ...entity,
     entityVersion: EntityVersion.V3,

--- a/content/test/integration/TestProgram.ts
+++ b/content/test/integration/TestProgram.ts
@@ -98,7 +98,7 @@ export class TestProgram {
 
   async getDeployments(options?: DeploymentOptions): Promise<Deployment[]> {
     const filters = Object.assign({ from: 1 }, options?.filters)
-    const deployments = await getDeployments(this.components, { ...options, filters })
+    const deployments = await getDeployments(this.components, this.components.database, { ...options, filters })
     return deployments.deployments
   }
 

--- a/content/test/integration/logic/snapshots.spec.ts
+++ b/content/test/integration/logic/snapshots.spec.ts
@@ -340,7 +340,7 @@ describe('snapshot generator - ', () => {
       await generateSnapshotsInMultipleTimeRanges(components, timeRangeOfDaysFromInitialTimestamp(15))
       // expect first week snapshot to be present
       const snapshots = await snapshotQueries.findSnapshotsStrictlyContainedInTimeRange(
-        components,
+        components.database,
         timeRangeOfDaysFromInitialTimestamp(15)
       )
       expect(snapshots[0].timeRange).toEqual(timeRangeOfDaysFromInitialTimestamp(7))

--- a/content/test/integration/ports/deployer/concurrent-deployments.spec.ts
+++ b/content/test/integration/ports/deployer/concurrent-deployments.spec.ts
@@ -39,16 +39,14 @@ describe('Integration - Concurrent deployments', () => {
       await Promise.all(entities.map((entityCombo) => deployEntity(deployer, entityCombo, components)))
 
       // Assert that only one is active
-      const { deployments } = await getDeployments(components, { filters: { pointers: [P1], onlyCurrentlyPointed: true } })
+      const { deployments } = await getDeployments(components, components.database, {
+        filters: { pointers: [P1], onlyCurrentlyPointed: true }
+      })
       expect(deployments.length).toEqual(1)
     }
   )
 
-  async function deployEntity(
-    deployer: Deployer,
-    entity: EntityCombo,
-    components: Pick<AppComponents, 'logs'>
-  ) {
+  async function deployEntity(deployer: Deployer, entity: EntityCombo, components: Pick<AppComponents, 'logs'>) {
     const logger = components.logs.getLogger('ConcurrentCheckTest/DeployEntity')
     try {
       logger.info('deploying', entity as any)

--- a/content/test/integration/ports/deployer/deployment-entity-overlap.spec.ts
+++ b/content/test/integration/ports/deployer/deployment-entity-overlap.spec.ts
@@ -145,7 +145,9 @@ describe('Integration - Deployment with Entity Overlaps', () => {
     components: Pick<AppComponents, 'database' | 'denylist' | 'metrics'>,
     ...expectedEntities: EntityCombo[]
   ) {
-    const actualDeployments = await getDeployments(components, { filters: { onlyCurrentlyPointed: true } })
+    const actualDeployments = await getDeployments(components, components.database, {
+      filters: { onlyCurrentlyPointed: true }
+    })
     const expectedEntityIds = expectedEntities.map((entityCombo) => entityCombo.entity.id).sort()
     const actualEntityIds = actualDeployments.deployments.map(({ entityId }) => entityId).sort()
     expect({ deployedEntityIds: actualEntityIds }).toEqual({ deployedEntityIds: expectedEntityIds })

--- a/content/test/integration/ports/deployer/deployment-filters.spec.ts
+++ b/content/test/integration/ports/deployer/deployment-filters.spec.ts
@@ -1,6 +1,9 @@
 import { EntityType } from '@dcl/schemas'
 import {
-  AuditInfo, DeploymentContext, DeploymentFilters, DeploymentResult,
+  AuditInfo,
+  DeploymentContext,
+  DeploymentFilters,
+  DeploymentResult,
   isInvalidDeployment,
   isSuccessfulDeployment
 } from '../../../../src/deployment-types'
@@ -125,7 +128,7 @@ describe('Integration - Deployment Filters', () => {
     filter: DeploymentFilters,
     ...expectedEntities: EntityCombo[]
   ) {
-    const actualDeployments = await getDeployments(components, { filters: filter })
+    const actualDeployments = await getDeployments(components, components.database, { filters: filter })
     const expectedEntityIds = expectedEntities.map((entityCombo) => entityCombo.entity.id).sort()
     const actualEntityIds = actualDeployments.deployments.map(({ entityId }) => entityId).sort()
     expect({ filter, deployedEntityIds: actualEntityIds }).toEqual({ filter, deployedEntityIds: expectedEntityIds })

--- a/content/test/integration/ports/deployer/order-check.spec.ts
+++ b/content/test/integration/ports/deployer/order-check.spec.ts
@@ -50,7 +50,7 @@ describe('Integration - Order Check', () => {
   }
 
   async function getActiveDeployments(components: Pick<AppComponents, 'database' | 'denylist' | 'metrics'>) {
-    const { deployments } = await getDeployments(components, {
+    const { deployments } = await getDeployments(components, components.database, {
       filters: {
         onlyCurrentlyPointed: true
       }

--- a/content/test/integration/ports/deployer/same-timestamp-check.spec.ts
+++ b/content/test/integration/ports/deployer/same-timestamp-check.spec.ts
@@ -61,8 +61,11 @@ describe('Integration - Same Timestamp Check', () => {
     }
   )
 
-  async function assertIsActive(components: Pick<AppComponents, 'database' | 'denylist' | 'metrics'>, entityCombo: EntityCombo) {
-    const { deployments } = await getDeployments(components, {
+  async function assertIsActive(
+    components: Pick<AppComponents, 'database' | 'denylist' | 'metrics'>,
+    entityCombo: EntityCombo
+  ) {
+    const { deployments } = await getDeployments(components, components.database, {
       filters: { entityIds: [entityCombo.controllerEntity.id], onlyCurrentlyPointed: true }
     })
     expect(deployments.length).toEqual(1)

--- a/content/test/integration/ports/failedDeployments.spec.ts
+++ b/content/test/integration/ports/failedDeployments.spec.ts
@@ -97,9 +97,11 @@ async function startComponentsWithBaseFailedDeployments(
 ) {
   await startComponent(components.metrics, startOptions)
   await startComponent(components.database, startOptions)
-  for (const failedDeployment of baseFailedDeployments) {
-    await saveSnapshotFailedDeployment(components, failedDeployment)
-  }
+  await components.database.transaction(async (db) => {
+    for (const failedDeployment of baseFailedDeployments) {
+      await saveSnapshotFailedDeployment(db, failedDeployment)
+    }
+  })
   await startComponent(components.failedDeployments, startOptions)
 }
 

--- a/content/test/integration/syncronization/bootstrapping.spec.ts
+++ b/content/test/integration/syncronization/bootstrapping.spec.ts
@@ -62,7 +62,10 @@ describe('Bootstrapping synchronization tests', function () {
       ).rows.map((s) => s.hash)
     )
 
-    const server2ProcessedSnapshots = await getProcessedSnapshots(server2.components, Array.from(server1Snapshots))
+    const server2ProcessedSnapshots = await getProcessedSnapshots(
+      server2.components.database,
+      Array.from(server1Snapshots)
+    )
     expect(server1Snapshots.size > 0).toBeTruthy()
     expect(server2ProcessedSnapshots).toEqual(server1Snapshots)
   })
@@ -134,7 +137,7 @@ describe('Bootstrapping synchronization tests', function () {
     )
     jest.spyOn(server2.components.snapshotStorage, 'has').mockResolvedValue(false)
     await startProgramAndWaitUntilBootstrapFinishes(server2)
-    const sevenDaysSnapshots = await findSnapshotsStrictlyContainedInTimeRange(server1.components, {
+    const sevenDaysSnapshots = await findSnapshotsStrictlyContainedInTimeRange(server1.components.database, {
       initTimestamp: initialTimestamp,
       endTimestamp: fakeNow()
     })
@@ -172,7 +175,7 @@ describe('Bootstrapping synchronization tests', function () {
     ).onSyncFinished()
     await server2.components.downloadQueue.onIdle()
     await server2.components.batchDeployer.onIdle()
-    const eightDaysSnapshots = await findSnapshotsStrictlyContainedInTimeRange(server1.components, {
+    const eightDaysSnapshots = await findSnapshotsStrictlyContainedInTimeRange(server1.components.database, {
       initTimestamp: initialTimestamp,
       endTimestamp: fakeNow()
     })
@@ -235,7 +238,7 @@ describe('Bootstrapping synchronization tests', function () {
     )
 
     // assert that the entity was not deployed on server 2
-    const { deployments } = await getDeployments(server2.components)
+    const { deployments } = await getDeployments(server2.components, server2.components.database)
     expect(deployments).toHaveLength(0)
   })
 

--- a/content/test/unit/logic/content-files-queries.spec.ts
+++ b/content/test/unit/logic/content-files-queries.spec.ts
@@ -1,13 +1,10 @@
-import { createTestMetricsComponent } from '@well-known-components/metrics'
 import { ContentFilesRow, getContentFiles } from '../../../src/logic/database-queries/content-files-queries'
-import { metricsDeclaration } from '../../../src/metrics'
 import { AppComponents } from '../../../src/types'
 
 describe('content files queries', () => {
   describe('getContentFiles', () => {
-    const components: Pick<AppComponents, 'database' | 'metrics'> = {
-      database: { queryWithValues: () => {} },
-      metrics: createTestMetricsComponent(metricsDeclaration)
+    const components: Pick<AppComponents, 'database'> = {
+      database: { queryWithValues: () => {} }
     } as any
 
     const deploymentIds = [127, 255]
@@ -38,7 +35,7 @@ describe('content files queries', () => {
     })
 
     it('should return a map from deployment id to an array of content', async () => {
-      const result = await getContentFiles(components, deploymentIds)
+      const result = await getContentFiles(components.database, deploymentIds)
       expect(result).toMatchObject(
         new Map([
           [

--- a/content/test/unit/logic/deployments-service.spec.ts
+++ b/content/test/unit/logic/deployments-service.spec.ts
@@ -91,7 +91,7 @@ describe('deployments service', () => {
       })
 
       it('should return the deployments result of passing the correct filters to get the historical deployments', async () => {
-        result = await getDeployments(components, options)
+        result = await getDeployments(components, components.database, options)
 
         expect(result).toEqual(
           expect.objectContaining({
@@ -121,7 +121,7 @@ describe('deployments service', () => {
 
       it("should not return a deployment if it's denylisted", async () => {
         jest.spyOn(components.denylist, 'isDenylisted').mockReturnValueOnce(true).mockReturnValueOnce(false)
-        result = await getDeployments(components, options)
+        result = await getDeployments(components, components.database, options)
 
         expect(result).toEqual(
           expect.objectContaining({
@@ -150,7 +150,7 @@ describe('deployments service', () => {
 
       it("should not return a deployment if it's denylisted", async () => {
         jest.spyOn(components.denylist, 'isDenylisted').mockReturnValueOnce(true).mockReturnValueOnce(false)
-        result = await getDeployments(components, { ...options, includeDenylisted: true })
+        result = await getDeployments(components, components.database, { ...options, includeDenylisted: true })
 
         expect(result).toEqual(
           expect.objectContaining({

--- a/content/test/unit/logic/deployments.spec.ts
+++ b/content/test/unit/logic/deployments.spec.ts
@@ -8,7 +8,7 @@ const metrics = createTestMetricsComponent(metricsDeclaration)
 describe('isEntityDeployed', () => {
   it('when deployedEntitiesBloomFilter returns true, then it should call the database', async () => {
     const database = createTestDatabaseComponent()
-    database.queryWithValues = jest.fn().mockResolvedValue({rowCount: 1})
+    database.queryWithValues = jest.fn().mockResolvedValue({ rowCount: 1 })
     const deployedEntitiesBloomFilter = deployedEntitiesBloomFilterWithEntity('id')
     const metricsSpy = jest.spyOn(metrics, 'increment')
     const components = {
@@ -16,14 +16,14 @@ describe('isEntityDeployed', () => {
       database,
       deployedEntitiesBloomFilter
     }
-    await isEntityDeployed(components, 'id')
+    await isEntityDeployed(components.database, components, 'id')
     expect(components.database.queryWithValues).toBeCalled()
     expect(metricsSpy).toBeCalledWith('dcl_deployed_entities_bloom_filter_checks_total', { hit: 'true' })
   })
 
   it('when deployedEntitiesBloomFilter returns false, then it should not call the database', async () => {
     const database = createTestDatabaseComponent()
-    database.queryWithValues = jest.fn().mockResolvedValue({rowCount: 1})
+    database.queryWithValues = jest.fn().mockResolvedValue({ rowCount: 1 })
     const components = {
       metrics,
       database,
@@ -32,13 +32,13 @@ describe('isEntityDeployed', () => {
         check: jest.fn().mockResolvedValue(false)
       }
     }
-    await isEntityDeployed(components, 'id')
+    await isEntityDeployed(components.database, components, 'id')
     expect(components.database.queryWithValues).not.toBeCalled()
   })
 
   it('when deployedEntitiesBloomFilter returns true and the entity exists in db, it should return true', async () => {
     const database = createTestDatabaseComponent()
-    database.queryWithValues = jest.fn().mockResolvedValue({rowCount: 1})
+    database.queryWithValues = jest.fn().mockResolvedValue({ rowCount: 1 })
     const components = {
       metrics,
       database,
@@ -47,13 +47,13 @@ describe('isEntityDeployed', () => {
         check: jest.fn().mockResolvedValue(true)
       }
     }
-    const isDeployed = await isEntityDeployed(components, 'id')
+    const isDeployed = await isEntityDeployed(components.database, components, 'id')
     expect(isDeployed).toBeTruthy()
   })
 
   it('when deployedEntitiesBloomFilter returns true and the entity dont exists in db, it should return false', async () => {
     const database = createTestDatabaseComponent()
-    database.queryWithValues = jest.fn().mockResolvedValue({rowCount: 0})
+    database.queryWithValues = jest.fn().mockResolvedValue({ rowCount: 0 })
     const components = {
       metrics,
       database,
@@ -62,13 +62,13 @@ describe('isEntityDeployed', () => {
         check: jest.fn().mockResolvedValue(true)
       }
     }
-    const isDeployed = await isEntityDeployed(components, 'id')
+    const isDeployed = await isEntityDeployed(components.database, components, 'id')
     expect(isDeployed).toBeFalsy()
   })
 
   it('when deployedEntitiesBloomFilter returns true and db too, then it should register as non false positive', async () => {
     const database = createTestDatabaseComponent()
-    database.queryWithValues = jest.fn().mockResolvedValue({rowCount: 1})
+    database.queryWithValues = jest.fn().mockResolvedValue({ rowCount: 1 })
     const deployedEntitiesBloomFilter = deployedEntitiesBloomFilterWithEntity('id')
     const metricsSpy = jest.spyOn(metrics, 'increment')
     const components = {
@@ -76,13 +76,13 @@ describe('isEntityDeployed', () => {
       database,
       deployedEntitiesBloomFilter: deployedEntitiesBloomFilter
     }
-    await isEntityDeployed(components, 'id')
+    await isEntityDeployed(components.database, components, 'id')
     expect(metricsSpy).toBeCalledWith('dcl_deployed_entities_bloom_filter_checks_total', { hit: 'true' })
   })
 
   it('when deployedEntitiesBloomFilter returns false, then it should register as non false positive', async () => {
     const database = createTestDatabaseComponent()
-    database.queryWithValues = jest.fn().mockResolvedValue({rowCount: 1})
+    database.queryWithValues = jest.fn().mockResolvedValue({ rowCount: 1 })
     const deployedEntitiesBloomFilter = deployedEntitiesBloomFilterWithEntity('id')
     const metricsSpy = jest.spyOn(metrics, 'increment')
     const components = {
@@ -90,13 +90,13 @@ describe('isEntityDeployed', () => {
       database,
       deployedEntitiesBloomFilter
     }
-    await isEntityDeployed(components, 'another-id')
+    await isEntityDeployed(components.database, components, 'another-id')
     expect(metricsSpy).toBeCalledWith('dcl_deployed_entities_bloom_filter_checks_total', { hit: 'true' })
   })
 
   it('when deployedEntitiesBloomFilter returns true and db false, then it should register as false positive', async () => {
     const database = createTestDatabaseComponent()
-    database.queryWithValues = jest.fn().mockResolvedValue({rowCount: 0})
+    database.queryWithValues = jest.fn().mockResolvedValue({ rowCount: 0 })
     const deployedEntitiesBloomFilter = deployedEntitiesBloomFilterWithEntity('id')
     const metricsSpy = jest.spyOn(metrics, 'increment')
     const components = {
@@ -104,7 +104,7 @@ describe('isEntityDeployed', () => {
       database,
       deployedEntitiesBloomFilter
     }
-    await isEntityDeployed(components, 'id')
+    await isEntityDeployed(components.database, components, 'id')
     expect(metricsSpy).toBeCalledWith('dcl_deployed_entities_bloom_filter_checks_total', { hit: 'false' })
   })
 })

--- a/content/test/unit/ports/failedDeployments.spec.ts
+++ b/content/test/unit/ports/failedDeployments.spec.ts
@@ -3,7 +3,7 @@ import { createTestMetricsComponent } from '@well-known-components/metrics'
 import * as failedDeploymentQueries from '../../../src/logic/database-queries/failed-deployments-queries'
 import { metricsDeclaration } from '../../../src/metrics'
 import { createFailedDeployments, FailureReason, SnapshotFailedDeployment } from '../../../src/ports/failedDeployments'
-import { createTestDatabaseComponent } from '../../../src/ports/postgres'
+import { createTestDatabaseComponent, DatabaseTransactionalClient } from '../../../src/ports/postgres'
 import { AppComponents } from '../../../src/types'
 
 describe('failed deployments', () => {
@@ -70,9 +70,9 @@ describe('failed deployments', () => {
   it('should report failed deployment and delete the previous one if there was one with the same entity id', async () => {
     const saveSpy = jest.spyOn(failedDeploymentQueries, 'saveSnapshotFailedDeployment').mockImplementation()
     const deleteSpy = jest.spyOn(failedDeploymentQueries, 'deleteFailedDeployment').mockImplementation()
-    const txSpy = jest
-      .spyOn(database, 'transaction')
-      .mockImplementation(async (fnToRun) => await fnToRun({ insideTx: true, ...database }))
+
+    const txDb: DatabaseTransactionalClient = { insideTx: true, ...database }
+    const txSpy = jest.spyOn(database, 'transaction').mockImplementation((fnToRun) => fnToRun(txDb))
     const components = { metrics, database }
     const failedDeployments = await createAndStartFailedDeploymentsWith(components, [aFailedDeployment])
     const newFailedDeploymentWithSameId = {
@@ -86,7 +86,7 @@ describe('failed deployments', () => {
     expect(failed).toHaveLength(1)
     expect(failed[0]).toEqual(newFailedDeploymentWithSameId)
     expect(failed[0].failureTimestamp).toEqual(aFailedDeployment.failureTimestamp + 10)
-    expect(saveSpy).toHaveBeenCalledWith(database, newFailedDeploymentWithSameId)
+    expect(saveSpy).toHaveBeenCalledWith(txDb, newFailedDeploymentWithSameId)
     expect(deleteSpy).toHaveBeenCalledWith(database, aFailedDeployment.entityId)
     expect(txSpy).toHaveBeenCalled()
   })

--- a/package.json
+++ b/package.json
@@ -55,7 +55,5 @@
   "jest-junit": {
     "addFileAttribute": "true"
   },
-  "dependencies": {
-    "@dcl/content-validator": "https://sdk-team-cdn.decentraland.org/@dcl//branch//dcl-content-validator-4.5.4-4930871395.commit-c8342d1.tgz"
-  }
+  "dependencies": {}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -373,20 +373,6 @@
     ms "^2.1.3"
     sharp "^0.32.0"
 
-"@dcl/content-validator@https://sdk-team-cdn.decentraland.org/@dcl//branch//dcl-content-validator-4.5.4-4930871395.commit-c8342d1.tgz":
-  version "4.5.4-4930871395.commit-c8342d1"
-  resolved "https://sdk-team-cdn.decentraland.org/@dcl//branch//dcl-content-validator-4.5.4-4930871395.commit-c8342d1.tgz#20fa76801c31a61603d5b4cc5d306e21f33c231f"
-  dependencies:
-    "@dcl/block-indexer" "^1.1.1"
-    "@dcl/content-hash-tree" "^1.1.4"
-    "@dcl/hashing" "^1.1.3"
-    "@dcl/schemas" "6.18.1"
-    "@dcl/urn-resolver" "^2.0.3"
-    "@well-known-components/interfaces" "^1.3.0"
-    "@well-known-components/thegraph-component" "^1.4.3"
-    ms "^2.1.3"
-    sharp "^0.32.0"
-
 "@dcl/crypto@^3.4.1":
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/@dcl/crypto/-/crypto-3.4.1.tgz#2ab9b9b5b18efbe5d65eee3936c0f73c20480858"
@@ -396,7 +382,7 @@
     eth-connect "^6.0.3"
     ethereum-cryptography "^1.0.3"
 
-"@dcl/hashing@^1.0.0", "@dcl/hashing@^1.1.0", "@dcl/hashing@^1.1.3":
+"@dcl/hashing@^1.0.0", "@dcl/hashing@^1.1.0":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@dcl/hashing/-/hashing-1.1.3.tgz#9ca331495333d8cf87310dc563475ca532d7f827"
   integrity sha512-mU1+Q8jcFLAR1hSBOd6WcnLwvQmKIPAH8+UPf2DZUk+Ntu7jWqSOqG+PoWRlh7/gPfI/gKofeW0a+HzVUK6N/g==
@@ -413,15 +399,6 @@
     ethereum-cryptography "^1.0.3"
     ipfs-unixfs-importer "^7.0.3"
     multiformats "^9.6.3"
-
-"@dcl/schemas@6.18.1":
-  version "6.18.1"
-  resolved "https://registry.yarnpkg.com/@dcl/schemas/-/schemas-6.18.1.tgz#c912223d529d6327463fe069ff5c4211dd404c9c"
-  integrity sha512-Us8E1FoJhG7jRRLjixkt6U79zD7oROdsjydo4t0t381xiNFZNUdclJQY6PGwEKCvPvO30cSR4OZCbqUT4DaFHg==
-  dependencies:
-    ajv "^8.11.0"
-    ajv-errors "^3.0.0"
-    ajv-keywords "^5.1.0"
 
 "@dcl/schemas@6.19.0", "@dcl/schemas@^6.19.0", "@dcl/schemas@^6.2.0", "@dcl/schemas@^6.4.2":
   version "6.19.0"


### PR DESCRIPTION
The database component `.transaction` returns a client that cannot create transactions itself, so no recursive transactions are possible. 