### PR TITLE
fix: cors

### DIFF
--- a/content/src/components.ts
+++ b/content/src/components.ts
@@ -315,7 +315,7 @@ export async function initComponentsWithEnv(env: Environment): Promise<AppCompon
     {
       cors: {
         origin: true,
-        methods: ['GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'CONNECT', 'TRACE', 'PATCH'],
+        methods: ['GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'CONNECT', 'TRACE', 'PATCH', 'OPTION'],
         allowedHeaders: ['Cache-Control', 'Content-Type', 'Origin', 'Accept', 'User-Agent', 'X-Upload-Origin'],
         credentials: true,
         maxAge: 86400

--- a/content/src/controller/routes.ts
+++ b/content/src/controller/routes.ts
@@ -4,7 +4,7 @@ import { EnvironmentConfig } from '../Environment'
 import { GlobalContext } from '../types'
 import { getActiveEntitiesHandler } from './handlers/active-entities-handler'
 import { createEntity } from './handlers/create-entity-handler'
-import { errorHandler, preventExecutionIfBoostrapping } from './middlewares'
+import { createErrorHandler, preventExecutionIfBoostrapping } from './middlewares'
 import { getFailedDeploymentsHandler } from './handlers/failed-deployments-handler'
 import { getEntitiesByPointerPrefixHandler } from './handlers/filter-by-urn-handler'
 import { getEntityAuditInformationHandler } from './handlers/get-audit-handler'
@@ -24,7 +24,7 @@ import { getActiveEntityIdsByDeploymentHashHandler } from './handlers/get-active
 // We return the entire router because it will be easier to test than a whole server
 export async function setupRouter({ components }: GlobalContext): Promise<Router<GlobalContext>> {
   const router = new Router<GlobalContext>()
-  router.use(errorHandler)
+  router.use(createErrorHandler({ logs: components.logs }))
 
   const env = components.env
   const logger = components.logs.getLogger('router')


### PR DESCRIPTION
## Description

The error handler middleware used to re-throw any unrecognized error it received. However, this caused an issue with the new [cors middleware](https://github.com/well-known-components/http-server/blob/main/src/cors.ts#L161) as it was unable to add CORS headers. Consequently, every unrecognized error resulted in misleading CORS errors, making it difficult to identify the actual cause of the failure."