### PR TITLE
fix: prevent unauthorized deployments from kernel scenes

### DIFF
--- a/content/package.json
+++ b/content/package.json
@@ -27,6 +27,7 @@
     "@dcl/content-validator": "^6.0.2",
     "@dcl/crypto": "^3.4.5",
     "@dcl/hashing": "^3.0.4",
+    "@dcl/platform-crypto-middleware": "^1.1.0",
     "@dcl/schemas": "^15.1.2",
     "@dcl/snapshots-fetcher": "^9.1.0",
     "@dcl/urn-resolver": "^3.6.0",

--- a/content/src/controller/handlers/create-entity-handler.ts
+++ b/content/src/controller/handlers/create-entity-handler.ts
@@ -3,6 +3,8 @@ import { Field } from '@well-known-components/multipart-wrapper'
 import { AuthChain, Authenticator, AuthLink, EthAddress, Signature } from '@dcl/crypto'
 import { DeploymentContext, isInvalidDeployment, isSuccessfulDeployment } from '../../deployment-types'
 import { FormHandlerContextWithPath, InvalidRequestError } from '../../types'
+import { verifyMetadata } from '@dcl/platform-crypto-middleware/dist/verify'
+import { AUTH_METADATA_HEADER } from '@dcl/platform-crypto-middleware'
 
 type ContentFile = {
   path?: string
@@ -32,6 +34,11 @@ export async function createEntity(
     authChain = Authenticator.createSimpleAuthChain(entityId, ethAddress, signature)
   } else {
     throw new InvalidRequestError('No auth chain can be derivated')
+  }
+
+  const authChainMetadata = verifyMetadata(context.request.headers[AUTH_METADATA_HEADER])
+  if (authChainMetadata?.signer === 'decentraland-kernel-scene') {
+    throw new InvalidRequestError('Kernel scene is not allowed to deploy entities')
   }
 
   const deployFiles: ContentFile[] = []

--- a/yarn.lock
+++ b/yarn.lock
@@ -367,7 +367,7 @@
     p-queue "^6.6.2"
     sharp "0.32.6"
 
-"@dcl/crypto@^3.4.0", "@dcl/crypto@^3.4.5":
+"@dcl/crypto@^3.4.0", "@dcl/crypto@^3.4.3", "@dcl/crypto@^3.4.5":
   version "3.4.5"
   resolved "https://registry.npmjs.org/@dcl/crypto/-/crypto-3.4.5.tgz"
   integrity sha512-uneyjOAOx7pi5kabZsLmPm9kSLkCk4Cok8FUsvT+6k8RquqkjKqocvkGVOMaoWsfU6S3mkLOyaeqEKmOy4ErxA==
@@ -380,6 +380,15 @@
   version "3.0.4"
   resolved "https://registry.npmjs.org/@dcl/hashing/-/hashing-3.0.4.tgz"
   integrity sha512-Cg+MoIOn+BYmQV2q8zSFnNYY+GldlnUazwBnfgrq3i66ZxOaZ65h01btd8OUtSAlfWG4VTNIOHDjtKqmuwJNBg==
+
+"@dcl/platform-crypto-middleware@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@dcl/platform-crypto-middleware/-/platform-crypto-middleware-1.1.0.tgz#11434eb4fc8d461799ab71d28ce869ab330bdb23"
+  integrity sha512-E2AAIRcbeF+DLQ6urmOkoqwSOGaBlX498nygyOc3EnChEPjJhM0LiTQ9rwAG572DdMGf8ZGbNg+odx6i9M3cMA==
+  dependencies:
+    "@dcl/crypto" "^3.4.3"
+    "@well-known-components/fetch-component" "^2.0.2"
+    "@well-known-components/interfaces" "^1.4.2"
 
 "@dcl/schemas@^11.5.0":
   version "11.12.0"


### PR DESCRIPTION
## Description

This PR updates the deployment flow to validate that the deployment is not coming from a scene (`authChainMetadata?.signer === 'decentraland-kernel-scene'`)

Fixes https://github.com/decentraland/core-team/issues/88

## Changes

Deployment endpoint now validates the auth chain metadata to check if the call is coming from a Kernel Scene.
