### PR TITLE
chore: for simple test cases use createDefaultServer

### DIFF
--- a/content/jest.globalSetup.ts
+++ b/content/jest.globalSetup.ts
@@ -1,6 +1,5 @@
 import * as tsNode from 'ts-node'
 import { isCI } from './test/integration/E2ETestUtils'
-import { getDefaultTestServer } from './test/integration/simpleTestEnvironment'
 
 const globalSetup = async (): Promise<void> => {
   if (!isCI()) {
@@ -13,8 +12,6 @@ const globalSetup = async (): Promise<void> => {
     const { initializePostgresContainer } = await import('./test/postgres-test-container')
     await initializePostgresContainer('postgres_test')
   }
-  global.defaultServer = await getDefaultTestServer()
-  console.log('HERE')
 }
 
 export default globalSetup

--- a/content/jest.globalSetup.ts
+++ b/content/jest.globalSetup.ts
@@ -1,5 +1,6 @@
 import * as tsNode from 'ts-node'
 import { isCI } from './test/integration/E2ETestUtils'
+import { getDefaultTestServer } from './test/integration/simpleTestEnvironment'
 
 const globalSetup = async (): Promise<void> => {
   if (!isCI()) {
@@ -12,6 +13,8 @@ const globalSetup = async (): Promise<void> => {
     const { initializePostgresContainer } = await import('./test/postgres-test-container')
     await initializePostgresContainer('postgres_test')
   }
+  global.defaultServer = await getDefaultTestServer()
+  console.log('HERE')
 }
 
 export default globalSetup

--- a/content/src/ports/activeEntities.ts
+++ b/content/src/ports/activeEntities.ts
@@ -57,7 +57,7 @@ export type ActiveEntities = {
    */
   getCachedEntity(idOrPointer: string | string): string | NotActiveEntity | undefined
   /**
-   * Reset interna state
+   * Reset internal state
    * Note: testing purposes
    */
   reset(): void

--- a/content/test/integration/E2ETestEnvironment.ts
+++ b/content/test/integration/E2ETestEnvironment.ts
@@ -52,7 +52,9 @@ export class E2ETestEnvironment {
       })
     })
     this.database = await createDatabaseComponent({ logs: this.logs, env: this.sharedEnv, metrics })
-    if (this.database.start) this.database.start()
+    if (this.database.start) {
+      await this.database.start()
+    }
   }
 
   async stop(): Promise<void> {

--- a/content/test/integration/E2ETestUtils.ts
+++ b/content/test/integration/E2ETestUtils.ts
@@ -49,10 +49,12 @@ export async function buildDeployData(pointers: string[], options?: DeploymentOp
     signature
   )
 
-  const entity: Entity = getEntityFromBuffer(
-    deploymentPreparationData.files.get(deploymentPreparationData.entityId)!,
-    deploymentPreparationData.entityId
-  )
+  const content = deploymentPreparationData.files.get(deploymentPreparationData.entityId)
+  if (!content) {
+    throw new Error('Unexpected error: no content')
+  }
+
+  const entity: Entity = getEntityFromBuffer(content, deploymentPreparationData.entityId)
 
   const deployData: DeploymentData = {
     entityId: entity.id,

--- a/content/test/integration/controller/active-entities.spec.ts
+++ b/content/test/integration/controller/active-entities.spec.ts
@@ -168,7 +168,7 @@ describe('Integration - Get Active Entities', () => {
     })
 
     it('when fetching active entities by pointer but there is no one, then entity is cached as NOT_ACTIVE', async () => {
-      const somePointer = '30,0'
+      const somePointer = '0,0'
       const result = await fetchActiveEntityByPointers(server, somePointer)
       expect(result).toHaveLength(0)
 

--- a/content/test/integration/controller/active-entities.spec.ts
+++ b/content/test/integration/controller/active-entities.spec.ts
@@ -1,24 +1,24 @@
 import { Entity } from '@dcl/schemas'
 import fetch from 'node-fetch'
-import { EnvironmentConfig } from '../../../src/Environment'
 import * as deployments from '../../../src/logic/deployments'
 import { makeNoopValidator } from '../../helpers/service/validations/NoOpValidator'
-import { setupTestEnvironment } from '../E2ETestEnvironment'
 import { buildDeployData } from '../E2ETestUtils'
 import { getIntegrationResourcePathFor } from '../resources/get-resource-path'
 import { TestProgram } from '../TestProgram'
 
 describe('Integration - Get Active Entities', () => {
-  const getTestEnv = setupTestEnvironment()
+  let server: TestProgram
+
+  beforeAll(async () => {
+    server = global.defaultServer
+    makeNoopValidator(server.components)
+  })
+
+  afterAll(async () => {
+    jest.restoreAllMocks()
+  })
 
   it('when asking without params, it returns client error', async () => {
-    const server = await getTestEnv()
-      .configServer()
-      .withConfig(EnvironmentConfig.DISABLE_SYNCHRONIZATION, true)
-      .andBuild()
-    makeNoopValidator(server.components)
-    await server.startProgram()
-
     const result = await fetch(server.getUrl() + `/entities/active`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -29,15 +29,6 @@ describe('Integration - Get Active Entities', () => {
   })
 
   it('when asking by ID, it returns active entities with given ID', async () => {
-    const server = await getTestEnv()
-      .configServer()
-      .withConfig(EnvironmentConfig.DISABLE_SYNCHRONIZATION, true)
-      .andBuild()
-
-    makeNoopValidator(server.components)
-
-    await server.startProgram()
-
     const deployResult = await buildDeployData(['0,0', '0,1'], {
       metadata: { a: 'this is just some metadata' },
       contentPaths: [getIntegrationResourcePathFor('some-binary-file.png')]
@@ -52,15 +43,6 @@ describe('Integration - Get Active Entities', () => {
   })
 
   it('when asking by Pointer, it returns active entities with given pointer', async () => {
-    const server = await getTestEnv()
-      .configServer()
-      .withConfig(EnvironmentConfig.DISABLE_SYNCHRONIZATION, true)
-      .andBuild()
-
-    makeNoopValidator(server.components)
-
-    await server.startProgram()
-
     const deployResult = await buildDeployData(['0,0', '0,1'], {
       metadata: { a: 'this is just some metadata' },
       contentPaths: [getIntegrationResourcePathFor('some-binary-file.png')]
@@ -77,15 +59,6 @@ describe('Integration - Get Active Entities', () => {
   })
 
   it('when asking for active entities, only active entities are returned', async () => {
-    const server = await getTestEnv()
-      .configServer()
-      .withConfig(EnvironmentConfig.DISABLE_SYNCHRONIZATION, true)
-      .andBuild()
-
-    makeNoopValidator(server.components)
-
-    await server.startProgram()
-
     const deployResult = await buildDeployData(['0,0', '0,1'], {
       metadata: { a: 'this is just some metadata' },
       contentPaths: [getIntegrationResourcePathFor('some-binary-file.png')]
@@ -110,15 +83,6 @@ describe('Integration - Get Active Entities', () => {
   })
 
   it('when there are multiple active entities, they are returned', async () => {
-    const server = await getTestEnv()
-      .configServer()
-      .withConfig(EnvironmentConfig.DISABLE_SYNCHRONIZATION, true)
-      .andBuild()
-
-    makeNoopValidator(server.components)
-
-    await server.startProgram()
-
     const deployResult = await buildDeployData(['0,0', '0,1'], {
       metadata: { a: 'this is just some metadata' },
       contentPaths: [getIntegrationResourcePathFor('some-binary-file.png')]
@@ -142,15 +106,6 @@ describe('Integration - Get Active Entities', () => {
   })
 
   it('when asking with duplicated IDs, entity is returned once', async () => {
-    const server = await getTestEnv()
-      .configServer()
-      .withConfig(EnvironmentConfig.DISABLE_SYNCHRONIZATION, true)
-      .andBuild()
-
-    makeNoopValidator(server.components)
-
-    await server.startProgram()
-
     const deployResult = await buildDeployData(['0,0', '0,1'], {
       metadata: { a: 'this is just some metadata' },
       contentPaths: [getIntegrationResourcePathFor('some-binary-file.png')]
@@ -165,15 +120,6 @@ describe('Integration - Get Active Entities', () => {
   })
 
   it('when asking with ID and pointer of same entity, result should be the same', async () => {
-    const server = await getTestEnv()
-      .configServer()
-      .withConfig(EnvironmentConfig.DISABLE_SYNCHRONIZATION, true)
-      .andBuild()
-
-    makeNoopValidator(server.components)
-
-    await server.startProgram()
-
     const pointers = ['0,0', '0,1']
     const deployResult = await buildDeployData(pointers, {
       metadata: { a: 'this is just some metadata' },
@@ -190,12 +136,6 @@ describe('Integration - Get Active Entities', () => {
 
   describe('Active Entities cache', () => {
     it('when fetching active entity by ids, then entity is cached', async () => {
-      const server = await getTestEnv()
-        .configServer()
-        .withConfig(EnvironmentConfig.DISABLE_SYNCHRONIZATION, true)
-        .andBuild()
-      makeNoopValidator(server.components)
-      await server.startProgram()
       const pointers = ['0,0', '0,1']
       const deployResult = await buildDeployData(pointers, {
         metadata: { a: 'this is just some metadata' },
@@ -215,14 +155,7 @@ describe('Integration - Get Active Entities', () => {
     })
 
     it('when fetching active entities by pointer but there is no one, then entity is cached as NOT_ACTIVE', async () => {
-      const server = await getTestEnv()
-        .configServer()
-        .withConfig(EnvironmentConfig.DISABLE_SYNCHRONIZATION, true)
-        .andBuild()
-      makeNoopValidator(server.components)
-      await server.startProgram()
-
-      const somePointer = '0,0'
+      const somePointer = '30,0'
       const result = await fetchActiveEntityByPointers(server, somePointer)
       expect(result).toHaveLength(0)
 
@@ -231,13 +164,6 @@ describe('Integration - Get Active Entities', () => {
     })
 
     it('when fetching active entities by id but there is no one, then is cached as NOT_ACTIVE', async () => {
-      const server = await getTestEnv()
-        .configServer()
-        .withConfig(EnvironmentConfig.DISABLE_SYNCHRONIZATION, true)
-        .andBuild()
-      makeNoopValidator(server.components)
-      await server.startProgram()
-
       const someId = 'someId'
       const result = await fetchActiveEntityByIds(server, someId)
       expect(result).toHaveLength(0)
@@ -248,12 +174,6 @@ describe('Integration - Get Active Entities', () => {
     })
 
     it('when overriding an entity, then cache is updated', async () => {
-      const server = await getTestEnv()
-        .configServer()
-        .withConfig(EnvironmentConfig.DISABLE_SYNCHRONIZATION, true)
-        .andBuild()
-      makeNoopValidator(server.components)
-      await server.startProgram()
       const pointers = ['0,0', '0,1']
       const { deployData } = await buildDeployData(pointers, {
         metadata: { a: 'this is just some metadata' },
@@ -278,12 +198,6 @@ describe('Integration - Get Active Entities', () => {
     })
 
     it('when deploying a new entity with same pointer, then cache is updated', async () => {
-      const server = await getTestEnv()
-        .configServer()
-        .withConfig(EnvironmentConfig.DISABLE_SYNCHRONIZATION, true)
-        .andBuild()
-      makeNoopValidator(server.components)
-      await server.startProgram()
       const activeEntities = server.components.activeEntities
       const pointers = ['0,0', '0,1']
       const { deployData } = await buildDeployData(pointers, {
@@ -324,12 +238,6 @@ describe('Integration - Get Active Entities', () => {
     })
 
     it('when fetching multiple active entities, all are cached', async () => {
-      const server = await getTestEnv()
-        .configServer()
-        .withConfig(EnvironmentConfig.DISABLE_SYNCHRONIZATION, true)
-        .andBuild()
-      makeNoopValidator(server.components)
-      await server.startProgram()
       const firstPointers = ['0,0', '0,1']
       const { deployData } = await buildDeployData(firstPointers, {
         metadata: { a: 'this is just some metadata' },
@@ -358,13 +266,6 @@ describe('Integration - Get Active Entities', () => {
     })
 
     it('when fetching a non active entity, result is cached', async () => {
-      const server = await getTestEnv()
-        .configServer()
-        .withConfig(EnvironmentConfig.DISABLE_SYNCHRONIZATION, true)
-        .andBuild()
-      makeNoopValidator(server.components)
-      await server.startProgram()
-
       const result = await fetchActiveEntityByIds(server, 'someId')
       expect(result).toHaveLength(0)
 
@@ -373,12 +274,6 @@ describe('Integration - Get Active Entities', () => {
     })
 
     it('when results are cached, getDeployments is not called', async () => {
-      const server = await getTestEnv()
-        .configServer()
-        .withConfig(EnvironmentConfig.DISABLE_SYNCHRONIZATION, true)
-        .andBuild()
-      makeNoopValidator(server.components)
-      await server.startProgram()
       const pointers = ['0,0', '0,1']
       const { deployData } = await buildDeployData(pointers, {
         metadata: { a: 'this is just some metadata' },
@@ -405,13 +300,6 @@ describe('Integration - Get Active Entities', () => {
 
   describe('Urn Prefix', () => {
     it('when fetching entities with invalid chars urn prefix, then a client error is returned', async () => {
-      const server = await getTestEnv()
-        .configServer()
-        .withConfig(EnvironmentConfig.DISABLE_SYNCHRONIZATION, true)
-        .andBuild()
-      makeNoopValidator(server.components)
-      await server.startProgram()
-
       const response = await fetch(server.getUrl() + `/entities/active/collections/in!valid`, {
         method: 'GET',
         headers: { 'Content-Type': 'application/json' }
@@ -420,13 +308,6 @@ describe('Integration - Get Active Entities', () => {
       expect(response.status).toBe(400)
     })
     it('when fetching entities with invalid urn prefix, then a client error is returned', async () => {
-      const server = await getTestEnv()
-        .configServer()
-        .withConfig(EnvironmentConfig.DISABLE_SYNCHRONIZATION, true)
-        .andBuild()
-      makeNoopValidator(server.components)
-      await server.startProgram()
-
       const response = await fetch(
         server.getUrl() +
           `/entities/active/collections/urn:decentraland:ethereum:collections-v1:0x32b7495895264ac9d0b12d32afd435453458b1c6`,
@@ -439,12 +320,6 @@ describe('Integration - Get Active Entities', () => {
       expect(response.status).toBe(400)
     })
     it('when fetching entities by item, then matching entity is retrieved', async () => {
-      const server = await getTestEnv()
-        .configServer()
-        .withConfig(EnvironmentConfig.DISABLE_SYNCHRONIZATION, true)
-        .andBuild()
-      makeNoopValidator(server.components)
-      await server.startProgram()
       const pointer = ['urn:decentraland:mumbai:collections-thirdparty:aThirdParty:winterCollection:1']
       const metadata = {
         a: 'this is just some metadata'
@@ -467,12 +342,6 @@ describe('Integration - Get Active Entities', () => {
       expect(entity.metadata).toEqual(metadata)
     })
     it('when fetching entities by collection name, then matching entity is retrieved', async () => {
-      const server = await getTestEnv()
-        .configServer()
-        .withConfig(EnvironmentConfig.DISABLE_SYNCHRONIZATION, true)
-        .andBuild()
-      makeNoopValidator(server.components)
-      await server.startProgram()
       const pointer = ['urn:decentraland:mumbai:collections-thirdparty:aThirdParty:winterCollection:1']
       const metadata = {
         a: 'this is just some metadata'
@@ -495,12 +364,6 @@ describe('Integration - Get Active Entities', () => {
       expect(entity.metadata).toEqual(metadata)
     })
     it('when fetching entities by collection name, then paginated matching entities are retrieved', async () => {
-      const server = await getTestEnv()
-        .configServer()
-        .withConfig(EnvironmentConfig.DISABLE_SYNCHRONIZATION, true)
-        .andBuild()
-      makeNoopValidator(server.components)
-      await server.startProgram()
       const metadata = {
         a: 'this is just some metadata'
       }
@@ -522,12 +385,6 @@ describe('Integration - Get Active Entities', () => {
       expect(response.entities).toHaveLength(3)
     })
     it('when fetching entities by third party name, then matching entity is retrieved', async () => {
-      const server = await getTestEnv()
-        .configServer()
-        .withConfig(EnvironmentConfig.DISABLE_SYNCHRONIZATION, true)
-        .andBuild()
-      makeNoopValidator(server.components)
-      await server.startProgram()
       const pointer = ['urn:decentraland:mumbai:collections-thirdparty:aThirdParty:winterCollection:1']
       const metadata = {
         a: 'this is just some metadata'
@@ -550,12 +407,6 @@ describe('Integration - Get Active Entities', () => {
       expect(entity.metadata).toEqual(metadata)
     })
     it('when fetching entities by not matching urn prefix, then none is retrieved', async () => {
-      const server = await getTestEnv()
-        .configServer()
-        .withConfig(EnvironmentConfig.DISABLE_SYNCHRONIZATION, true)
-        .andBuild()
-      makeNoopValidator(server.components)
-      await server.startProgram()
       const pointer = ['urn:dcl:collection:itemId']
       const deployResult = await buildDeployData(pointer, {
         metadata: { a: 'this is just some metadata' },
@@ -574,12 +425,6 @@ describe('Integration - Get Active Entities', () => {
     })
 
     it('when pointer is updated and getting by prefix, the new one is retrieved', async () => {
-      const server = await getTestEnv()
-        .configServer()
-        .withConfig(EnvironmentConfig.DISABLE_SYNCHRONIZATION, true)
-        .andBuild()
-      makeNoopValidator(server.components)
-      await server.startProgram()
       const pointer = ['urn:decentraland:mumbai:collections-thirdparty:aThirdParty:winterCollection:1']
       const firstDeploy = await buildDeployData(pointer, {
         metadata: { a: 'this is just some metadata' },

--- a/content/test/integration/controller/active-entity-by-content-hash.spec.ts
+++ b/content/test/integration/controller/active-entity-by-content-hash.spec.ts
@@ -1,30 +1,27 @@
 import fetch from 'node-fetch'
 import { makeNoopValidator } from '../../helpers/service/validations/NoOpValidator'
 import { buildDeployData } from '../E2ETestUtils'
-import { SimpleTestEnvironment, createSimpleTestEnvironment } from '../simpleTestEnvironment'
+import { createDefaultServer, resetServer } from '../simpleTestEnvironment'
 import { TestProgram } from '../TestProgram'
 import LeakDetector from 'jest-leak-detector'
 
 describe('Integration - Get Active Entities By Content Hash', () => {
   let server: TestProgram
-  let env: SimpleTestEnvironment
 
   beforeAll(async () => {
-    env = await createSimpleTestEnvironment()
-    server = await env.start()
+    server = await createDefaultServer()
     makeNoopValidator(server.components)
   })
 
   beforeEach(async () => {
-    server.components.activeEntities.reset()
-    await env.clearDatabase()
+    resetServer(server)
   })
 
   afterAll(async () => {
     jest.restoreAllMocks()
-    const detector = new LeakDetector(env)
-    await env.stop()
-    env = null as any
+    const detector = new LeakDetector(server)
+    await server.stopProgram()
+    server = null as any
     expect(await detector.isLeaking()).toBe(false)
   })
 

--- a/content/test/integration/controller/active-entity-by-content-hash.spec.ts
+++ b/content/test/integration/controller/active-entity-by-content-hash.spec.ts
@@ -13,9 +13,7 @@ describe('Integration - Get Active Entities By Content Hash', () => {
     makeNoopValidator(server.components)
   })
 
-  beforeEach(async () => {
-    resetServer(server)
-  })
+  beforeEach(() => resetServer(server))
 
   afterAll(async () => {
     jest.restoreAllMocks()

--- a/content/test/integration/controller/active-entity-by-content-hash.spec.ts
+++ b/content/test/integration/controller/active-entity-by-content-hash.spec.ts
@@ -1,21 +1,21 @@
 import fetch from 'node-fetch'
-import { EnvironmentConfig } from '../../../src/Environment'
 import { makeNoopValidator } from '../../helpers/service/validations/NoOpValidator'
-import { setupTestEnvironment } from '../E2ETestEnvironment'
 import { buildDeployData } from '../E2ETestUtils'
 import { TestProgram } from '../TestProgram'
 
 describe('Integration - Get Active Entities By Content Hash', () => {
-  const getTestEnv = setupTestEnvironment()
+  let server: TestProgram
+
+  beforeAll(async () => {
+    server = globalThis.defaultServer
+    makeNoopValidator(server.components)
+  })
+
+  afterAll(async () => {
+    jest.restoreAllMocks()
+  })
 
   it("When the deployment doesn't exist returns 404", async () => {
-    const server = await getTestEnv()
-      .configServer()
-      .withConfig(EnvironmentConfig.DISABLE_SYNCHRONIZATION, true)
-      .andBuild()
-
-    await server.startProgram()
-
     const response = await fetch(server.getUrl() + `/contents/fail/active-entities`)
 
     expect(response.status).toEqual(404)
@@ -26,15 +26,6 @@ describe('Integration - Get Active Entities By Content Hash', () => {
   })
 
   it('When the deployment exists returns the entity id', async () => {
-    const server = await getTestEnv()
-      .configServer()
-      .withConfig(EnvironmentConfig.DISABLE_SYNCHRONIZATION, true)
-      .andBuild()
-
-    makeNoopValidator(server.components)
-
-    await server.startProgram()
-
     const deployResult = await buildDeployData(['0,0', '0,1'], {
       metadata: { a: 'this is just some metadata' },
       contentPaths: ['test/integration/resources/some-binary-file.png']

--- a/content/test/integration/controller/active-pointers.spec.ts
+++ b/content/test/integration/controller/active-pointers.spec.ts
@@ -5,7 +5,7 @@ import { makeNoopServerValidator, makeNoopValidator } from '../../helpers/servic
 import { getIntegrationResourcePathFor } from '../resources/get-resource-path'
 import { TestProgram } from '../TestProgram'
 import FormData = require('form-data')
-import { createSimpleTestEnvironment, SimpleTestEnvironment } from '../simpleTestEnvironment'
+import { resetServer, createDefaultServer } from '../simpleTestEnvironment'
 import LeakDetector from 'jest-leak-detector'
 
 interface ActivePointersRow {
@@ -25,26 +25,23 @@ const profileOverwriteEntityId = 'bafkreiczclosnorj7bzibuvotiwf2gyvtmnxmyvl62nac
 
 describe('Integration - Create entities', () => {
   let server: TestProgram
-  let env: SimpleTestEnvironment
 
   beforeAll(async () => {
-    env = await createSimpleTestEnvironment()
-    server = await env.start()
+    server = await createDefaultServer()
     makeNoopValidator(server.components)
     makeNoopServerValidator(server.components)
   })
 
   beforeEach(async () => {
-    server.components.activeEntities.reset()
-    await env.clearDatabase()
+    resetServer(server)
   })
 
   afterAll(async () => {
     jest.restoreAllMocks()
     stopAllComponents({ fs })
-    const detector = new LeakDetector(env)
-    await env.stop()
-    env = null as any
+    const detector = new LeakDetector(server)
+    await server.stopProgram()
+    server = null as any
     expect(await detector.isLeaking()).toBe(false)
   })
 

--- a/content/test/integration/controller/active-pointers.spec.ts
+++ b/content/test/integration/controller/active-pointers.spec.ts
@@ -32,9 +32,7 @@ describe('Integration - Create entities', () => {
     makeNoopServerValidator(server.components)
   })
 
-  beforeEach(async () => {
-    resetServer(server)
-  })
+  beforeEach(() => resetServer(server))
 
   afterAll(async () => {
     jest.restoreAllMocks()

--- a/content/test/integration/controller/audit.spec.ts
+++ b/content/test/integration/controller/audit.spec.ts
@@ -2,25 +2,23 @@ import { EntityType } from '@dcl/schemas'
 import fetch from 'node-fetch'
 import { makeNoopValidator } from '../../helpers/service/validations/NoOpValidator'
 import { buildDeployData, deployEntitiesCombo } from '../E2ETestUtils'
-import { SimpleTestEnvironment, createSimpleTestEnvironment } from '../simpleTestEnvironment'
+import { createDefaultServer } from '../simpleTestEnvironment'
 import { TestProgram } from '../TestProgram'
 import LeakDetector from 'jest-leak-detector'
 
 describe('Integration - Audit', () => {
   let server: TestProgram
-  let env: SimpleTestEnvironment
 
   beforeAll(async () => {
-    env = await createSimpleTestEnvironment()
-    server = await env.start()
+    server = await createDefaultServer()
     makeNoopValidator(server.components)
   })
 
   afterAll(async () => {
     jest.restoreAllMocks()
-    const detector = new LeakDetector(env)
-    await env.stop()
-    env = null as any
+    const detector = new LeakDetector(server)
+    await server.stopProgram()
+    server = null as any
     expect(await detector.isLeaking()).toBe(false)
   })
 

--- a/content/test/integration/controller/available-content.spec.ts
+++ b/content/test/integration/controller/available-content.spec.ts
@@ -1,24 +1,22 @@
 import fetch from 'node-fetch'
 import { makeNoopValidator } from '../../helpers/service/validations/NoOpValidator'
-import { SimpleTestEnvironment, createSimpleTestEnvironment } from '../simpleTestEnvironment'
+import { createDefaultServer } from '../simpleTestEnvironment'
 import { TestProgram } from '../TestProgram'
 import LeakDetector from 'jest-leak-detector'
 
 describe('Integration - Available Content', () => {
   let server: TestProgram
-  let env: SimpleTestEnvironment
 
   beforeAll(async () => {
-    env = await createSimpleTestEnvironment()
-    server = await env.start()
+    server = await createDefaultServer()
     makeNoopValidator(server.components)
   })
 
   afterAll(async () => {
     jest.restoreAllMocks()
-    const detector = new LeakDetector(env)
-    await env.stop()
-    env = null as any
+    const detector = new LeakDetector(server)
+    await server.stopProgram()
+    server = null as any
     expect(await detector.isLeaking()).toBe(false)
   })
 

--- a/content/test/integration/controller/available-content.spec.ts
+++ b/content/test/integration/controller/available-content.spec.ts
@@ -1,21 +1,28 @@
 import fetch from 'node-fetch'
-import { EnvironmentConfig } from '../../../src/Environment'
 import { makeNoopValidator } from '../../helpers/service/validations/NoOpValidator'
-import { setupTestEnvironment } from '../E2ETestEnvironment'
+import { SimpleTestEnvironment, createSimpleTestEnvironment } from '../simpleTestEnvironment'
+import { TestProgram } from '../TestProgram'
+import LeakDetector from 'jest-leak-detector'
 
 describe('Integration - Available Content', () => {
-  const getTestEnv = setupTestEnvironment()
+  let server: TestProgram
+  let env: SimpleTestEnvironment
+
+  beforeAll(async () => {
+    env = await createSimpleTestEnvironment()
+    server = await env.start()
+    makeNoopValidator(server.components)
+  })
+
+  afterAll(async () => {
+    jest.restoreAllMocks()
+    const detector = new LeakDetector(env)
+    await env.stop()
+    env = null as any
+    expect(await detector.isLeaking()).toBe(false)
+  })
 
   it('returns 400 when no cid is provided', async () => {
-    const server = await getTestEnv()
-      .configServer()
-      .withConfig(EnvironmentConfig.DISABLE_SYNCHRONIZATION, true)
-      .andBuild()
-
-    makeNoopValidator(server.components)
-
-    await server.startProgram()
-
     const url = server.getUrl() + `/available-content`
     const res = await fetch(url)
 

--- a/content/test/integration/controller/content.spec.ts
+++ b/content/test/integration/controller/content.spec.ts
@@ -1,24 +1,22 @@
 import fetch from 'node-fetch'
 import { makeNoopValidator } from '../../helpers/service/validations/NoOpValidator'
-import { SimpleTestEnvironment, createSimpleTestEnvironment } from '../simpleTestEnvironment'
+import { createDefaultServer } from '../simpleTestEnvironment'
 import { TestProgram } from '../TestProgram'
 import LeakDetector from 'jest-leak-detector'
 
 describe('Integration - Get Content', () => {
   let server: TestProgram
-  let env: SimpleTestEnvironment
 
   beforeAll(async () => {
-    env = await createSimpleTestEnvironment()
-    server = await env.start()
+    server = await createDefaultServer()
     makeNoopValidator(server.components)
   })
 
   afterAll(async () => {
     jest.restoreAllMocks()
-    const detector = new LeakDetector(env)
-    await env.stop()
-    env = null as any
+    const detector = new LeakDetector(server)
+    await server.stopProgram()
+    server = null as any
     expect(await detector.isLeaking()).toBe(false)
   })
 

--- a/content/test/integration/controller/content.spec.ts
+++ b/content/test/integration/controller/content.spec.ts
@@ -1,21 +1,28 @@
 import fetch from 'node-fetch'
-import { EnvironmentConfig } from '../../../src/Environment'
 import { makeNoopValidator } from '../../helpers/service/validations/NoOpValidator'
-import { setupTestEnvironment } from '../E2ETestEnvironment'
+import { SimpleTestEnvironment, createSimpleTestEnvironment } from '../simpleTestEnvironment'
+import { TestProgram } from '../TestProgram'
+import LeakDetector from 'jest-leak-detector'
 
 describe('Integration - Get Content', () => {
-  const getTestEnv = setupTestEnvironment()
+  let server: TestProgram
+  let env: SimpleTestEnvironment
+
+  beforeAll(async () => {
+    env = await createSimpleTestEnvironment()
+    server = await env.start()
+    makeNoopValidator(server.components)
+  })
+
+  afterAll(async () => {
+    jest.restoreAllMocks()
+    const detector = new LeakDetector(env)
+    await env.stop()
+    env = null as any
+    expect(await detector.isLeaking()).toBe(false)
+  })
 
   it('returns 404 when the content file does not exist', async () => {
-    const server = await getTestEnv()
-      .configServer()
-      .withConfig(EnvironmentConfig.DISABLE_SYNCHRONIZATION, true)
-      .andBuild()
-
-    makeNoopValidator(server.components)
-
-    await server.startProgram()
-
     const url = server.getUrl() + `/contents/non-existent-file`
     const res = await fetch(url)
 
@@ -23,15 +30,6 @@ describe('Integration - Get Content', () => {
   })
 
   it('returns 404 when the content file does not exist for the head method', async () => {
-    const server = await getTestEnv()
-      .configServer()
-      .withConfig(EnvironmentConfig.DISABLE_SYNCHRONIZATION, true)
-      .andBuild()
-
-    makeNoopValidator(server.components)
-
-    await server.startProgram()
-
     const url = server.getUrl() + `/contents/non-existent-file`
     const res = await fetch(url, { method: 'HEAD' })
 

--- a/content/test/integration/controller/deployment-fields.spec.ts
+++ b/content/test/integration/controller/deployment-fields.spec.ts
@@ -3,7 +3,7 @@ import { DeploymentField } from '../../../src/types'
 import { Deployment } from '../../../src/deployment-types'
 import { makeNoopValidator } from '../../helpers/service/validations/NoOpValidator'
 import { buildDeployData } from '../E2ETestUtils'
-import { SimpleTestEnvironment, createSimpleTestEnvironment } from '../simpleTestEnvironment'
+import { createDefaultServer } from '../simpleTestEnvironment'
 import { TestProgram } from '../TestProgram'
 import LeakDetector from 'jest-leak-detector'
 
@@ -17,19 +17,17 @@ describe('Integration - Deployment Fields', () => {
   }
 
   let server: TestProgram
-  let env: SimpleTestEnvironment
 
   beforeAll(async () => {
-    env = await createSimpleTestEnvironment()
-    server = await env.start()
+    server = await createDefaultServer()
     makeNoopValidator(server.components)
   })
 
   afterAll(async () => {
     jest.restoreAllMocks()
-    const detector = new LeakDetector(env)
-    await env.stop()
-    env = null as any
+    const detector = new LeakDetector(server)
+    await server.stopProgram()
+    server = null as any
     expect(await detector.isLeaking()).toBe(false)
   })
 

--- a/content/test/integration/controller/deployment-pagination.spec.ts
+++ b/content/test/integration/controller/deployment-pagination.spec.ts
@@ -2,30 +2,27 @@ import { EntityType } from '@dcl/schemas'
 import { createFetchComponent } from '@well-known-components/fetch-component'
 import { DeploymentField } from '../../../src/types'
 import { DeploymentOptions, SortingField, SortingOrder } from '../../../src/deployment-types'
-import { EnvironmentConfig } from '../../../src/Environment'
 import { toQueryParams } from '../../../src/logic/query-params'
 import { PointerChangesFilters } from '../../../src/service/pointers/types'
 import { makeNoopValidator } from '../../helpers/service/validations/NoOpValidator'
-import { setupTestEnvironment } from '../E2ETestEnvironment'
 import { buildDeployData, EntityCombo } from '../E2ETestUtils'
+import { SimpleTestEnvironment, createSimpleTestEnvironment } from '../simpleTestEnvironment'
 import { TestProgram } from '../TestProgram'
+import LeakDetector from 'jest-leak-detector'
 
 describe('Integration - Deployment Pagination', () => {
-  const getTestEnv = setupTestEnvironment()
-
   const fetcher = createFetchComponent()
 
   let E1: EntityCombo, E2: EntityCombo, E3: EntityCombo
 
   let server: TestProgram
-
-  beforeEach(async () => {
-    server = await getTestEnv().configServer().withConfig(EnvironmentConfig.DISABLE_SYNCHRONIZATION, true).andBuild()
-    makeNoopValidator(server.components)
-    await server.startProgram()
-  })
+  let env: SimpleTestEnvironment
 
   beforeAll(async () => {
+    env = await createSimpleTestEnvironment()
+    server = await env.start()
+    makeNoopValidator(server.components)
+
     const P1 = 'X1,Y1'
     const P2 = 'X2,Y2'
     const P3 = 'X3,Y3'
@@ -42,6 +39,19 @@ describe('Integration - Deployment Pagination', () => {
       E2 = a
     }
     E3 = await buildDeployData([P3], { type, timestamp: timestamp + 1, metadata: { a: 'metadata3' } })
+  })
+
+  beforeEach(async () => {
+    server.components.activeEntities.reset()
+    await env.clearDatabase()
+  })
+
+  afterAll(async () => {
+    jest.restoreAllMocks()
+    const detector = new LeakDetector(env)
+    await env.stop()
+    env = null as any
+    expect(await detector.isLeaking()).toBe(false)
   })
 
   it('given local timestamp and asc when getting two elements the next link page is correct', async () => {

--- a/content/test/integration/controller/deployment-pagination.spec.ts
+++ b/content/test/integration/controller/deployment-pagination.spec.ts
@@ -6,7 +6,7 @@ import { toQueryParams } from '../../../src/logic/query-params'
 import { PointerChangesFilters } from '../../../src/service/pointers/types'
 import { makeNoopValidator } from '../../helpers/service/validations/NoOpValidator'
 import { buildDeployData, EntityCombo } from '../E2ETestUtils'
-import { SimpleTestEnvironment, createSimpleTestEnvironment } from '../simpleTestEnvironment'
+import { resetServer, createDefaultServer } from '../simpleTestEnvironment'
 import { TestProgram } from '../TestProgram'
 import LeakDetector from 'jest-leak-detector'
 
@@ -16,11 +16,9 @@ describe('Integration - Deployment Pagination', () => {
   let E1: EntityCombo, E2: EntityCombo, E3: EntityCombo
 
   let server: TestProgram
-  let env: SimpleTestEnvironment
 
   beforeAll(async () => {
-    env = await createSimpleTestEnvironment()
-    server = await env.start()
+    server = await createDefaultServer()
     makeNoopValidator(server.components)
 
     const P1 = 'X1,Y1'
@@ -41,16 +39,13 @@ describe('Integration - Deployment Pagination', () => {
     E3 = await buildDeployData([P3], { type, timestamp: timestamp + 1, metadata: { a: 'metadata3' } })
   })
 
-  beforeEach(async () => {
-    server.components.activeEntities.reset()
-    await env.clearDatabase()
-  })
+  beforeEach(() => resetServer(server))
 
   afterAll(async () => {
     jest.restoreAllMocks()
-    const detector = new LeakDetector(env)
-    await env.stop()
-    env = null as any
+    const detector = new LeakDetector(server)
+    await server.stopProgram()
+    server = null as any
     expect(await detector.isLeaking()).toBe(false)
   })
 

--- a/content/test/integration/controller/entities.spec.ts
+++ b/content/test/integration/controller/entities.spec.ts
@@ -1,24 +1,22 @@
 import fetch from 'node-fetch'
 import { makeNoopValidator } from '../../helpers/service/validations/NoOpValidator'
-import { SimpleTestEnvironment, createSimpleTestEnvironment } from '../simpleTestEnvironment'
+import { createDefaultServer } from '../simpleTestEnvironment'
 import { TestProgram } from '../TestProgram'
 import LeakDetector from 'jest-leak-detector'
 
 describe('Integration - Entities', () => {
   let server: TestProgram
-  let env: SimpleTestEnvironment
 
   beforeAll(async () => {
-    env = await createSimpleTestEnvironment()
-    server = await env.start()
+    server = await createDefaultServer()
     makeNoopValidator(server.components)
   })
 
   afterAll(async () => {
     jest.restoreAllMocks()
-    const detector = new LeakDetector(env)
-    await env.stop()
-    env = null as any
+    const detector = new LeakDetector(server)
+    await server.stopProgram()
+    server = null as any
     expect(await detector.isLeaking()).toBe(false)
   })
 

--- a/content/test/integration/controller/entity-metadata.spec.ts
+++ b/content/test/integration/controller/entity-metadata.spec.ts
@@ -1,30 +1,25 @@
 import fetch from 'node-fetch'
 import { makeNoopValidator } from '../../helpers/service/validations/NoOpValidator'
 import { buildDeployData } from '../E2ETestUtils'
-import { SimpleTestEnvironment, createSimpleTestEnvironment } from '../simpleTestEnvironment'
+import { createDefaultServer, resetServer } from '../simpleTestEnvironment'
 import { TestProgram } from '../TestProgram'
 import LeakDetector from 'jest-leak-detector'
 
 describe('Integration - Get wearable image and thumbnail', () => {
   let server: TestProgram
-  let env: SimpleTestEnvironment
 
   beforeAll(async () => {
-    env = await createSimpleTestEnvironment()
-    server = await env.start()
+    server = await createDefaultServer()
     makeNoopValidator(server.components)
   })
 
-  beforeEach(async () => {
-    server.components.activeEntities.reset()
-    await env.clearDatabase()
-  })
+  beforeEach(() => resetServer(server))
 
   afterAll(async () => {
     jest.restoreAllMocks()
-    const detector = new LeakDetector(env)
-    await env.stop()
-    env = null as any
+    const detector = new LeakDetector(server)
+    await server.stopProgram()
+    server = null as any
     expect(await detector.isLeaking()).toBe(false)
   })
 

--- a/content/test/integration/controller/status.spec.ts
+++ b/content/test/integration/controller/status.spec.ts
@@ -1,21 +1,28 @@
 import fetch from 'node-fetch'
-import { EnvironmentConfig } from '../../../src/Environment'
 import { makeNoopValidator } from '../../helpers/service/validations/NoOpValidator'
-import { setupTestEnvironment } from '../E2ETestEnvironment'
+import { SimpleTestEnvironment, createSimpleTestEnvironment } from '../simpleTestEnvironment'
+import { TestProgram } from '../TestProgram'
+import LeakDetector from 'jest-leak-detector'
 
 describe('Integration - Status', () => {
-  const getTestEnv = setupTestEnvironment()
+  let server: TestProgram
+  let env: SimpleTestEnvironment
+
+  beforeAll(async () => {
+    env = await createSimpleTestEnvironment()
+    server = await env.start()
+    makeNoopValidator(server.components)
+  })
+
+  afterAll(async () => {
+    jest.restoreAllMocks()
+    const detector = new LeakDetector(env)
+    await env.stop()
+    env = null as any
+    expect(await detector.isLeaking()).toBe(false)
+  })
 
   it('returns 200 when the status is ok', async () => {
-    const server = await getTestEnv()
-      .configServer()
-      .withConfig(EnvironmentConfig.DISABLE_SYNCHRONIZATION, true)
-      .andBuild()
-
-    makeNoopValidator(server.components)
-
-    await server.startProgram()
-
     const url = server.getUrl() + `/status`
     const res = await fetch(url)
 

--- a/content/test/integration/controller/status.spec.ts
+++ b/content/test/integration/controller/status.spec.ts
@@ -1,24 +1,22 @@
 import fetch from 'node-fetch'
 import { makeNoopValidator } from '../../helpers/service/validations/NoOpValidator'
-import { SimpleTestEnvironment, createSimpleTestEnvironment } from '../simpleTestEnvironment'
+import { createDefaultServer } from '../simpleTestEnvironment'
 import { TestProgram } from '../TestProgram'
 import LeakDetector from 'jest-leak-detector'
 
 describe('Integration - Status', () => {
   let server: TestProgram
-  let env: SimpleTestEnvironment
 
   beforeAll(async () => {
-    env = await createSimpleTestEnvironment()
-    server = await env.start()
+    server = await createDefaultServer()
     makeNoopValidator(server.components)
   })
 
   afterAll(async () => {
     jest.restoreAllMocks()
-    const detector = new LeakDetector(env)
-    await env.stop()
-    env = null as any
+    const detector = new LeakDetector(server)
+    await server.stopProgram()
+    server = null as any
     expect(await detector.isLeaking()).toBe(false)
   })
 

--- a/content/test/integration/ports/deployer/concurrent-deployments.spec.ts
+++ b/content/test/integration/ports/deployer/concurrent-deployments.spec.ts
@@ -3,48 +3,54 @@ import { getDeployments } from '../../../../src/logic/deployments'
 import { Deployer } from '../../../../src/ports/deployer'
 import { AppComponents } from '../../../../src/types'
 import { makeNoopServerValidator, makeNoopValidator } from '../../../helpers/service/validations/NoOpValidator'
-import { setupTestEnvironment, testCaseWithComponents } from '../../E2ETestEnvironment'
 import { buildDeployData, deployEntitiesCombo, EntityCombo } from '../../E2ETestUtils'
+import { TestProgram } from '../../TestProgram'
+import LeakDetector from 'jest-leak-detector'
+import { createDefaultServer } from '../../simpleTestEnvironment'
+
+const P1 = 'x1,y1'
+const AMOUNT_OF_DEPLOYMENTS = 5
+const type = EntityType.PROFILE
 
 /**
  * This test verifies that if concurrent deployments are made, then only one remains as active
  */
 describe('Integration - Concurrent deployments', () => {
-  const getTestEnv = setupTestEnvironment()
+  let server: TestProgram
 
-  const P1 = 'x1,y1'
-  const AMOUNT_OF_DEPLOYMENTS = 500
-  const type = EntityType.PROFILE
-
-  let entities: EntityCombo[]
-
-  it('creates initial entities', async () => {
-    entities = []
-    for (let i = 0; i < AMOUNT_OF_DEPLOYMENTS; i++) {
-      entities[i] = await buildDeployData([P1], { type, metadata: { a: 'metadata' } })
-    }
+  beforeAll(async () => {
+    server = await createDefaultServer()
+    makeNoopValidator(server.components)
+    makeNoopServerValidator(server.components)
   })
 
-  testCaseWithComponents(
-    getTestEnv,
-    `When deployments are executed concurrently, then only one remains active`,
-    async (components) => {
-      const { deployer } = components
+  afterAll(async () => {
+    jest.restoreAllMocks()
+    const detector = new LeakDetector(server)
+    await server.stopProgram()
+    server = null as any
+    expect(await detector.isLeaking()).toBe(false)
+  })
 
-      // make noop validator
-      makeNoopValidator(components)
-      makeNoopServerValidator(components)
-
-      // Perform all the deployments concurrently
-      await Promise.all(entities.map((entityCombo) => deployEntity(deployer, entityCombo, components)))
-
-      // Assert that only one is active
-      const { deployments } = await getDeployments(components, components.database, {
-        filters: { pointers: [P1], onlyCurrentlyPointed: true }
-      })
-      expect(deployments.length).toEqual(1)
+  it('When deployments are executed concurrently, then only one remains active', async () => {
+    const p: Promise<EntityCombo>[] = []
+    for (let i = 0; i < AMOUNT_OF_DEPLOYMENTS; i++) {
+      p.push(buildDeployData([P1], { type, metadata: { a: 'metadata' } }))
     }
-  )
+    const entities = await Promise.all(p)
+
+    const { components } = server
+    const { deployer } = components
+
+    // Perform all the deployments concurrently
+    await Promise.all(entities.map((entityCombo) => deployEntity(deployer, entityCombo, components)))
+
+    // Assert that only one is active
+    const { deployments } = await getDeployments(components, components.database, {
+      filters: { pointers: [P1], onlyCurrentlyPointed: true }
+    })
+    expect(deployments.length).toEqual(1)
+  })
 
   async function deployEntity(deployer: Deployer, entity: EntityCombo, components: Pick<AppComponents, 'logs'>) {
     const logger = components.logs.getLogger('ConcurrentCheckTest/DeployEntity')

--- a/content/test/integration/ports/deployer/metadata-schema-validations.spec.ts
+++ b/content/test/integration/ports/deployer/metadata-schema-validations.spec.ts
@@ -2,188 +2,170 @@ import { EntityType } from '@dcl/schemas'
 import { AuditInfo, DeploymentContext, DeploymentResult, InvalidResult } from '../../../../src/deployment-types'
 import { AppComponents, EntityVersion } from '../../../../src/types'
 import { makeNoopServerValidator } from '../../../helpers/service/validations/NoOpValidator'
-import { setupTestEnvironment, testCaseWithComponents } from '../../E2ETestEnvironment'
 import { EntityCombo, buildDeployData, createIdentity } from '../../E2ETestUtils'
+import { TestProgram } from '../../TestProgram'
+import LeakDetector from 'jest-leak-detector'
+import { createDefaultServer, resetServer } from '../../simpleTestEnvironment'
 
+const P1 = '0,0'
+const P2 = '0,1'
 describe('Integration - Deployment with metadata validation', () => {
-  const getTestEnv = setupTestEnvironment()
+  let server: TestProgram
 
-  testCaseWithComponents(
-    getTestEnv,
-    'When scene metadata is missing, deployment result should include the proper error',
-    async (components) => {
-      makeNoopServerValidator(components)
+  const identity = createIdentity()
 
-      const P1 = '0,0'
-      const P2 = '0,1'
-      let E1: EntityCombo = await buildDeployData([P1, P2], {
-        type: EntityType.SCENE,
-        metadata: { a: 'metadata' }
-      })
+  beforeAll(async () => {
+    server = await createDefaultServer()
+    makeNoopServerValidator(server.components)
+  })
 
-      expect(await deployEntity(components, E1)).toEqual({
-        errors: [
-          'The metadata for this entity type (scene) is not valid.',
-          "must have required property 'main'",
-          "must have required property 'scene'"
-        ]
-      })
-    }
-  )
+  beforeEach(async () => {
+    await resetServer(server)
+  })
 
-  testCaseWithComponents(
-    getTestEnv,
-    'When scene metadata is present but incomplete, deployment result should include the proper errors',
-    async (components) => {
-      makeNoopServerValidator(components)
+  afterAll(async () => {
+    jest.restoreAllMocks()
+    const detector = new LeakDetector(server)
+    await server.stopProgram()
+    server = null as any
+    expect(await detector.isLeaking()).toBe(false)
+  })
 
-      const P1 = '0,0'
-      const P2 = '0,1'
-      let E1: EntityCombo = await buildDeployData([P1, P2], {
-        type: EntityType.SCENE,
-        metadata: {}
-      })
+  it('When scene metadata is missing, deployment result should include the proper error', async () => {
+    const { components } = server
+    let E1: EntityCombo = await buildDeployData([P1, P2], {
+      type: EntityType.SCENE,
+      metadata: { a: 'metadata' }
+    })
 
-      expect(await deployEntity(components, E1)).toEqual({
-        errors: [
-          'The metadata for this entity type (scene) is not valid.',
-          "must have required property 'main'",
-          "must have required property 'scene'"
-        ]
-      })
-    }
-  )
-
-  testCaseWithComponents(
-    getTestEnv,
-    'When scene metadata is present but incomplete (missing scene), deployment result should include the proper error',
-    async (components) => {
-      makeNoopServerValidator(components)
-
-      const P1 = '0,0'
-      const P2 = '0,1'
-      let E1: EntityCombo = await buildDeployData([P1, P2], {
-        type: EntityType.SCENE,
-        metadata: {
-          main: 'main.js'
-        }
-      })
-
-      expect(await deployEntity(components, E1)).toEqual({
-        errors: ['The metadata for this entity type (scene) is not valid.', "must have required property 'scene'"]
-      })
-    }
-  )
-
-  testCaseWithComponents(
-    getTestEnv,
-    'When profile metadata is missing, deployment result should include the proper error',
-    async (components) => {
-      makeNoopServerValidator(components)
-
-      const identity = createIdentity()
-      let E1: EntityCombo = await buildDeployData([identity.address], {
-        type: EntityType.PROFILE,
-        metadata: { a: 'metadata' },
-        identity
-      })
-
-      expect(await deployEntity(components, E1)).toEqual({
-        errors: ['The metadata for this entity type (profile) is not valid.', "must have required property 'avatars'"]
-      })
-    }
-  )
-
-  testCaseWithComponents(
-    getTestEnv,
-    'When profile metadata is present but incomplete (missing avatars), deployment result should include the proper error',
-    async (components) => {
-      makeNoopServerValidator(components)
-
-      const identity = createIdentity()
-      let E1: EntityCombo = await buildDeployData([identity.address], {
-        type: EntityType.PROFILE,
-        metadata: {},
-        identity
-      })
-
-      expect(await deployEntity(components, E1)).toEqual({
-        errors: ['The metadata for this entity type (profile) is not valid.', "must have required property 'avatars'"]
-      })
-    }
-  )
-
-  testCaseWithComponents(
-    getTestEnv,
-    'When wearable metadata is wrong, deployment result should include the proper error',
-    async (components) => {
-      const expectedErrors = [
-        'The metadata for this entity type (wearable) is not valid.',
-        "must have required property 'collectionAddress'",
-        "must have required property 'rarity'",
-        'must pass "_isThirdParty" keyword validation',
-        'must pass "_isBaseAvatar" keyword validation',
-        "must have required property 'merkleProof'",
-        "must have required property 'content'",
-        "must have required property 'id'",
-        "must have required property 'name'",
-        "must have required property 'description'",
-        "must have required property 'i18n'",
-        "must have required property 'thumbnail'",
-        "must have required property 'image'",
-        "must have required property 'data'",
-        'either standard XOR thirdparty properties conditions must be met'
+    expect(await deployEntity(components, E1)).toEqual({
+      errors: [
+        'The metadata for this entity type (scene) is not valid.',
+        "must have required property 'main'",
+        "must have required property 'scene'"
       ]
-      makeNoopServerValidator(components)
+    })
+  })
 
-      const identity = createIdentity()
-      let E1: EntityCombo = await buildDeployData([identity.address], {
-        type: EntityType.WEARABLE,
-        metadata: { a: 'metadata' },
-        identity
-      })
+  it('When scene metadata is present but incomplete, deployment result should include the proper errors', async () => {
+    const { components } = server
 
-      const result = (await deployEntity(components, E1)) as InvalidResult
+    const E1: EntityCombo = await buildDeployData([P1, P2], {
+      type: EntityType.SCENE,
+      metadata: {}
+    })
 
-      expectedErrors.forEach(($) => expect(result?.errors).toContain($))
-    }
-  )
-
-  testCaseWithComponents(
-    getTestEnv,
-    'When wearable metadata is present but incomplete, deployment result should include the proper error',
-    async (components) => {
-      const expectedErrors = [
-        'The metadata for this entity type (wearable) is not valid.',
-        "must have required property 'collectionAddress'",
-        "must have required property 'rarity'",
-        'must pass "_isThirdParty" keyword validation',
-        'must pass "_isBaseAvatar" keyword validation',
-        "must have required property 'merkleProof'",
-        "must have required property 'content'",
-        "must have required property 'id'",
-        "must have required property 'name'",
-        "must have required property 'description'",
-        "must have required property 'i18n'",
-        "must have required property 'thumbnail'",
-        "must have required property 'image'",
-        "must have required property 'data'",
-        'either standard XOR thirdparty properties conditions must be met'
+    expect(await deployEntity(components, E1)).toEqual({
+      errors: [
+        'The metadata for this entity type (scene) is not valid.',
+        "must have required property 'main'",
+        "must have required property 'scene'"
       ]
-      makeNoopServerValidator(components)
+    })
+  })
 
-      const identity = createIdentity()
-      let E1: EntityCombo = await buildDeployData([identity.address], {
-        type: EntityType.WEARABLE,
-        metadata: {},
-        identity
-      })
+  it('When scene metadata is present but incomplete (missing scene), deployment result should include the proper error', async () => {
+    const { components } = server
 
-      const result = (await deployEntity(components, E1)) as InvalidResult
+    const E1: EntityCombo = await buildDeployData([P1, P2], {
+      type: EntityType.SCENE,
+      metadata: {
+        main: 'main.js'
+      }
+    })
 
-      expectedErrors.forEach(($) => expect(result?.errors).toContain($))
-    }
-  )
+    expect(await deployEntity(components, E1)).toEqual({
+      errors: ['The metadata for this entity type (scene) is not valid.', "must have required property 'scene'"]
+    })
+  })
+
+  it('When profile metadata is missing, deployment result should include the proper error', async () => {
+    const { components } = server
+    const E1: EntityCombo = await buildDeployData([identity.address], {
+      type: EntityType.PROFILE,
+      metadata: { a: 'metadata' },
+      identity
+    })
+
+    expect(await deployEntity(components, E1)).toEqual({
+      errors: ['The metadata for this entity type (profile) is not valid.', "must have required property 'avatars'"]
+    })
+  })
+
+  it('When profile metadata is present but incomplete (missing avatars), deployment result should include the proper error', async () => {
+    const { components } = server
+    const E1: EntityCombo = await buildDeployData([identity.address], {
+      type: EntityType.PROFILE,
+      metadata: {},
+      identity
+    })
+
+    expect(await deployEntity(components, E1)).toEqual({
+      errors: ['The metadata for this entity type (profile) is not valid.', "must have required property 'avatars'"]
+    })
+  })
+
+  it('When wearable metadata is wrong, deployment result should include the proper error', async () => {
+    const { components } = server
+    const expectedErrors = [
+      'The metadata for this entity type (wearable) is not valid.',
+      "must have required property 'collectionAddress'",
+      "must have required property 'rarity'",
+      'must pass "_isThirdParty" keyword validation',
+      'must pass "_isBaseAvatar" keyword validation',
+      "must have required property 'merkleProof'",
+      "must have required property 'content'",
+      "must have required property 'id'",
+      "must have required property 'name'",
+      "must have required property 'description'",
+      "must have required property 'i18n'",
+      "must have required property 'thumbnail'",
+      "must have required property 'image'",
+      "must have required property 'data'",
+      'either standard XOR thirdparty properties conditions must be met'
+    ]
+
+    const E1: EntityCombo = await buildDeployData([identity.address], {
+      type: EntityType.WEARABLE,
+      metadata: { a: 'metadata' },
+      identity
+    })
+
+    const result = (await deployEntity(components, E1)) as InvalidResult
+
+    expectedErrors.forEach(($) => expect(result?.errors).toContain($))
+  })
+
+  it('When wearable metadata is present but incomplete, deployment result should include the proper error', async () => {
+    const { components } = server
+    const expectedErrors = [
+      'The metadata for this entity type (wearable) is not valid.',
+      "must have required property 'collectionAddress'",
+      "must have required property 'rarity'",
+      'must pass "_isThirdParty" keyword validation',
+      'must pass "_isBaseAvatar" keyword validation',
+      "must have required property 'merkleProof'",
+      "must have required property 'content'",
+      "must have required property 'id'",
+      "must have required property 'name'",
+      "must have required property 'description'",
+      "must have required property 'i18n'",
+      "must have required property 'thumbnail'",
+      "must have required property 'image'",
+      "must have required property 'data'",
+      'either standard XOR thirdparty properties conditions must be met'
+    ]
+
+    const E1: EntityCombo = await buildDeployData([identity.address], {
+      type: EntityType.WEARABLE,
+      metadata: {},
+      identity
+    })
+
+    const result = (await deployEntity(components, E1)) as InvalidResult
+
+    expectedErrors.forEach(($) => expect(result?.errors).toContain($))
+  })
 
   async function deployEntity(
     components: Pick<AppComponents, 'deployer'>,

--- a/content/test/integration/ports/deployer/old-entity-synced.spec.ts
+++ b/content/test/integration/ports/deployer/old-entity-synced.spec.ts
@@ -1,81 +1,89 @@
-import { createFsComponent } from '@dcl/catalyst-storage'
 import { AuthLinkType, Entity, EntityType } from '@dcl/schemas'
 import { AuditInfo, DeploymentContext, DeploymentResult } from '../../../../src/deployment-types'
 import { AppComponents } from '../../../../src/types'
 import { makeNoopServerValidator } from '../../../helpers/service/validations/NoOpValidator'
-import { setupTestEnvironment, testCaseWithComponents } from '../../E2ETestEnvironment'
 import { EntityCombo } from '../../E2ETestUtils'
 import { getIntegrationResourcePathFor } from '../../resources/get-resource-path'
-
-const fs = createFsComponent()
+import { TestProgram } from '../../TestProgram'
+import LeakDetector from 'jest-leak-detector'
+import { createDefaultServer } from '../../simpleTestEnvironment'
 
 describe('Integration - Deployment synced old entity', () => {
-  const getTestEnv = setupTestEnvironment()
+  let server: TestProgram
 
-  testCaseWithComponents(
-    getTestEnv,
-    'When deploying an entity with cid v0 hashes of entities before ADR 45, it should succeed',
-    async (components) => {
-      makeNoopServerValidator(components)
+  beforeAll(async () => {
+    server = await createDefaultServer()
+    makeNoopServerValidator(server.components)
+  })
 
-      const entity: Entity = {
-        version: 'v3',
-        id: 'QmYfCVBv7PJCcBh3AutAzNesdGZVKUEd8KCc8Jh1Y8ba4u',
-        type: EntityType.PROFILE,
-        pointers: ['0x4CAb2E350499bAd0eC5941aD6B6995a6a20f0130'],
-        timestamp: 1632416205936,
-        content: [
+  afterAll(async () => {
+    jest.restoreAllMocks()
+    const detector = new LeakDetector(server)
+    await server.stopProgram()
+    server = null as any
+    expect(await detector.isLeaking()).toBe(false)
+  })
+
+  it('When deploying an entity with cid v0 hashes of entities before ADR 45, it should succeed', async () => {
+    const { components } = server
+    const { fs } = components
+    const entity: Entity = {
+      version: 'v3',
+      id: 'QmYfCVBv7PJCcBh3AutAzNesdGZVKUEd8KCc8Jh1Y8ba4u',
+      type: EntityType.PROFILE,
+      pointers: ['0x4CAb2E350499bAd0eC5941aD6B6995a6a20f0130'],
+      timestamp: 1632416205936,
+      content: [
+        {
+          file: 'aFile-zjxd',
+          hash: 'QmbNcPuVAq6Dv821kfFnyaM59Go3xCeBMnSxYRSHEpwWeF'
+        },
+        {
+          file: 'anotherFile-zjxd',
+          hash: 'QmbNcPuVAq6Dv821kfFnyaM59Go3xCeBMnSxYRSHEpwWeF'
+        },
+        {
+          file: 'aThirdFile-zjxd',
+          hash: 'QmbNcPuVAq6Dv821kfFnyaM59Go3xCeBMnSxYRSHEpwWeF'
+        }
+      ]
+    }
+
+    const contentFile = await fs.readFile(
+      getIntegrationResourcePathFor('QmbNcPuVAq6Dv821kfFnyaM59Go3xCeBMnSxYRSHEpwWeF')
+    )
+    const entityFile = await fs.readFile(
+      getIntegrationResourcePathFor('QmYfCVBv7PJCcBh3AutAzNesdGZVKUEd8KCc8Jh1Y8ba4u')
+    )
+
+    const E1: EntityCombo = {
+      deployData: {
+        entityId: 'QmYfCVBv7PJCcBh3AutAzNesdGZVKUEd8KCc8Jh1Y8ba4u',
+        files: new Map([
+          ['QmbNcPuVAq6Dv821kfFnyaM59Go3xCeBMnSxYRSHEpwWeF', contentFile],
+          ['QmYfCVBv7PJCcBh3AutAzNesdGZVKUEd8KCc8Jh1Y8ba4u', entityFile]
+        ]),
+        authChain: [
           {
-            file: 'aFile-zjxd',
-            hash: 'QmbNcPuVAq6Dv821kfFnyaM59Go3xCeBMnSxYRSHEpwWeF'
+            type: AuthLinkType.SIGNER,
+            payload: '0x4CAb2E350499bAd0eC5941aD6B6995a6a20f0130',
+            signature: ''
           },
           {
-            file: 'anotherFile-zjxd',
-            hash: 'QmbNcPuVAq6Dv821kfFnyaM59Go3xCeBMnSxYRSHEpwWeF'
-          },
-          {
-            file: 'aThirdFile-zjxd',
-            hash: 'QmbNcPuVAq6Dv821kfFnyaM59Go3xCeBMnSxYRSHEpwWeF'
+            type: AuthLinkType.ECDSA_PERSONAL_SIGNED_ENTITY,
+            payload: 'QmYfCVBv7PJCcBh3AutAzNesdGZVKUEd8KCc8Jh1Y8ba4u',
+            signature:
+              '0x10c80e802b3d5faea8e253c809d254ec2e17a4b36c50ade38e0a4e7766c320e903aa262a5be9458802d57f0c69b283855d3734848fc7b68467d0749f082700b01b'
           }
         ]
-      }
-
-      const contentFile = await fs.readFile(
-        getIntegrationResourcePathFor('QmbNcPuVAq6Dv821kfFnyaM59Go3xCeBMnSxYRSHEpwWeF')
-      )
-      const entityFile = await fs.readFile(
-        getIntegrationResourcePathFor('QmYfCVBv7PJCcBh3AutAzNesdGZVKUEd8KCc8Jh1Y8ba4u')
-      )
-
-      const E1: EntityCombo = {
-        deployData: {
-          entityId: 'QmYfCVBv7PJCcBh3AutAzNesdGZVKUEd8KCc8Jh1Y8ba4u',
-          files: new Map([
-            ['QmbNcPuVAq6Dv821kfFnyaM59Go3xCeBMnSxYRSHEpwWeF', contentFile],
-            ['QmYfCVBv7PJCcBh3AutAzNesdGZVKUEd8KCc8Jh1Y8ba4u', entityFile]
-          ]),
-          authChain: [
-            {
-              type: AuthLinkType.SIGNER,
-              payload: '0x4CAb2E350499bAd0eC5941aD6B6995a6a20f0130',
-              signature: ''
-            },
-            {
-              type: AuthLinkType.ECDSA_PERSONAL_SIGNED_ENTITY,
-              payload: 'QmYfCVBv7PJCcBh3AutAzNesdGZVKUEd8KCc8Jh1Y8ba4u',
-              signature:
-                '0x10c80e802b3d5faea8e253c809d254ec2e17a4b36c50ade38e0a4e7766c320e903aa262a5be9458802d57f0c69b283855d3734848fc7b68467d0749f082700b01b'
-            }
-          ]
-        },
-        entity: entity
-      }
-
-      const deploymentResult = await deployEntity(components, E1)
-
-      expect(typeof deploymentResult === 'number').toBeTruthy()
+      },
+      entity: entity
     }
-  )
+
+    const deploymentResult = await deployEntity(components, E1)
+
+    expect(typeof deploymentResult === 'number').toBeTruthy()
+  })
 
   async function deployEntity(
     components: Pick<AppComponents, 'deployer'>,

--- a/content/test/integration/ports/deployer/order-check.spec.ts
+++ b/content/test/integration/ports/deployer/order-check.spec.ts
@@ -1,15 +1,15 @@
 import { getDeployments } from '../../../../src/logic/deployments'
 import { AppComponents } from '../../../../src/types'
 import { makeNoopServerValidator, makeNoopValidator } from '../../../helpers/service/validations/NoOpValidator'
-import { setupTestEnvironment, testCaseWithComponents } from '../../E2ETestEnvironment'
 import { buildDeployData, buildDeployDataAfterEntity, deployEntitiesCombo, EntityCombo } from '../../E2ETestUtils'
+import { SimpleTestEnvironment, createSimpleTestEnvironment } from '../../simpleTestEnvironment'
+import { TestProgram } from '../../TestProgram'
+import LeakDetector from 'jest-leak-detector'
 
 /**
  * This test verifies that the active entity and overwrites are calculated correctly, regardless of the order in which the entities where deployed.
  */
 describe('Integration - Order Check', () => {
-  const getTestEnv = setupTestEnvironment()
-
   const P1 = 'X1,Y1'
   const P2 = 'X2,Y2'
   const P3 = 'X3,Y3'
@@ -17,6 +17,24 @@ describe('Integration - Order Check', () => {
   let E1: EntityCombo, E2: EntityCombo, E3: EntityCombo, E4: EntityCombo, E5: EntityCombo
 
   let allEntities: EntityCombo[]
+
+  let server: TestProgram
+  let env: SimpleTestEnvironment
+
+  beforeAll(async () => {
+    env = await createSimpleTestEnvironment()
+    server = await env.start()
+    makeNoopValidator(server.components)
+    makeNoopServerValidator(server.components)
+  })
+
+  afterAll(async () => {
+    jest.restoreAllMocks()
+    const detector = new LeakDetector(env)
+    await env.stop()
+    env = null as any
+    expect(await detector.isLeaking()).toBe(false)
+  })
 
   beforeAll(async () => {
     E1 = await buildDeployData([P1])
@@ -30,11 +48,8 @@ describe('Integration - Order Check', () => {
 
   permutator([0, 1, 2, 3, 4]).forEach(function (indices) {
     const names = indices.map((idx) => `E${idx + 1}`).join(' -> ')
-    testCaseWithComponents(getTestEnv, names, async (components) => {
-      // make noop validator
-      makeNoopValidator(components)
-      makeNoopServerValidator(components)
-
+    it(names, async () => {
+      const { components } = server
       const entityCombos = indices.map((idx) => allEntities[idx])
       await deployEntitiesCombo(components.deployer, ...entityCombos)
       await assertCommitsWhereDoneCorrectly(components)

--- a/content/test/integration/ports/deployer/order-check.spec.ts
+++ b/content/test/integration/ports/deployer/order-check.spec.ts
@@ -2,7 +2,7 @@ import { getDeployments } from '../../../../src/logic/deployments'
 import { AppComponents } from '../../../../src/types'
 import { makeNoopServerValidator, makeNoopValidator } from '../../../helpers/service/validations/NoOpValidator'
 import { buildDeployData, buildDeployDataAfterEntity, deployEntitiesCombo, EntityCombo } from '../../E2ETestUtils'
-import { SimpleTestEnvironment, createSimpleTestEnvironment } from '../../simpleTestEnvironment'
+import { createDefaultServer } from '../../simpleTestEnvironment'
 import { TestProgram } from '../../TestProgram'
 import LeakDetector from 'jest-leak-detector'
 
@@ -19,20 +19,18 @@ describe('Integration - Order Check', () => {
   let allEntities: EntityCombo[]
 
   let server: TestProgram
-  let env: SimpleTestEnvironment
 
   beforeAll(async () => {
-    env = await createSimpleTestEnvironment()
-    server = await env.start()
+    server = await createDefaultServer()
     makeNoopValidator(server.components)
     makeNoopServerValidator(server.components)
   })
 
   afterAll(async () => {
     jest.restoreAllMocks()
-    const detector = new LeakDetector(env)
-    await env.stop()
-    env = null as any
+    const detector = new LeakDetector(server)
+    await server.stopProgram()
+    server = null as any
     expect(await detector.isLeaking()).toBe(false)
   })
 

--- a/content/test/integration/ports/snapshotStorage.spec.ts
+++ b/content/test/integration/ports/snapshotStorage.spec.ts
@@ -1,21 +1,34 @@
 import * as snapshotQueries from '../../../src/logic/database-queries/snapshots-queries'
-import { setupTestEnvironment, testCaseWithComponents } from '../E2ETestEnvironment'
+import { TestProgram } from '../TestProgram'
+import LeakDetector from 'jest-leak-detector'
+import { createDefaultServer } from '../simpleTestEnvironment'
 
 describe('snapshot storage', () => {
-  const getTestEnv = setupTestEnvironment()
+  let server: TestProgram
 
-  describe('has', () => {
-    testCaseWithComponents(getTestEnv, 'should return true if the snapshot is stored', async (components) => {
-      const snapshotHash = 'snapshotHash'
-      await snapshotQueries.saveSnapshot(components.database, {
-        hash: snapshotHash,
-        timeRange: { initTimestamp: 0, endTimestamp: 1 },
-        numberOfEntities: 0,
-        generationTimestamp: 2
-      })
+  beforeAll(async () => {
+    server = await createDefaultServer()
+  })
 
-      expect(await components.snapshotStorage.has(snapshotHash)).toBeTruthy()
-      expect(await components.snapshotStorage.has('another-hash')).toBeFalsy()
+  afterAll(async () => {
+    jest.restoreAllMocks()
+    const detector = new LeakDetector(server)
+    await server.stopProgram()
+    server = null as any
+    expect(await detector.isLeaking()).toBe(false)
+  })
+
+  it('should return true if the snapshot is stored', async () => {
+    const { components } = server
+    const snapshotHash = 'snapshotHash'
+    await snapshotQueries.saveSnapshot(components.database, {
+      hash: snapshotHash,
+      timeRange: { initTimestamp: 0, endTimestamp: 1 },
+      numberOfEntities: 0,
+      generationTimestamp: 2
     })
+
+    expect(await components.snapshotStorage.has(snapshotHash)).toBeTruthy()
+    expect(await components.snapshotStorage.has('another-hash')).toBeFalsy()
   })
 })

--- a/content/test/integration/simpleTestEnvironment.ts
+++ b/content/test/integration/simpleTestEnvironment.ts
@@ -15,6 +15,7 @@ const POSTGRES_PORT = 5432
 
 export type SimpleTestEnvironment = {
   start(): Promise<TestProgram>
+  clearDatabase(): Promise<void>
   stop(): Promise<void>
 }
 
@@ -22,53 +23,63 @@ export async function createSimpleTestEnvironment(): Promise<SimpleTestEnvironme
   let server: TestProgram | undefined = undefined
 
   const dao = MockedDAOClient.withAddresses()
-
   const logs = await createLogComponent({
     config: createConfigComponent({
-      LOG_LEVEL: 'WARN'
+      LOG_LEVEL: 'DEBUG'
     })
   })
-  const port = process.env.MAPPED_POSTGRES_PORT ? parseInt(process.env.MAPPED_POSTGRES_PORT) : POSTGRES_PORT
-
   const sharedEnv = new Environment()
     .setConfig(EnvironmentConfig.PSQL_PASSWORD, DEFAULT_DATABASE_CONFIG.password)
     .setConfig(EnvironmentConfig.PSQL_USER, DEFAULT_DATABASE_CONFIG.user)
-    .setConfig(EnvironmentConfig.PSQL_PORT, port)
+    .setConfig(
+      EnvironmentConfig.PSQL_PORT,
+      process.env.MAPPED_POSTGRES_PORT ? parseInt(process.env.MAPPED_POSTGRES_PORT) : POSTGRES_PORT
+    )
     .setConfig(EnvironmentConfig.PSQL_SCHEMA, TEST_SCHEMA)
     .setConfig(EnvironmentConfig.PSQL_HOST, 'localhost')
     .setConfig(EnvironmentConfig.LOG_REQUESTS, false)
     .setConfig(EnvironmentConfig.LOG_LEVEL, 'WARN')
     .setConfig(EnvironmentConfig.BOOTSTRAP_FROM_SCRATCH, false)
   const metrics = createTestMetricsComponent(metricsDeclaration)
-  const database = await createDatabaseComponent({ logs, env: sharedEnv, metrics })
-  if (database.start) {
-    database.start()
-  }
 
   const dbName = 'db' + random.alphaNumeric(8)
-  await database.query(`CREATE DATABASE ${dbName}`)
-  await database.query(`
+  {
+    // create db and run migrations
+    const database = await createDatabaseComponent({ logs, env: sharedEnv, metrics })
+    if (database.start) {
+      await database.start()
+    }
+
+    await database.query(`CREATE DATABASE ${dbName}`)
+    await database.query(`
       CREATE SCHEMA IF NOT EXISTS ${TEST_SCHEMA}
     `)
 
-  const env = new Environment(sharedEnv).setConfig(EnvironmentConfig.PSQL_DATABASE, dbName)
-  const migrationManager = createMigrationExecutor({ logs, env })
-  await migrationManager.run()
-  await stopAllComponents({ migrationManager })
+    const env = new Environment(sharedEnv).setConfig(EnvironmentConfig.PSQL_DATABASE, dbName)
+    const migrationManager = createMigrationExecutor({ logs, env })
+    await migrationManager.run()
+    await stopAllComponents({ migrationManager, database })
+  }
+  sharedEnv.setConfig(EnvironmentConfig.PSQL_DATABASE, dbName)
+
+  const database = await createDatabaseComponent({ logs, env: sharedEnv, metrics })
+  if (database.start) {
+    await database.start()
+  }
+
+  const port = 1200
+  const storageBaseFolder = sharedEnv.getConfig(EnvironmentConfig.STORAGE_ROOT_FOLDER) ?? 'storage'
+
+  const builder = new EnvironmentBuilder(sharedEnv).withConfig(EnvironmentConfig.DISABLE_SYNCHRONIZATION, true)
+  const components = await builder
+    .withConfig(EnvironmentConfig.HTTP_SERVER_PORT, port)
+    .withConfig(EnvironmentConfig.STORAGE_ROOT_FOLDER, `${storageBaseFolder}/${port}`)
+    .withConfig(EnvironmentConfig.PSQL_DATABASE, dbName)
+    .buildConfigAndComponents()
+
+  const domain = `http://localhost:${port}`
 
   async function start(): Promise<TestProgram> {
-    const port = 1200
-
-    const storageBaseFolder = env.getConfig(EnvironmentConfig.STORAGE_ROOT_FOLDER) ?? 'storage'
-
-    const builder = new EnvironmentBuilder(sharedEnv).withConfig(EnvironmentConfig.DISABLE_SYNCHRONIZATION, true)
-    const components = await builder
-      .withConfig(EnvironmentConfig.HTTP_SERVER_PORT, port)
-      .withConfig(EnvironmentConfig.STORAGE_ROOT_FOLDER, `${storageBaseFolder}/${port}`)
-      .withConfig(EnvironmentConfig.PSQL_DATABASE, dbName)
-      .buildConfigAndComponents()
-
-    const domain = `http://localhost:${port}`
     dao.add(domain)
 
     // if (this.dao) {
@@ -89,42 +100,18 @@ export async function createSimpleTestEnvironment(): Promise<SimpleTestEnvironme
       server.stopProgram()
     }
 
-    // then the components of the environment
-    await stopAllComponents({
-      database: database,
-      logs: logs
-    })
+    await stopAllComponents({ database, logs })
   }
 
-  // async function resetDatabases(): Promise<void> {
-  //   await database.query(`
-  //     DROP SCHEMA IF EXISTS ${E2ETestEnvironment.TEST_SCHEMA} CASCADE
-  //   `)
-  // }
+  async function clearDatabase(): Promise<void> {
+    if (server) {
+      await components.database.query('TRUNCATE TABLE deployments, content_files, active_pointers CASCADE')
+    }
+  }
 
   return {
     start,
+    clearDatabase,
     stop
   }
-}
-
-let env: SimpleTestEnvironment | undefined = undefined
-export async function getOrCreateSimpleTestEnvironment() {
-  if (env) {
-    return env
-  }
-
-  env = await createSimpleTestEnvironment()
-  return env
-}
-
-let server: TestProgram | undefined = undefined
-export async function getDefaultTestServer() {
-  if (server) {
-    return server
-  }
-
-  const env = await getOrCreateSimpleTestEnvironment()
-  server = await env.start()
-  return server
 }

--- a/content/test/integration/simpleTestEnvironment.ts
+++ b/content/test/integration/simpleTestEnvironment.ts
@@ -1,13 +1,13 @@
 import { createConfigComponent } from '@well-known-components/env-config-provider'
 import { createLogComponent } from '@well-known-components/logger'
 import { createTestMetricsComponent } from '@well-known-components/metrics'
-import { random } from 'faker'
 import { DEFAULT_DATABASE_CONFIG, Environment, EnvironmentBuilder, EnvironmentConfig } from '../../src/Environment'
 import { stopAllComponents } from '../../src/logic/components-lifecycle'
 import { metricsDeclaration } from '../../src/metrics'
 import { createMigrationExecutor } from '../../src/migrations/migration-executor'
 import { createDatabaseComponent } from '../../src/ports/postgres'
 import { MockedDAOClient } from '../helpers/service/synchronization/clients/MockedDAOClient'
+import { random } from 'faker'
 import { TestProgram } from './TestProgram'
 
 const TEST_SCHEMA = 'e2etest'
@@ -19,13 +19,12 @@ export type SimpleTestEnvironment = {
   stop(): Promise<void>
 }
 
-export async function createSimpleTestEnvironment(): Promise<SimpleTestEnvironment> {
-  let server: TestProgram | undefined = undefined
-
-  const dao = MockedDAOClient.withAddresses()
+export async function createDefaultDB() {
+  const dbName = 'db' + random.alphaNumeric(8)
+  process.env.__TEST_DB_NAME = dbName
   const logs = await createLogComponent({
     config: createConfigComponent({
-      LOG_LEVEL: 'DEBUG'
+      LOG_LEVEL: 'WARN'
     })
   })
   const sharedEnv = new Environment()
@@ -41,31 +40,50 @@ export async function createSimpleTestEnvironment(): Promise<SimpleTestEnvironme
     .setConfig(EnvironmentConfig.LOG_LEVEL, 'WARN')
     .setConfig(EnvironmentConfig.BOOTSTRAP_FROM_SCRATCH, false)
   const metrics = createTestMetricsComponent(metricsDeclaration)
-
-  const dbName = 'db' + random.alphaNumeric(8)
-  {
-    // create db and run migrations
-    const database = await createDatabaseComponent({ logs, env: sharedEnv, metrics })
-    if (database.start) {
-      await database.start()
-    }
-
-    await database.query(`CREATE DATABASE ${dbName}`)
-    await database.query(`
-      CREATE SCHEMA IF NOT EXISTS ${TEST_SCHEMA}
-    `)
-
-    const env = new Environment(sharedEnv).setConfig(EnvironmentConfig.PSQL_DATABASE, dbName)
-    const migrationManager = createMigrationExecutor({ logs, env })
-    await migrationManager.run()
-    await stopAllComponents({ migrationManager, database })
-  }
-  sharedEnv.setConfig(EnvironmentConfig.PSQL_DATABASE, dbName)
-
   const database = await createDatabaseComponent({ logs, env: sharedEnv, metrics })
   if (database.start) {
     await database.start()
   }
+
+  await database.query(`CREATE DATABASE ${dbName}`)
+  await database.query(`
+      CREATE SCHEMA IF NOT EXISTS ${TEST_SCHEMA}
+    `)
+
+  const env = new Environment(sharedEnv).setConfig(EnvironmentConfig.PSQL_DATABASE, dbName)
+  const migrationManager = createMigrationExecutor({ logs, env })
+  await migrationManager.run()
+  await stopAllComponents({ migrationManager, database })
+}
+
+let dbCreated = false
+export async function createSimpleTestEnvironment(): Promise<SimpleTestEnvironment> {
+  let server: TestProgram | undefined = undefined
+
+  if (!dbCreated) {
+    await createDefaultDB()
+    dbCreated = true
+  }
+
+  const dao = MockedDAOClient.withAddresses()
+  const logs = await createLogComponent({
+    config: createConfigComponent({
+      LOG_LEVEL: 'WARN'
+    })
+  })
+  const sharedEnv = new Environment()
+    .setConfig(EnvironmentConfig.PSQL_PASSWORD, DEFAULT_DATABASE_CONFIG.password)
+    .setConfig(EnvironmentConfig.PSQL_USER, DEFAULT_DATABASE_CONFIG.user)
+    .setConfig(
+      EnvironmentConfig.PSQL_PORT,
+      process.env.MAPPED_POSTGRES_PORT ? parseInt(process.env.MAPPED_POSTGRES_PORT) : POSTGRES_PORT
+    )
+    .setConfig(EnvironmentConfig.PSQL_SCHEMA, TEST_SCHEMA)
+    .setConfig(EnvironmentConfig.PSQL_HOST, 'localhost')
+    .setConfig(EnvironmentConfig.LOG_REQUESTS, false)
+    .setConfig(EnvironmentConfig.LOG_LEVEL, 'WARN')
+    .setConfig(EnvironmentConfig.BOOTSTRAP_FROM_SCRATCH, false)
+    .setConfig(EnvironmentConfig.PSQL_DATABASE, process.env.__TEST_DB_NAME)
 
   const port = 1200
   const storageBaseFolder = sharedEnv.getConfig(EnvironmentConfig.STORAGE_ROOT_FOLDER) ?? 'storage'
@@ -74,7 +92,6 @@ export async function createSimpleTestEnvironment(): Promise<SimpleTestEnvironme
   const components = await builder
     .withConfig(EnvironmentConfig.HTTP_SERVER_PORT, port)
     .withConfig(EnvironmentConfig.STORAGE_ROOT_FOLDER, `${storageBaseFolder}/${port}`)
-    .withConfig(EnvironmentConfig.PSQL_DATABASE, dbName)
     .buildConfigAndComponents()
 
   const domain = `http://localhost:${port}`
@@ -91,7 +108,7 @@ export async function createSimpleTestEnvironment(): Promise<SimpleTestEnvironme
       server.stopProgram()
     }
 
-    await stopAllComponents({ database, logs })
+    await stopAllComponents({ logs })
   }
 
   async function clearDatabase(): Promise<void> {

--- a/content/test/integration/simpleTestEnvironment.ts
+++ b/content/test/integration/simpleTestEnvironment.ts
@@ -1,0 +1,130 @@
+import { createConfigComponent } from '@well-known-components/env-config-provider'
+import { createLogComponent } from '@well-known-components/logger'
+import { createTestMetricsComponent } from '@well-known-components/metrics'
+import { random } from 'faker'
+import { DEFAULT_DATABASE_CONFIG, Environment, EnvironmentBuilder, EnvironmentConfig } from '../../src/Environment'
+import { stopAllComponents } from '../../src/logic/components-lifecycle'
+import { metricsDeclaration } from '../../src/metrics'
+import { createMigrationExecutor } from '../../src/migrations/migration-executor'
+import { createDatabaseComponent } from '../../src/ports/postgres'
+import { MockedDAOClient } from '../helpers/service/synchronization/clients/MockedDAOClient'
+import { TestProgram } from './TestProgram'
+
+const TEST_SCHEMA = 'e2etest'
+const POSTGRES_PORT = 5432
+
+export type SimpleTestEnvironment = {
+  start(): Promise<TestProgram>
+  stop(): Promise<void>
+}
+
+export async function createSimpleTestEnvironment(): Promise<SimpleTestEnvironment> {
+  let server: TestProgram | undefined = undefined
+
+  const dao = MockedDAOClient.withAddresses()
+
+  const logs = await createLogComponent({
+    config: createConfigComponent({
+      LOG_LEVEL: 'WARN'
+    })
+  })
+  const port = process.env.MAPPED_POSTGRES_PORT ? parseInt(process.env.MAPPED_POSTGRES_PORT) : POSTGRES_PORT
+
+  const sharedEnv = new Environment()
+    .setConfig(EnvironmentConfig.PSQL_PASSWORD, DEFAULT_DATABASE_CONFIG.password)
+    .setConfig(EnvironmentConfig.PSQL_USER, DEFAULT_DATABASE_CONFIG.user)
+    .setConfig(EnvironmentConfig.PSQL_PORT, port)
+    .setConfig(EnvironmentConfig.PSQL_SCHEMA, TEST_SCHEMA)
+    .setConfig(EnvironmentConfig.PSQL_HOST, 'localhost')
+    .setConfig(EnvironmentConfig.LOG_REQUESTS, false)
+    .setConfig(EnvironmentConfig.LOG_LEVEL, 'WARN')
+    .setConfig(EnvironmentConfig.BOOTSTRAP_FROM_SCRATCH, false)
+  const metrics = createTestMetricsComponent(metricsDeclaration)
+  const database = await createDatabaseComponent({ logs, env: sharedEnv, metrics })
+  if (database.start) {
+    database.start()
+  }
+
+  const dbName = 'db' + random.alphaNumeric(8)
+  await database.query(`CREATE DATABASE ${dbName}`)
+  await database.query(`
+      CREATE SCHEMA IF NOT EXISTS ${TEST_SCHEMA}
+    `)
+
+  const env = new Environment(sharedEnv).setConfig(EnvironmentConfig.PSQL_DATABASE, dbName)
+  const migrationManager = createMigrationExecutor({ logs, env })
+  await migrationManager.run()
+  await stopAllComponents({ migrationManager })
+
+  async function start(): Promise<TestProgram> {
+    const port = 1200
+
+    const storageBaseFolder = env.getConfig(EnvironmentConfig.STORAGE_ROOT_FOLDER) ?? 'storage'
+
+    const builder = new EnvironmentBuilder(sharedEnv).withConfig(EnvironmentConfig.DISABLE_SYNCHRONIZATION, true)
+    const components = await builder
+      .withConfig(EnvironmentConfig.HTTP_SERVER_PORT, port)
+      .withConfig(EnvironmentConfig.STORAGE_ROOT_FOLDER, `${storageBaseFolder}/${port}`)
+      .withConfig(EnvironmentConfig.PSQL_DATABASE, dbName)
+      .buildConfigAndComponents()
+
+    const domain = `http://localhost:${port}`
+    dao.add(domain)
+
+    // if (this.dao) {
+    //   // mock DAO client
+    //   jest
+    //     .spyOn(components.daoClient, 'getAllContentServers')
+    //     .mockImplementation(() => this.dao.getAllContentServers())
+    //   jest.spyOn(components.daoClient, 'getAllServers').mockImplementation(() => this.dao.getAllServers())
+    // }
+
+    server = new TestProgram(components)
+    await server.startProgram()
+    return server
+  }
+
+  async function stop(): Promise<void> {
+    if (server) {
+      server.stopProgram()
+    }
+
+    // then the components of the environment
+    await stopAllComponents({
+      database: database,
+      logs: logs
+    })
+  }
+
+  // async function resetDatabases(): Promise<void> {
+  //   await database.query(`
+  //     DROP SCHEMA IF EXISTS ${E2ETestEnvironment.TEST_SCHEMA} CASCADE
+  //   `)
+  // }
+
+  return {
+    start,
+    stop
+  }
+}
+
+let env: SimpleTestEnvironment | undefined = undefined
+export async function getOrCreateSimpleTestEnvironment() {
+  if (env) {
+    return env
+  }
+
+  env = await createSimpleTestEnvironment()
+  return env
+}
+
+let server: TestProgram | undefined = undefined
+export async function getDefaultTestServer() {
+  if (server) {
+    return server
+  }
+
+  const env = await getOrCreateSimpleTestEnvironment()
+  server = await env.start()
+  return server
+}

--- a/content/test/integration/simpleTestEnvironment.ts
+++ b/content/test/integration/simpleTestEnvironment.ts
@@ -52,7 +52,9 @@ export async function createDefaultDB() {
 }
 
 export async function clearDatabase(server: TestProgram): Promise<void> {
-  await server.components.database.query('TRUNCATE TABLE deployments, content_files, active_pointers CASCADE')
+  await server.components.database.query(
+    'TRUNCATE TABLE deployments, content_files, active_pointers, processed_snapshots CASCADE'
+  )
 }
 
 export function resetServer(server: TestProgram): Promise<void> {

--- a/content/test/integration/simpleTestEnvironment.ts
+++ b/content/test/integration/simpleTestEnvironment.ts
@@ -81,15 +81,6 @@ export async function createSimpleTestEnvironment(): Promise<SimpleTestEnvironme
 
   async function start(): Promise<TestProgram> {
     dao.add(domain)
-
-    // if (this.dao) {
-    //   // mock DAO client
-    //   jest
-    //     .spyOn(components.daoClient, 'getAllContentServers')
-    //     .mockImplementation(() => this.dao.getAllContentServers())
-    //   jest.spyOn(components.daoClient, 'getAllServers').mockImplementation(() => this.dao.getAllServers())
-    // }
-
     server = new TestProgram(components)
     await server.startProgram()
     return server

--- a/content/test/integration/syncronization/batch-deployer.spec.ts
+++ b/content/test/integration/syncronization/batch-deployer.spec.ts
@@ -1,31 +1,81 @@
-import { EnvironmentConfig } from '../../../src/Environment'
+import { EnvironmentBuilder, EnvironmentConfig } from '../../../src/Environment'
 import * as deployments from '../../../src/logic/deployments'
 import * as deployRemote from '../../../src/service/synchronization/deployRemoteEntity'
-import { setupTestEnvironment, testCaseWithComponents } from '../E2ETestEnvironment'
 
 describe('batch deployer - ', () => {
-  const getTestEnv = setupTestEnvironment({ [EnvironmentConfig.DISABLE_SYNCHRONIZATION]: true })
+  beforeEach(async () => {
+    jest.restoreAllMocks()
+  })
 
-  testCaseWithComponents(
-    getTestEnv,
-    'multiple sequential deployments with same entityId is done one time but markAsDeployed is called for both',
-    async (components) => {
-      const deployedEntitites = new Set()
-      const deployEntityFromRemoteServerSpy = jest
-        .spyOn(deployRemote, 'deployEntityFromRemoteServer')
-        .mockImplementation(async (components, entityId, ...args) => {
-          deployedEntitites.add(entityId)
-        })
+  afterAll(async () => {
+    jest.restoreAllMocks()
+  })
 
-      jest.spyOn(deployments, 'isEntityDeployed').mockImplementation(async (components, entityId) => {
-        return deployedEntitites.has(entityId)
+  function createComponents() {
+    return new EnvironmentBuilder()
+      .withConfig(EnvironmentConfig.BOOTSTRAP_FROM_SCRATCH, false)
+      .withConfig(EnvironmentConfig.DISABLE_SYNCHRONIZATION, true)
+      .buildConfigAndComponents()
+  }
+
+  it('multiple sequential deployments with same entityId is done one time but markAsDeployed is called for both', async () => {
+    const components = await createComponents()
+    const deployedEntitites = new Set()
+    const deployEntityFromRemoteServerSpy = jest
+      .spyOn(deployRemote, 'deployEntityFromRemoteServer')
+      .mockImplementation(async (components, entityId, ...args) => {
+        deployedEntitites.add(entityId)
       })
 
-      const markedAsDeployed = new Set()
+    jest.spyOn(deployments, 'isEntityDeployed').mockImplementation(async (components, entityId) => {
+      return deployedEntitites.has(entityId)
+    })
 
-      const numberOfDeployments = 15
-      for (let i = 0; i < numberOfDeployments; i++) {
-        await components.batchDeployer.scheduleEntityDeployment(
+    const markedAsDeployed = new Set()
+
+    const numberOfDeployments = 15
+    for (let i = 0; i < numberOfDeployments; i++) {
+      await components.batchDeployer.scheduleEntityDeployment(
+        {
+          entityId: 'asdf',
+          entityTimestamp: 123,
+          entityType: 'profile',
+          pointers: ['anAddress'],
+          authChain: [],
+          markAsDeployed: async () => {
+            markedAsDeployed.add(i)
+          }
+        },
+        []
+      )
+    }
+
+    await components.batchDeployer.onIdle()
+    for (let i = 0; i < numberOfDeployments; i++) {
+      expect(markedAsDeployed.has(i)).toBeTruthy()
+    }
+    expect(deployEntityFromRemoteServerSpy).toBeCalledTimes(1)
+  })
+
+  it('multiple concurrent deployments with same entityId is done one time but markAsDeployed is called for both', async () => {
+    const components = await createComponents()
+    const deployedEntitites = new Set()
+    const deployEntityFromRemoteServerSpy = jest
+      .spyOn(deployRemote, 'deployEntityFromRemoteServer')
+      .mockImplementation(async (components, entityId, ...args) => {
+        deployedEntitites.add(entityId)
+      })
+
+    jest.spyOn(deployments, 'isEntityDeployed').mockImplementation(async (components, entityId) => {
+      return deployedEntitites.has(entityId)
+    })
+
+    const markedAsDeployed = new Set()
+    const batchDeployments: Promise<void>[] = []
+    const numberOfDeployments = 15
+    for (let i = 0; i < numberOfDeployments; i++) {
+      batchDeployments.push(
+        components.batchDeployer.scheduleEntityDeployment(
           {
             entityId: 'asdf',
             entityTimestamp: 123,
@@ -38,230 +88,174 @@ describe('batch deployer - ', () => {
           },
           []
         )
-      }
-
-      await components.batchDeployer.onIdle()
-      for (let i = 0; i < numberOfDeployments; i++) {
-        expect(markedAsDeployed.has(i)).toBeTruthy()
-      }
-      expect(deployEntityFromRemoteServerSpy).toBeCalledTimes(1)
+      )
     }
-  )
 
-  testCaseWithComponents(
-    getTestEnv,
-    'multiple concurrent deployments with same entityId is done one time but markAsDeployed is called for both',
-    async (components) => {
-      const deployedEntitites = new Set()
-      const deployEntityFromRemoteServerSpy = jest
-        .spyOn(deployRemote, 'deployEntityFromRemoteServer')
-        .mockImplementation(async (components, entityId, ...args) => {
-          deployedEntitites.add(entityId)
-        })
+    await Promise.all(batchDeployments)
 
-      jest.spyOn(deployments, 'isEntityDeployed').mockImplementation(async (components, entityId) => {
+    await components.batchDeployer.onIdle()
+    for (let i = 0; i < numberOfDeployments; i++) {
+      expect(markedAsDeployed.has(i)).toBeTruthy()
+    }
+
+    expect(deployEntityFromRemoteServerSpy).toBeCalledTimes(1)
+  })
+
+  it('five concurrent deployments with different entityId are done for each one and markAsDeployed is called for each one', async () => {
+    const components = await createComponents()
+    const deployedEntitites = new Set()
+    const deployEntityFromRemoteServerSpy = jest
+      .spyOn(deployRemote, 'deployEntityFromRemoteServer')
+      .mockImplementation(async (components, entityId, ...args) => {
+        deployedEntitites.add(entityId)
+      })
+
+    jest.spyOn(deployments, 'isEntityDeployed').mockImplementation(async (components, entityId) => {
+      return deployedEntitites.has(entityId)
+    })
+
+    const markedAsDeployed = new Set()
+    const batchDeployments: Promise<void>[] = []
+    const numberOfDeployments = 15
+    for (let i = 0; i < numberOfDeployments; i++) {
+      batchDeployments.push(
+        components.batchDeployer.scheduleEntityDeployment(
+          {
+            entityId: i.toString(),
+            entityTimestamp: 123,
+            entityType: 'profile',
+            pointers: ['anAddress'],
+            authChain: [],
+            markAsDeployed: async () => {
+              markedAsDeployed.add(i)
+            }
+          },
+          []
+        )
+      )
+    }
+
+    await Promise.all(batchDeployments)
+
+    await components.batchDeployer.onIdle()
+    for (let i = 0; i < numberOfDeployments; i++) {
+      expect(markedAsDeployed.has(i)).toBeTruthy()
+    }
+
+    expect(deployEntityFromRemoteServerSpy).toBeCalledTimes(numberOfDeployments)
+  })
+
+  it('markAsDeployed is called but not deployed for deployments that are already deployed', async () => {
+    const components = await createComponents()
+    const deployEntityFromRemoteServerSpy = jest.spyOn(deployRemote, 'deployEntityFromRemoteServer')
+
+    jest.spyOn(deployments, 'isEntityDeployed').mockResolvedValue(true)
+
+    const markedAsDeployed = new Set()
+    await components.batchDeployer.scheduleEntityDeployment(
+      {
+        entityId: 'asdf',
+        entityTimestamp: 123,
+        entityType: 'profile',
+        pointers: ['anAddress'],
+        authChain: [],
+        markAsDeployed: async () => {
+          markedAsDeployed.add(1)
+        }
+      },
+      []
+    )
+
+    await components.batchDeployer.onIdle()
+    expect(markedAsDeployed.has(1)).toBeTruthy()
+    expect(deployEntityFromRemoteServerSpy).toBeCalledTimes(0)
+  })
+
+  it('when a deployment fails, it is reported as failed deployment and markAsDeployed is called', async () => {
+    const components = await createComponents()
+    const deployEntityFromRemoteServerSpy = jest
+      .spyOn(deployRemote, 'deployEntityFromRemoteServer')
+      .mockImplementation(async () => {
+        throw new Error('error deploying entity (test)')
+      })
+
+    jest.spyOn(deployments, 'isEntityDeployed').mockResolvedValue(false)
+    const reportFailureSpy = jest.spyOn(components.failedDeployments, 'reportFailure').mockResolvedValue()
+
+    const markedAsDeployed = new Set()
+    await components.batchDeployer.scheduleEntityDeployment(
+      {
+        entityId: 'asdf',
+        entityTimestamp: 123,
+        entityType: 'profile',
+        pointers: ['anAddress'],
+        authChain: [],
+        markAsDeployed: async () => {
+          markedAsDeployed.add(1)
+        }
+      },
+      []
+    )
+
+    await components.batchDeployer.onIdle()
+    expect(markedAsDeployed.has(1)).toBeTruthy()
+    expect(deployEntityFromRemoteServerSpy).toBeCalledTimes(1)
+    expect(reportFailureSpy).toBeCalledTimes(1)
+  })
+
+  it('when a deployment is successfull, consecutive ones with same entityId are ignored but markAsDeployed is called', async () => {
+    const components = await createComponents()
+    const deployedEntitites = new Set()
+    const deployEntityFromRemoteServerSpy = jest
+      .spyOn(deployRemote, 'deployEntityFromRemoteServer')
+      .mockImplementation(async (components, entityId, ...args) => {
+        deployedEntitites.add(entityId)
+      })
+
+    const isEntityDeployedSpy = jest
+      .spyOn(deployments, 'isEntityDeployed')
+      .mockImplementation(async (components, entityId) => {
         return deployedEntitites.has(entityId)
       })
 
-      const markedAsDeployed = new Set()
-      const batchDeployments: Promise<void>[] = []
-      const numberOfDeployments = 15
-      for (let i = 0; i < numberOfDeployments; i++) {
-        batchDeployments.push(
-          components.batchDeployer.scheduleEntityDeployment(
-            {
-              entityId: 'asdf',
-              entityTimestamp: 123,
-              entityType: 'profile',
-              pointers: ['anAddress'],
-              authChain: [],
-              markAsDeployed: async () => {
-                markedAsDeployed.add(i)
-              }
-            },
-            []
-          )
-        )
-      }
+    const markedAsDeployed = new Set()
+    const entityId = 'asdf'
+    await components.batchDeployer.scheduleEntityDeployment(
+      {
+        entityId,
+        entityTimestamp: 123,
+        entityType: 'profile',
+        pointers: ['anAddress'],
+        authChain: [],
+        markAsDeployed: async () => {
+          markedAsDeployed.add(1)
+        }
+      },
+      []
+    )
+    await components.batchDeployer.onIdle()
 
-      await Promise.all(batchDeployments)
+    // Now we deployed an entity with same entityId
+    await components.batchDeployer.scheduleEntityDeployment(
+      {
+        entityId,
+        entityTimestamp: 123,
+        entityType: 'profile',
+        pointers: ['anAddress'],
+        authChain: [],
+        markAsDeployed: async () => {
+          markedAsDeployed.add(2)
+        }
+      },
+      []
+    )
+    await components.batchDeployer.onIdle()
 
-      await components.batchDeployer.onIdle()
-      for (let i = 0; i < numberOfDeployments; i++) {
-        expect(markedAsDeployed.has(i)).toBeTruthy()
-      }
-
-      expect(deployEntityFromRemoteServerSpy).toBeCalledTimes(1)
-    }
-  )
-
-  testCaseWithComponents(
-    getTestEnv,
-    'five concurrent deployments with different entityId are done for each one and markAsDeployed is called for each one',
-    async (components) => {
-      const deployedEntitites = new Set()
-      const deployEntityFromRemoteServerSpy = jest
-        .spyOn(deployRemote, 'deployEntityFromRemoteServer')
-        .mockImplementation(async (components, entityId, ...args) => {
-          deployedEntitites.add(entityId)
-        })
-
-      jest.spyOn(deployments, 'isEntityDeployed').mockImplementation(async (components, entityId) => {
-        return deployedEntitites.has(entityId)
-      })
-
-      const markedAsDeployed = new Set()
-      const batchDeployments: Promise<void>[] = []
-      const numberOfDeployments = 15
-      for (let i = 0; i < numberOfDeployments; i++) {
-        batchDeployments.push(
-          components.batchDeployer.scheduleEntityDeployment(
-            {
-              entityId: i.toString(),
-              entityTimestamp: 123,
-              entityType: 'profile',
-              pointers: ['anAddress'],
-              authChain: [],
-              markAsDeployed: async () => {
-                markedAsDeployed.add(i)
-              }
-            },
-            []
-          )
-        )
-      }
-
-      await Promise.all(batchDeployments)
-
-      await components.batchDeployer.onIdle()
-      for (let i = 0; i < numberOfDeployments; i++) {
-        expect(markedAsDeployed.has(i)).toBeTruthy()
-      }
-
-      expect(deployEntityFromRemoteServerSpy).toBeCalledTimes(numberOfDeployments)
-    }
-  )
-
-  testCaseWithComponents(
-    getTestEnv,
-    'markAsDeployed is called but not deployed for deployments that are already deployed',
-    async (components) => {
-      const deployEntityFromRemoteServerSpy = jest.spyOn(deployRemote, 'deployEntityFromRemoteServer')
-
-      jest.spyOn(deployments, 'isEntityDeployed').mockResolvedValue(true)
-
-      const markedAsDeployed = new Set()
-      await components.batchDeployer.scheduleEntityDeployment(
-        {
-          entityId: 'asdf',
-          entityTimestamp: 123,
-          entityType: 'profile',
-          pointers: ['anAddress'],
-          authChain: [],
-          markAsDeployed: async () => {
-            markedAsDeployed.add(1)
-          }
-        },
-        []
-      )
-
-      await components.batchDeployer.onIdle()
-      expect(markedAsDeployed.has(1)).toBeTruthy()
-      expect(deployEntityFromRemoteServerSpy).toBeCalledTimes(0)
-    }
-  )
-
-  testCaseWithComponents(
-    getTestEnv,
-    'when a deployment fails, it is reported as failed deployment and markAsDeployed is called',
-    async (components) => {
-      const deployEntityFromRemoteServerSpy = jest
-        .spyOn(deployRemote, 'deployEntityFromRemoteServer')
-        .mockImplementation(async () => {
-          throw new Error('error deploying entity (test)')
-        })
-
-      jest.spyOn(deployments, 'isEntityDeployed').mockResolvedValue(false)
-      const reportFailureSpy = jest.spyOn(components.failedDeployments, 'reportFailure').mockResolvedValue()
-
-      const markedAsDeployed = new Set()
-      await components.batchDeployer.scheduleEntityDeployment(
-        {
-          entityId: 'asdf',
-          entityTimestamp: 123,
-          entityType: 'profile',
-          pointers: ['anAddress'],
-          authChain: [],
-          markAsDeployed: async () => {
-            markedAsDeployed.add(1)
-          }
-        },
-        []
-      )
-
-      await components.batchDeployer.onIdle()
-      expect(markedAsDeployed.has(1)).toBeTruthy()
-      expect(deployEntityFromRemoteServerSpy).toBeCalledTimes(1)
-      expect(reportFailureSpy).toBeCalledTimes(1)
-    }
-  )
-
-  testCaseWithComponents(
-    getTestEnv,
-    'when a deployment is successfull, consecutive ones with same entityId are ignored but markAsDeployed is called',
-    async (components) => {
-      const deployedEntitites = new Set()
-      const deployEntityFromRemoteServerSpy = jest
-        .spyOn(deployRemote, 'deployEntityFromRemoteServer')
-        .mockImplementation(async (components, entityId, ...args) => {
-          deployedEntitites.add(entityId)
-        })
-
-      const isEntityDeployedSpy = jest
-        .spyOn(deployments, 'isEntityDeployed')
-        .mockImplementation(async (components, entityId) => {
-          return deployedEntitites.has(entityId)
-        })
-
-      const markedAsDeployed = new Set()
-      const entityId = 'asdf'
-      await components.batchDeployer.scheduleEntityDeployment(
-        {
-          entityId,
-          entityTimestamp: 123,
-          entityType: 'profile',
-          pointers: ['anAddress'],
-          authChain: [],
-          markAsDeployed: async () => {
-            markedAsDeployed.add(1)
-          }
-        },
-        []
-      )
-      await components.batchDeployer.onIdle()
-
-      // Now we deployed an entity with same entityId
-      await components.batchDeployer.scheduleEntityDeployment(
-        {
-          entityId,
-          entityTimestamp: 123,
-          entityType: 'profile',
-          pointers: ['anAddress'],
-          authChain: [],
-          markAsDeployed: async () => {
-            markedAsDeployed.add(2)
-          }
-        },
-        []
-      )
-      await components.batchDeployer.onIdle()
-
-      expect(markedAsDeployed.has(1)).toBeTruthy()
-      expect(markedAsDeployed.has(2)).toBeTruthy()
-      // Only the first one is truly deployed
-      expect(deployEntityFromRemoteServerSpy).toBeCalledTimes(1)
-      // It is consulted two times but by the first deployment (early noop and in-queue check)
-      expect(isEntityDeployedSpy).toBeCalledTimes(2)
-    }
-  )
+    expect(markedAsDeployed.has(1)).toBeTruthy()
+    expect(markedAsDeployed.has(2)).toBeTruthy()
+    // Only the first one is truly deployed
+    expect(deployEntityFromRemoteServerSpy).toBeCalledTimes(1)
+    // It is consulted two times but by the first deployment (early noop and in-queue check)
+    expect(isEntityDeployedSpy).toBeCalledTimes(2)
+  })
 })


### PR DESCRIPTION
Create a default database (one per runner) and create a default server pointing to such database once per test suite.