### PR TITLE
chore: use sepolia as default L1 testnet

### DIFF
--- a/content/README.md
+++ b/content/README.md
@@ -39,13 +39,13 @@ There are many ways to configure the content server. You can provide these confi
 
 These are some of the more important configuration values:
 
-| Name                    | Description                                                                                         |  Default  |
-| ----------------------- |-----------------------------------------------------------------------------------------------------| :-------: |
-| ETH_NETWORK             | Which Ethereum network you want to use. Usually is `goerli` for testing or `mainnet` for production | 'goerli'  |
-| STORAGE_ROOT_FOLDER.    | Folder where all content will be stored                                                             | 'storage' |
-| SERVER_PORT             | Port to be used by the service                                                                      |   6969    |
-| LOG_LEVEL               | Minimum log level                                                                                   |  'info'   |
-| DISABLE_SYNCHRONIZATION | Disables synchronization with other content servers                                                 |   false   |
+| Name                    | Description                                                                                        |  Default  |
+|-------------------------|----------------------------------------------------------------------------------------------------|:---------:|
+| ETH_NETWORK             | Which Ethereum network you want to use. Usually `sepolia` for testing or `mainnet` for production. | `sepolia` |
+| STORAGE_ROOT_FOLDER.    | Folder where all content will be stored                                                            | `storage` |
+| SERVER_PORT             | Port to be used by the service                                                                     |  `6969`   |
+| LOG_LEVEL               | Minimum log level                                                                                  |  `info`   |
+| DISABLE_SYNCHRONIZATION | Disables synchronization with other content servers                                                |  `false`  |
 
 ## Run unit tests
 

--- a/content/src/Environment.ts
+++ b/content/src/Environment.ts
@@ -13,15 +13,16 @@ const DECENTRALAND_ADDRESS: EthAddress = '0x1337e0507eb4ab47e08a179573ed4533d9e2
 
 const DEFAULT_FOLDER_MIGRATION_MAX_CONCURRENCY = 1000
 export const DEFAULT_ENTITIES_CACHE_SIZE = 150000
-export const DEFAULT_ETH_NETWORK = 'goerli'
+export const DEFAULT_ETH_NETWORK = 'sepolia'
+
 export const DEFAULT_ENS_OWNER_PROVIDER_URL_TESTNET =
-  'https://api.thegraph.com/subgraphs/name/decentraland/marketplace-goerli'
+  'https://api.studio.thegraph.com/query/49472/marketplace-sepolia/version/latest'
 const DEFAULT_ENS_OWNER_PROVIDER_URL_MAINNET = 'https://api.thegraph.com/subgraphs/name/decentraland/marketplace'
 export const DEFAULT_LAND_MANAGER_SUBGRAPH_TESTNET =
-  'https://api.thegraph.com/subgraphs/name/decentraland/land-manager-goerli'
+  'https://api.studio.thegraph.com/query/49472/land-manager-sepolia/version/latest'
 export const DEFAULT_LAND_MANAGER_SUBGRAPH_MAINNET = 'https://api.thegraph.com/subgraphs/name/decentraland/land-manager'
 export const DEFAULT_COLLECTIONS_SUBGRAPH_TESTNET =
-  'https://api.thegraph.com/subgraphs/name/decentraland/collections-ethereum-goerli'
+  'https://api.studio.thegraph.com/query/49472/collections-ethereum-sepolia/version/latest'
 export const DEFAULT_COLLECTIONS_SUBGRAPH_MAINNET =
   'https://api.thegraph.com/subgraphs/name/decentraland/collections-ethereum-mainnet'
 export const DEFAULT_COLLECTIONS_SUBGRAPH_MATIC_MUMBAI =
@@ -33,7 +34,7 @@ export const DEFAULT_THIRD_PARTY_REGISTRY_SUBGRAPH_MATIC_MUMBAI =
 export const DEFAULT_THIRD_PARTY_REGISTRY_SUBGRAPH_MATIC_MAINNET =
   'https://api.thegraph.com/subgraphs/name/decentraland/tpr-matic-mainnet'
 export const DEFAULT_BLOCKS_SUBGRAPH_TESTNET =
-  'https://api.thegraph.com/subgraphs/name/decentraland/blocks-ethereum-goerli'
+  'https://api.studio.thegraph.com/query/49472/blocks-ethereum-sepolia/version/latest'
 export const DEFAULT_BLOCKS_SUBGRAPH_MAINNET =
   'https://api.thegraph.com/subgraphs/name/decentraland/blocks-ethereum-mainnet'
 export const DEFAULT_BLOCKS_SUBGRAPH_MATIC_MUMBAI =

--- a/content/src/logic/checker.ts
+++ b/content/src/logic/checker.ts
@@ -4,7 +4,7 @@ import { RequestManager, HTTPProvider, ContractFactory, toData } from 'eth-conne
 import { l1Contracts, l2Contracts, checkerAbi } from '@dcl/catalyst-contracts'
 import { code } from '@dcl/catalyst-contracts/dist/checkerByteCode'
 
-export async function createL1Checker(provider: HTTPProvider, network: 'mainnet' | 'goerli'): Promise<L1Checker> {
+export async function createL1Checker(provider: HTTPProvider, network: 'mainnet' | 'sepolia'): Promise<L1Checker> {
   const contracts = l1Contracts[network]
 
   const requestManager = new RequestManager(provider)

--- a/content/src/service/validations/validator.ts
+++ b/content/src/service/validations/validator.ts
@@ -80,7 +80,7 @@ export async function createOnChainValidator(
   l2Provider: HTTPProvider
 ): Promise<ValidateFn> {
   const { env, metrics, logs, fetcher, config, externalCalls } = components
-  const l1Network: 'mainnet' | 'goerli' = env.getConfig(EnvironmentConfig.ETH_NETWORK)
+  const l1Network: 'mainnet' | 'sepolia' = env.getConfig(EnvironmentConfig.ETH_NETWORK)
   const l2Network = l1Network === 'mainnet' ? 'polygon' : 'mumbai'
 
   const l1Checker = await createL1Checker(l1Provider, l1Network)
@@ -198,7 +198,7 @@ export async function createSubgraphValidator(
     }
   }
 
-  const network: 'mainnet' | 'goerli' = components.env.getConfig(EnvironmentConfig.ETH_NETWORK)
+  const network: 'mainnet' | 'sepolia' = components.env.getConfig(EnvironmentConfig.ETH_NETWORK)
   const contracts = l1Contracts[network]
   const tokenAddresses: TokenAddresses = {
     land: contracts.land,

--- a/lambdas/src/Environment.ts
+++ b/lambdas/src/Environment.ts
@@ -13,12 +13,12 @@ import { SmartContentServerFetcherFactory } from './utils/SmartContentServerFetc
 import { getCommsServerUrl } from './utils/commons'
 
 const DEFAULT_SERVER_PORT = 7070
-export const DEFAULT_ETH_NETWORK = 'goerli'
+export const DEFAULT_ETH_NETWORK = 'sepolia'
 export const DEFAULT_ENS_OWNER_PROVIDER_URL_TESTNET =
-  'https://api.thegraph.com/subgraphs/name/decentraland/marketplace-goerli'
+  'https://api.studio.thegraph.com/query/49472/marketplace-sepolia/version/latest'
 const DEFAULT_ENS_OWNER_PROVIDER_URL_MAINNET = 'https://api.thegraph.com/subgraphs/name/decentraland/marketplace'
 export const DEFAULT_COLLECTIONS_SUBGRAPH_TESTNET =
-  'https://api.thegraph.com/subgraphs/name/decentraland/collections-ethereum-goerli'
+  'https://api.studio.thegraph.com/query/49472/collections-ethereum-sepolia/version/latest'
 export const DEFAULT_COLLECTIONS_SUBGRAPH_MAINNET =
   'https://api.thegraph.com/subgraphs/name/decentraland/collections-ethereum-mainnet'
 export const DEFAULT_COLLECTIONS_SUBGRAPH_MATIC_MUMBAI =

--- a/lambdas/src/apis/collections/controllers/collections.ts
+++ b/lambdas/src/apis/collections/controllers/collections.ts
@@ -136,6 +136,8 @@ function getProtocol(chainId: string): string | undefined {
   switch (parseInt(chainId, 10)) {
     case ChainId.ETHEREUM_MAINNET:
       return 'ethereum'
+    case ChainId.ETHEREUM_SEPOLIA:
+      return 'sepolia'
     case ChainId.ETHEREUM_RINKEBY:
       return 'rinkeby'
     case ChainId.ETHEREUM_GOERLI:

--- a/lambdas/src/ports/the-graph-client.ts
+++ b/lambdas/src/ports/the-graph-client.ts
@@ -364,7 +364,7 @@ export async function createTheGraphClient(components: {
     pagination: { limit: number; lastId: string | undefined }
   ): Promise<WearableId[]> {
     // Order will be L1 > L2
-    const L1_NETWORKS = ['mainnet', 'ropsten', 'kovan', 'rinkeby', 'goerli']
+    const L1_NETWORKS = ['mainnet', 'sepolia', 'ropsten', 'kovan', 'rinkeby', 'goerli']
     const L2_NETWORKS = ['matic', 'mumbai']
     const wearableTypes: BlockchainItemType[] = ['wearable_v1', 'wearable_v2', 'smart_wearable_v1', 'emote_v1']
 
@@ -405,7 +405,7 @@ export async function createTheGraphClient(components: {
     pagination: { limit: number; lastId: string | undefined }
   ): Promise<EmoteId[]> {
     // Order will be L1 > L2
-    const L1_NETWORKS = ['mainnet', 'kovan', 'rinkeby', 'goerli']
+    const L1_NETWORKS = ['mainnet', 'sepolia', 'kovan', 'rinkeby', 'goerli']
     const L2_NETWORKS = ['matic', 'mumbai']
 
     let limit = pagination.limit


### PR DESCRIPTION
## Description

Goerli has been deprecated some time ago. Sepolia should be the new default L1 testnet. This PR updates the defaults so that all subgraphs point to the Sepolia network.

In case you still need to use Goerli, the subgraphs URLs can be passed in as environment variables.

