### PR TITLE
chore: increase max-old-space for tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,7 @@ jobs:
           command: |
             cd content
             TESTFILES=$(circleci tests glob "test/**/*.spec.ts" | circleci tests split --split-by=timings)
-            yarn test $TESTFILES --coverageDirectory=reports --reporters=jest-junit --reporters=default
+            yarn test:ci $TESTFILES --coverageDirectory=reports --reporters=jest-junit --reporters=default
             mv reports/coverage-final.json reports/coverage-${CIRCLE_NODE_INDEX:-0}.json
             mv api-coverage/api-coverage.csv api-coverage/api-coverage-${CIRCLE_NODE_INDEX:-0}.csv || true
           environment:

--- a/content/package.json
+++ b/content/package.json
@@ -14,6 +14,7 @@
     "start:maintenance": "node ./dist/src/entrypoints/run-maintenance.js",
     "start:content-files-fixer": "node ./dist/src/entrypoints/run-content-files-fixer.js",
     "start:server": "node ./dist/src/entrypoints/run-server.js",
+    "test:ci": "jest --forceExit --coverage",
     "test": "jest --runInBand --detectOpenHandles --forceExit --coverage",
     "test:integration": "jest --selectProjects integration --runInBand --forceExit --detectOpenHandles --coverage",
     "test:unit": "jest --selectProjects unit --runInBand --forceExit --detectOpenHandles --coverage"

--- a/content/package.json
+++ b/content/package.json
@@ -14,7 +14,7 @@
     "start:maintenance": "node ./dist/src/entrypoints/run-maintenance.js",
     "start:content-files-fixer": "node ./dist/src/entrypoints/run-content-files-fixer.js",
     "start:server": "node ./dist/src/entrypoints/run-server.js",
-    "test:ci": "jest --forceExit --coverage",
+    "test:ci": "jest --runInBand --forceExit --coverage",
     "test": "jest --runInBand --detectOpenHandles --forceExit --coverage",
     "test:integration": "jest --selectProjects integration --runInBand --forceExit --detectOpenHandles --coverage",
     "test:unit": "jest --selectProjects unit --runInBand --forceExit --detectOpenHandles --coverage"

--- a/content/package.json
+++ b/content/package.json
@@ -14,7 +14,7 @@
     "start:maintenance": "node ./dist/src/entrypoints/run-maintenance.js",
     "start:content-files-fixer": "node ./dist/src/entrypoints/run-content-files-fixer.js",
     "start:server": "node ./dist/src/entrypoints/run-server.js",
-    "test:ci": "node --expose-gc node_modules/.bin/jest --runInBand --forceExit --coverage --logHeapUsage",
+    "test:ci": "node --max-old-space-size=8000 node_modules/.bin/jest --runInBand --forceExit --coverage",
     "test": "jest --runInBand --detectOpenHandles --forceExit --coverage",
     "test:integration": "jest --selectProjects integration --runInBand --forceExit --detectOpenHandles --coverage",
     "test:unit": "jest --selectProjects unit --runInBand --forceExit --detectOpenHandles --coverage"

--- a/content/package.json
+++ b/content/package.json
@@ -14,7 +14,7 @@
     "start:maintenance": "node ./dist/src/entrypoints/run-maintenance.js",
     "start:content-files-fixer": "node ./dist/src/entrypoints/run-content-files-fixer.js",
     "start:server": "node ./dist/src/entrypoints/run-server.js",
-    "test:ci": "jest --runInBand --forceExit --coverage",
+    "test:ci": "node --expose-gc node_modules/.bin/jest --runInBand --forceExit --coverage --logHeapUsage",
     "test": "jest --runInBand --detectOpenHandles --forceExit --coverage",
     "test:integration": "jest --selectProjects integration --runInBand --forceExit --detectOpenHandles --coverage",
     "test:unit": "jest --selectProjects unit --runInBand --forceExit --detectOpenHandles --coverage"

--- a/content/src/service.ts
+++ b/content/src/service.ts
@@ -12,9 +12,7 @@ async function setupApiCoverage(server: IHttpServerComponent<GlobalContext>) {
   const coverageDir = path.join(__dirname, '../api-coverage')
   try {
     await fs.promises.mkdir(coverageDir)
-  } catch (err) {
-    console.error(err)
-  }
+  } catch (err) {}
   const coverageFilePath = path.join(coverageDir, `api-coverage.csv`)
   server.use(async (context, next) => {
     const response = await next()
@@ -25,19 +23,6 @@ async function setupApiCoverage(server: IHttpServerComponent<GlobalContext>) {
     return response
   })
 }
-
-// TODO
-// if (env.getConfig(EnvironmentConfig.VALIDATE_API) || process.env.CI === 'true') {
-//   this.app.use(
-//     OpenApiValidator.middleware({
-//       apiSpec: CONTENT_API,
-//       validateResponses: true,
-//       validateRequests: false,
-//       ignoreUndocumented: true,
-//       ignorePaths: /\/entities/
-//     })
-//   )
-// }
 
 // this function wires the business logic (adapters & controllers) with the components (ports)
 export async function main(program: Lifecycle.EntryPointParameters<AppComponents>): Promise<void> {


### PR DESCRIPTION
I notice using `--expose-gc and --logHeapUsage` there is no more out of memory, which I think indicates we are not dealing with a memory leak here, our tests just take a lot of memory!
