### PR TITLE
break: remove deprecated contentv2 endpoints

### DIFF
--- a/lambdas/src/apis/content-v2/controllers/translator.ts
+++ b/lambdas/src/apis/content-v2/controllers/translator.ts
@@ -1,88 +1,10 @@
 import { Request, Response } from 'express'
 import log4js from 'log4js'
-import fetch, { Response as NodeFetchResponse } from 'node-fetch'
+import fetch from 'node-fetch'
 import { asArray } from '../../../utils/ControllerUtils'
 import { SmartContentServerFetcher } from '../../../utils/SmartContentServerFetcher'
 
 const LOGGER = log4js.getLogger('ContentTranslator')
-const MAX_SCENE_AREA: number = 100
-
-export async function getScenes(fetcher: SmartContentServerFetcher, req: Request, res: Response) {
-  // Method: GET
-  // Path: /scenes
-  // Query String: ?x1={number}&x2={number}&y1={number}&y2={number}
-  const x1: number = parseInt(req.query.x1 as string)
-  const x2: number = parseInt(req.query.x2 as string)
-  const y1: number = parseInt(req.query.y1 as string)
-  const y2: number = parseInt(req.query.y2 as string)
-
-  // Make sure that all params are set, and that they are numbers
-  if (isNaN(x1) || isNaN(x2) || isNaN(y1) || isNaN(y2)) {
-    res.status(400).send(`Please make sure that all given parcels are set, and that they are numbers.`)
-    return
-  }
-
-  // Calculate max and min for each coordinate
-  const minX = Math.min(x1, x2)
-  const maxX = Math.max(x1, x2)
-  const minY = Math.min(y1, y2)
-  const maxY = Math.max(y1, y2)
-
-  // Make sure that the specified rectangle meets the max size criteria
-  const size = (maxX - minX + 1) * (maxY - minY + 1)
-  if (size > MAX_SCENE_AREA) {
-    res.status(400).send(`Please make sure that the specified area contains ${MAX_SCENE_AREA} or less parcels.`)
-    return
-  }
-
-  // Calculate all inner parcels and transform them into pointers
-  const pointers: string[] = []
-  for (let x = minX; x <= maxX; x++) {
-    for (let y = minY; y <= maxY; y++) {
-      pointers.push(`${x},${y}`)
-    }
-  }
-
-  // If there are no pointers, then there is no need to query the content server
-  if (pointers.length === 0) {
-    res.send({ data: [] })
-    return
-  }
-
-  // Calculate the url
-  const pointerParams = 'pointer=' + pointers.join('&pointer=')
-  const v3Url = (await fetcher.getContentServerUrl()) + `/entities/scenes?${pointerParams}`
-  LOGGER.trace(`Querying the content server for scenes. Url is ${v3Url}`)
-
-  // Perform the fetch
-  const response = await fetch(v3Url)
-
-  // If the request failed, then return the status code and text
-  if (!response.ok) {
-    const returnedText = await response.text()
-    res.status(response.status).send(returnedText)
-    LOGGER.warn(`Translation to content failed. Response status was ${response.status} and text was ${returnedText}`)
-    return
-  }
-
-  const data: ScenesItem[] = []
-
-  // Read the response, and transform it
-  const entities = (await response.json()) as V3ControllerEntity[]
-  entities.forEach((entity: V3ControllerEntity) => {
-    entity.pointers.forEach((pointer) => {
-      data.push({
-        parcel_id: pointer,
-        root_cid: entity.id,
-        scene_cid: findSceneJsonId(entity)
-      })
-    })
-  })
-
-  // Return the result
-  const scenesResult: ScenesResult = { data }
-  res.send(scenesResult)
-}
 
 interface V3ControllerEntity {
   id: string
@@ -96,16 +18,6 @@ interface V3ControllerEntity {
 interface V3ControllerEntityContent {
   file: string
   hash: string
-}
-
-interface ScenesResult {
-  data: ScenesItem[]
-}
-
-interface ScenesItem {
-  parcel_id: string
-  root_cid: string
-  scene_cid: string
 }
 
 export async function getInfo(fetcher: SmartContentServerFetcher, req: Request, res: Response) {
@@ -158,59 +70,6 @@ interface ParcelInfoItem {
   }
 }
 
-export async function getContents(fetcher: SmartContentServerFetcher, req: Request, res: Response) {
-  // Method: GET
-  // Path: /contents/:cid
-  const cid = req.params.cid
-
-  const v3Url = (await fetcher.getContentServerUrl()) + `/contents/${cid}`
-  const contentServerResponse = await fetch(v3Url)
-  if (contentServerResponse.ok) {
-    copySuccessResponse(contentServerResponse, res)
-  } else {
-    if (contentServerResponse.status === 404) {
-      // Let's try on the old content server
-      // TODO: Remove this
-      const legacyContentServerResponse = await fetch(`https://content.decentraland.org/contents/${cid}`)
-      if (legacyContentServerResponse.ok) {
-        LOGGER.info(`Failed to find '${cid}' on the content server, but found it on the legacy one.`)
-        copySuccessResponse(legacyContentServerResponse, res)
-      } else {
-        res.status(404).send()
-      }
-    } else {
-      res.status(404).send()
-    }
-  }
-}
-
-function copySuccessResponse(responseFrom: NodeFetchResponse, responseTo: Response) {
-  copyHeaders(responseFrom, responseTo)
-  responseTo.status(200)
-  responseFrom.body?.pipe(responseTo)
-}
-
-const KNOWN_HEADERS: string[] = [
-  'Content-Type',
-  'Access-Control-Allow-Origin',
-  'Access-Control-Expose-Headers',
-  'ETag',
-  'Date',
-  'Content-Length',
-  'Cache-Control'
-]
-function fixHeaderNameCase(headerName: string): string | undefined {
-  return KNOWN_HEADERS.find((item) => item.toLowerCase() === headerName.toLowerCase())
-}
-
-function copyHeaders(responseFrom: NodeFetchResponse, responseTo: Response) {
-  responseFrom.headers.forEach((headerValue, headerName) => {
-    const fixedHeader = fixHeaderNameCase(headerName)
-    if (fixedHeader) {
-      responseTo.setHeader(fixedHeader, headerValue)
-    }
-  })
-}
 function findSceneJsonId(entity: V3ControllerEntity): string {
   let sceneJsonHash = ''
   try {

--- a/lambdas/src/apis/content-v2/routes.ts
+++ b/lambdas/src/apis/content-v2/routes.ts
@@ -1,11 +1,9 @@
 import { Request, Response, Router } from 'express'
 import { SmartContentServerFetcher } from '../../utils/SmartContentServerFetcher'
-import { getContents, getInfo, getScenes } from './controllers/translator'
+import { getInfo } from './controllers/translator'
 
 export function initializeContentV2Routes(router: Router, fetcher: SmartContentServerFetcher): Router {
-  router.get('/scenes', createHandler(fetcher, getScenes))
   router.get('/parcel_info', createHandler(fetcher, getInfo))
-  router.get('/contents/:cid', createHandler(fetcher, getContents))
   return router
 }
 


### PR DESCRIPTION
## Description

Deprecated endpoints
--
[First poll](https://governance.decentraland.org/proposal/?id=24f524f0-eb50-11ed-ac2d-876c6fc9416f)
```
GET /lambdas/health used by:
https://molecule.muaverse.build/
https://molecule-dev.muaverse.build/
https://labs.muadao.build/
catalyst-client/v3 (+https://github.com/decentraland/catalyst-client) [según vi, no es unity, porque no están llamando a fetchPeerHealth en ningún lado]
https://preview-1.xraremeta.com/

GET /lambdas/profiles used by:
https://wearable-preview.decentraland.org/
https://decentral.games/
https://play.decentraland.org/
```

[Second poll](https://governance.decentraland.org/proposal/?id=709968b0-ef44-11ed-813c-b353c3943eab)
```
GET /lambdas/contentv2/contents/:cid used by:
Usages not found

GET /lambdas/contentv2/scenes used by:
Usages not found

GET /lambdas/contentv2/parcel_info used by:
UnityPlayer/2020.3.0f1
```

[Third poll](https://governance.decentraland.org/proposal/?id=cd182780-f41b-11ed-9bc2-e5fe350d0c93)
```
GET /lambdas/collections/wearables-by-owner/:address used by:
Unity
```
