### PR TITLE
fix: opt-in of Content-Type header on /contents endpoint

### DIFF
--- a/content/src/controller/handlers/get-content-handler.ts
+++ b/content/src/controller/handlers/get-content-handler.ts
@@ -4,7 +4,7 @@ import { createContentFileHeaders } from '../utils'
 
 // Method: GET or HEAD
 export async function getContentHandler(context: HandlerContextWithPath<'storage', '/contents/:hashId'>) {
-  const shouldCalculateContentType = context.request.headers.get('Accept') === 'Any'
+  const shouldCalculateContentType = context.url.searchParams.has('includeMimeType')
   const hash = context.params.hashId
 
   const content: ContentItem | undefined = await context.components.storage.retrieve(hash)


### PR DESCRIPTION
This PR changes the `GET /content/contents` endpoint to check a query-string param instead of a Header to decide whether it should calculate a content-type or return the default one used by the sync.

This is a fix since CDNs caches requests based on URL path and does not acknowledge headers while doing so.