### PR TITLE
fix: array query params handling to support param[] format

### DIFF
--- a/content/src/controller/Controller.ts
+++ b/content/src/controller/Controller.ts
@@ -365,8 +365,9 @@ export async function getAvailableContent(
   context: HandlerContextWithPath<'denylist' | 'storage', '/available-content'>
 ) {
   const { storage, denylist } = context.components
-  const queryParams = qsParser(context.url.searchParams)
-  const cids: string[] = qsGetArray(queryParams, 'cid')
+  // const queryParams = qsParser(context.url.searchParams)
+  // const cids: string[] = qsGetArray(queryParams, 'cid')
+  const cids = context.url.searchParams.getAll('cid')
 
   if (cids.length === 0) {
     return {

--- a/content/src/controller/Controller.ts
+++ b/content/src/controller/Controller.ts
@@ -365,9 +365,8 @@ export async function getAvailableContent(
   context: HandlerContextWithPath<'denylist' | 'storage', '/available-content'>
 ) {
   const { storage, denylist } = context.components
-  // const queryParams = qsParser(context.url.searchParams)
-  // const cids: string[] = qsGetArray(queryParams, 'cid')
-  const cids = context.url.searchParams.getAll('cid')
+  const queryParams = qsParser(context.url.searchParams)
+  const cids: string[] = qsGetArray(queryParams, 'cid')
 
   if (cids.length === 0) {
     return {

--- a/content/src/controller/Controller.ts
+++ b/content/src/controller/Controller.ts
@@ -22,7 +22,7 @@ import { getActiveDeploymentsByContentHash } from '../logic/database-queries/dep
 import { getDeployments } from '../logic/deployments'
 import { findEntityByPointer, findImageHash, findThumbnailHash } from '../logic/entities'
 import { buildUrn, formatERC21Entity, getProtocol } from '../logic/erc721'
-import { qsGetArray, qsParser, toQueryParams } from '../logic/query-params'
+import { qsGetArray, qsGetBoolean, qsGetNumber, qsParser, toQueryParams } from '../logic/query-params'
 import { statusResponseFromComponents } from '../logic/status-checks'
 import { getPointerChanges } from '../service/pointers/pointers'
 import { PointerChangesFilters } from '../service/pointers/types'
@@ -438,12 +438,13 @@ export async function getPointerChangesHandler(
   const entityTypes: (EntityType | undefined)[] = qsGetArray(queryParams, 'entityType').map((type) =>
     parseEntityType(type)
   )
-  const from: number | undefined = asInt(queryParams.from)
-  const to: number | undefined = asInt(queryParams.to)
-  const offset: number | undefined = asInt(queryParams.offset)
-  const limit: number | undefined = asInt(queryParams.limit)
+
+  const from: number | undefined = qsGetNumber(queryParams, 'from')
+  const to: number | undefined = qsGetNumber(queryParams, 'to')
+  const offset: number | undefined = qsGetNumber(queryParams, 'offset')
+  const limit: number | undefined = qsGetNumber(queryParams, 'limit')
   const lastId: string | undefined = (queryParams.lastId as string)?.toLowerCase()
-  const includeAuthChain = asBoolean(queryParams.includeAuthChain) ?? false
+  const includeAuthChain = qsGetBoolean(queryParams, 'includeAuthChain') ?? false
 
   const sortingFieldParam: string | undefined = queryParams.sortingField as string
   const snake_case_sortingField = sortingFieldParam ? fromCamelCaseToSnakeCase(sortingFieldParam) : undefined
@@ -571,10 +572,10 @@ export async function getDeploymentsHandler(
     parseEntityType(type)
   )
   const entityIds = qsGetArray(queryParams, 'entityId')
-  const onlyCurrentlyPointed: boolean | undefined = asBoolean(queryParams.onlyCurrentlyPointed)
+  const onlyCurrentlyPointed: boolean | undefined = qsGetBoolean(queryParams, 'onlyCurrentlyPointed')
   const pointers = qsGetArray(queryParams, 'pointer').map((pointer) => pointer.toLowerCase())
-  const offset: number | undefined = asInt(queryParams.offset)
-  const limit: number | undefined = asInt(queryParams.limit)
+  const offset: number | undefined = qsGetNumber(queryParams, 'offset')
+  const limit: number | undefined = qsGetNumber(queryParams, 'limit')
   const fields: string | null = queryParams.fields as string
   const sortingFieldParam: string | null = queryParams.sortingField as string
   const snake_case_sortingField = sortingFieldParam ? fromCamelCaseToSnakeCase(sortingFieldParam) : undefined
@@ -584,8 +585,8 @@ export async function getDeploymentsHandler(
     (queryParams.sortingOrder as string) || undefined
   )
   const lastId: string | undefined = (queryParams.lastId as string)?.toLowerCase()
-  const from: number | undefined = asInt(queryParams.from)
-  const to: number | undefined = asInt(queryParams.to)
+  const from: number | undefined = qsGetNumber(queryParams, 'from')
+  const to: number | undefined = qsGetNumber(queryParams, 'to')
 
   if (entityTypes && entityTypes.some((type) => !type)) {
     return {
@@ -833,12 +834,4 @@ function asEnumValue<T extends { [key: number]: string }>(
     const match = validEnumValues.has(stringToMap)
     return match ? (stringToMap as T[keyof T]) : 'unknown'
   }
-}
-
-function asInt(value: any): number | undefined {
-  return value ? parseInt(value) : undefined
-}
-
-function asBoolean(value: any): boolean | undefined {
-  return value ? value === 'true' : undefined
 }

--- a/content/src/logic/query-params.ts
+++ b/content/src/logic/query-params.ts
@@ -5,8 +5,8 @@ export function qsParser(rawQueryParams: URLSearchParams): QueryParams {
   return qs.parse(rawQueryParams.toString(), { parseArrays: true })
 }
 
-export function qsGetArray(queryParams: QueryParams, paramName: string) {
-  return (queryParams[paramName] as string[]) || []
+export function qsGetArray(queryParams: QueryParams, paramName: string): string[] {
+  return [...((queryParams[paramName] as string[]) || [])]
 }
 
 export function toQueryParams(filters: Record<string, any>): string {

--- a/content/src/logic/query-params.ts
+++ b/content/src/logic/query-params.ts
@@ -1,3 +1,4 @@
+import { isArray } from 'eth-connect'
 import qs from 'qs'
 import { QueryParams } from '../types'
 
@@ -6,7 +7,16 @@ export function qsParser(rawQueryParams: URLSearchParams): QueryParams {
 }
 
 export function qsGetArray(queryParams: QueryParams, paramName: string): string[] {
-  return [...((queryParams[paramName] as string[]) || [])]
+  const parsedParam = (queryParams[paramName] as string[]) || []
+  return isArray(parsedParam) ? parsedParam : [parsedParam]
+}
+
+export function qsGetNumber(queryParams: QueryParams, paramName: string): number | undefined {
+  return queryParams[paramName] ? parseInt(queryParams[paramName] as string) : undefined
+}
+
+export function qsGetBoolean(queryParams: QueryParams, paramName: string): boolean | undefined {
+  return queryParams[paramName] ? queryParams[paramName] === 'true' : undefined
 }
 
 export function toQueryParams(filters: Record<string, any>): string {

--- a/content/src/logic/query-params.ts
+++ b/content/src/logic/query-params.ts
@@ -1,5 +1,11 @@
 import qs from 'qs'
 
+export function fromQueryParamsAsArray(queryParams: qs.ParsedQs, paramName: string): string[] {
+  const receivedParameter: string[] = (queryParams[paramName] as string[]) || []
+
+  return receivedParameter
+}
+
 export function toQueryParams(filters: Record<string, any>): string {
   const entries = convertFiltersToQueryParams(filters)
   return qs.stringify(Object.fromEntries(entries), { arrayFormat: 'repeat' })

--- a/content/src/logic/query-params.ts
+++ b/content/src/logic/query-params.ts
@@ -1,4 +1,3 @@
-import { isArray } from 'eth-connect'
 import qs from 'qs'
 import { QueryParams } from '../types'
 
@@ -8,7 +7,7 @@ export function qsParser(rawQueryParams: URLSearchParams): QueryParams {
 
 export function qsGetArray(queryParams: QueryParams, paramName: string): string[] {
   const parsedParam = (queryParams[paramName] as string[]) || []
-  return isArray(parsedParam) ? parsedParam : [parsedParam]
+  return Array.isArray(parsedParam) ? parsedParam : [parsedParam]
 }
 
 export function qsGetNumber(queryParams: QueryParams, paramName: string): number | undefined {

--- a/content/src/logic/query-params.ts
+++ b/content/src/logic/query-params.ts
@@ -1,9 +1,12 @@
 import qs from 'qs'
+import { QueryParams } from '../types'
 
-export function fromQueryParamsAsArray(queryParams: qs.ParsedQs, paramName: string): string[] {
-  const receivedParameter: string[] = (queryParams[paramName] as string[]) || []
+export function qsParser(rawQueryParams: URLSearchParams): QueryParams {
+  return qs.parse(rawQueryParams.toString(), { parseArrays: true })
+}
 
-  return receivedParameter
+export function qsGetArray(queryParams: QueryParams, paramName: string) {
+  return (queryParams[paramName] as string[]) || []
 }
 
 export function toQueryParams(filters: Record<string, any>): string {

--- a/content/src/types.ts
+++ b/content/src/types.ts
@@ -13,15 +13,16 @@ import {
 } from '@well-known-components/interfaces'
 import { FormDataContext } from '@well-known-components/multipart-wrapper'
 import { Fetcher } from 'dcl-catalyst-commons'
+import qs from 'qs'
 import { Environment } from './Environment'
 import { metricsDeclaration } from './metrics'
 import { MigrationManager } from './migrations/MigrationManager'
 import { ActiveEntities } from './ports/activeEntities'
 import { Clock } from './ports/clock'
 import { Denylist } from './ports/denylist'
+import { IDeployRateLimiterComponent } from './ports/deployRateLimiterComponent'
 import { DeployedEntitiesBloomFilter } from './ports/deployedEntitiesBloomFilter'
 import { Deployer } from './ports/deployer'
-import { IDeployRateLimiterComponent } from './ports/deployRateLimiterComponent'
 import { IFailedDeploymentsComponent } from './ports/failedDeployments'
 import { IDatabaseComponent } from './ports/postgres'
 import { ISequentialTaskExecutorComponent } from './ports/sequecuentialTaskExecutor'
@@ -32,8 +33,8 @@ import { ContentAuthenticator } from './service/auth/Authenticator'
 import { GarbageCollectionManager } from './service/garbage-collection/GarbageCollectionManager'
 import { PointerManager } from './service/pointers/PointerManager'
 import { IChallengeSupervisor } from './service/synchronization/ChallengeSupervisor'
-import { DaoComponent } from './service/synchronization/clients/HardcodedDAOClient'
 import { ContentCluster } from './service/synchronization/ContentCluster'
+import { DaoComponent } from './service/synchronization/clients/HardcodedDAOClient'
 import { IRetryFailedDeploymentsComponent } from './service/synchronization/retryFailedDeployments'
 import { ServerValidator } from './service/validations/server'
 
@@ -164,3 +165,5 @@ export class InvalidRequestError extends Error {
     Error.captureStackTrace(this, this.constructor)
   }
 }
+
+export type QueryParams = qs.ParsedQs

--- a/content/test/integration/controller/deployment-pagination.spec.ts
+++ b/content/test/integration/controller/deployment-pagination.spec.ts
@@ -1,13 +1,13 @@
 import { EntityType } from '@dcl/schemas'
 import { fetchJson } from 'dcl-catalyst-commons'
+import { EnvironmentConfig } from '../../../src/Environment'
 import { DeploymentField } from '../../../src/controller/Controller'
 import { DeploymentOptions, SortingField, SortingOrder } from '../../../src/deployment-types'
-import { EnvironmentConfig } from '../../../src/Environment'
-import { toQueryParams } from '../../../src/logic/toQueryParams'
+import { toQueryParams } from '../../../src/logic/query-params'
 import { PointerChangesFilters } from '../../../src/service/pointers/types'
 import { makeNoopValidator } from '../../helpers/service/validations/NoOpValidator'
 import { setupTestEnvironment } from '../E2ETestEnvironment'
-import { buildDeployData, EntityCombo } from '../E2ETestUtils'
+import { EntityCombo, buildDeployData } from '../E2ETestUtils'
 import { TestProgram } from '../TestProgram'
 
 describe('Integration - Deployment Pagination', () => {


### PR DESCRIPTION
## Description

This PR adds support to different array query params formats:
* param=1&param=2 => [1, 2]
* param[]=1&param[]=2 => [1,2]
* param[1]=1&param[0]=2 => [2,1]