### PR TITLE
fix: getContentUrl on SmartContentClient

### DIFF
--- a/lambdas/src/utils/SmartContentClient.ts
+++ b/lambdas/src/utils/SmartContentClient.ts
@@ -174,7 +174,12 @@ export class SmartContentClient implements ContentClient {
         SmartContentClient.LOGGER.info('Defaulting to external content server url: ', contentClientUrl)
       }
 
-      this.contentClient.resolve(createContentClient({ url: contentClientUrl, fetcher }))
+      this.contentClient.resolve({
+        ...createContentClient({ url: contentClientUrl, fetcher }),
+        getContentUrl: () => contentClientUrl
+      } as ContentClient & {
+        getContentUrl: () => string
+      })
     }
 
     return { ...(await this.contentClient), getContentUrl: () => contentClientUrl } as ContentClient & {


### PR DESCRIPTION
Fixes SmartContentClient to always return aggregated type with `getContentUrl`.