### PR TITLE
chore: bump @dcl/schemas to ^26.2.0

### DIFF
--- a/content/package.json
+++ b/content/package.json
@@ -30,7 +30,7 @@
     "@dcl/http-server": "^1.0.1",
     "@dcl/job-component": "^0.2.7",
     "@dcl/metrics": "^1.0.1",
-    "@dcl/schemas": "^26.1.0",
+    "@dcl/schemas": "^26.2.0",
     "@dcl/snapshots-fetcher": "9.2.3",
     "@dcl/traced-fetch-component": "^1.0.2",
     "@dcl/urn-resolver": "^3.6.1",

--- a/lambdas/package.json
+++ b/lambdas/package.json
@@ -14,7 +14,7 @@
     "@dcl/catalyst-api-specs": "^3.8.0",
     "@dcl/content-validator": "^7.3.1",
     "@dcl/crypto": "^3.4.5",
-    "@dcl/schemas": "^26.1.0",
+    "@dcl/schemas": "^26.2.0",
     "@dcl/urn-resolver": "^3.6.1",
     "@well-known-components/env-config-provider": "^1.2.0",
     "@well-known-components/fetch-component": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -422,16 +422,6 @@
     ajv-keywords "^5.1.0"
     mitt "^3.0.1"
 
-"@dcl/schemas@^26.1.0":
-  version "26.1.0"
-  resolved "https://registry.yarnpkg.com/@dcl/schemas/-/schemas-26.1.0.tgz#07a08df2e40450f4540fd4c5e7fb5de46348d5b2"
-  integrity sha512-BrtZm/BNEpDde1U5yCfbRsp8IMajYiThNj5QCgilXCcqO2JYB6RL5FZj+9KRZPyW+/zzeYgLVDAnn/eiSW6dmA==
-  dependencies:
-    ajv "^8.11.0"
-    ajv-errors "^3.0.0"
-    ajv-keywords "^5.1.0"
-    mitt "^3.0.1"
-
 "@dcl/schemas@^26.2.0":
   version "26.2.0"
   resolved "https://registry.yarnpkg.com/@dcl/schemas/-/schemas-26.2.0.tgz#7207d1e99953d8019123e59cc79fbe653685e1fd"


### PR DESCRIPTION
## summary

bumps `@dcl/schemas` from `^26.1.0` to `^26.2.0` in both `content` and `lambdas` workspaces.

## test plan

- [x] yarn install resolves to a single 26.2.0 entry in yarn.lock
- [x] yarn build (tsc -b on both workspaces) passes
- [ ] ci green