### PR TITLE
fix: use asset-bundle-registry /denylist endpoint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,5 @@
 {
+  "root": true,
   "parserOptions": {
     "ecmaVersion": 2020, // Allows for the parsing of modern ECMAScript features
     "sourceType": "module", // Allows for the use of imports

--- a/content/src/Environment.ts
+++ b/content/src/Environment.ts
@@ -8,7 +8,7 @@ const DEFAULT_STORAGE_ROOT_FOLDER = 'storage'
 const DEFAULT_HTTP_SERVER_PORT = 6969
 const DEFAULT_HTTP_SERVER_HOST = '0.0.0.0'
 const DEFAULT_DENYLIST_FILE_NAME = 'denylist.txt'
-const DEFAULT_DENYLIST_URLS = 'https://config.decentraland.org/denylist'
+const DEFAULT_DENYLIST_URLS = 'https://asset-bundle-registry.decentraland.org/denylist'
 const DECENTRALAND_ADDRESS: EthAddress = '0x1337e0507eb4ab47e08a179573ed4533d9e22a7b'
 
 const DEFAULT_FOLDER_MIGRATION_MAX_CONCURRENCY = 1000

--- a/content/src/adapters/denylist/component.ts
+++ b/content/src/adapters/denylist/component.ts
@@ -61,11 +61,7 @@ export async function createDenylist(
         try {
           const response = await components.fetcher.fetch(url.toString())
           const entries: { entity_id: string }[] = await response.json()
-          for (const entry of entries) {
-            if (entry.entity_id) {
-              deniedContentIdentifiers.add(entry.entity_id)
-            }
-          }
+          await processLines(entries.map((entry) => entry.entity_id).filter(Boolean))
         } catch (err: any) {
           logger.error(err)
         }

--- a/content/src/adapters/denylist/component.ts
+++ b/content/src/adapters/denylist/component.ts
@@ -60,9 +60,12 @@ export async function createDenylist(
       for (const url of denylistsUrls) {
         try {
           const response = await components.fetcher.fetch(url.toString())
-          const content = await response.text()
-          const lines = content ? content.split(/[\r\n]+/) : []
-          await processLines(lines)
+          const entries: { entity_id: string }[] = await response.json()
+          for (const entry of entries) {
+            if (entry.entity_id) {
+              deniedContentIdentifiers.add(entry.entity_id)
+            }
+          }
         } catch (err: any) {
           logger.error(err)
         }

--- a/content/src/adapters/denylist/component.ts
+++ b/content/src/adapters/denylist/component.ts
@@ -60,8 +60,12 @@ export async function createDenylist(
       for (const url of denylistsUrls) {
         try {
           const response = await components.fetcher.fetch(url.toString())
-          const entries: { entity_id: string }[] = await response.json()
-          await processLines(entries.map((entry) => entry.entity_id).filter(Boolean))
+          const body = await response.json()
+          if (!Array.isArray(body)) {
+            logger.error(`Unexpected denylist response from ${url}: expected array, got ${typeof body}`)
+            continue
+          }
+          await processLines((body as { entity_id: string }[]).map((entry) => entry.entity_id).filter(Boolean))
         } catch (err: any) {
           logger.error(err)
         }

--- a/content/test/unit/ports/denylist.spec.ts
+++ b/content/test/unit/ports/denylist.spec.ts
@@ -83,6 +83,23 @@ describe('when creating a denylist', () => {
       expect(fetcher.fetch).toBeCalledWith('https://asset-bundle-registry.decentraland.org/denylist')
     })
 
+    it('should not add any items when the url returns a non-array response', async () => {
+      const logs = await setupLogs()
+      const fs = {
+        createReadStream: jest.fn(),
+        existPath: jest.fn().mockResolvedValue(false)
+      }
+      env.setConfig(EnvironmentConfig.DENYLIST_URLS, 'https://asset-bundle-registry.decentraland.org/denylist')
+      const fetcher = {
+        fetch: jest.fn().mockResolvedValue({
+          json: () => Promise.resolve({ entity_id: 'denied3' })
+        } as Partial<Response>)
+      }
+      denylist = await createDenylist({ env, logs, fs, fetcher })
+      await denylist.start!()
+      expect(denylist.isDenylisted('denied3')).toBe(false)
+    })
+
     it('should create it without using the invalid url', async () => {
       const logs = await setupLogs()
       const fs = {

--- a/content/test/unit/ports/denylist.spec.ts
+++ b/content/test/unit/ports/denylist.spec.ts
@@ -70,15 +70,17 @@ describe('when creating a denylist', () => {
         createReadStream: jest.fn().mockReturnValue(Readable.from(`denied1\n denied2`)),
         existPath: jest.fn().mockResolvedValue(false)
       }
-      env.setConfig(EnvironmentConfig.DENYLIST_URLS, 'https://config.decentraland.org/denylist')
+      env.setConfig(EnvironmentConfig.DENYLIST_URLS, 'https://asset-bundle-registry.decentraland.org/denylist')
       const fetcher = {
-        fetch: jest.fn().mockResolvedValue({ text: () => Promise.resolve(`denied3\ndenied4`) } as Partial<Response>)
+        fetch: jest.fn().mockResolvedValue({
+          json: () => Promise.resolve([{ entity_id: 'denied3' }, { entity_id: 'denied4' }])
+        } as Partial<Response>)
       }
       const denylist = await createDenylist({ env, logs, fs, fetcher })
       await denylist.start!()
       expect(['denied3', 'denied4'].every((line) => denylist.isDenylisted(line))).toBe(true)
       expect(['denied1', 'denied2'].every((line) => denylist.isDenylisted(line))).toBe(false)
-      expect(fetcher.fetch).toBeCalledWith('https://config.decentraland.org/denylist')
+      expect(fetcher.fetch).toBeCalledWith('https://asset-bundle-registry.decentraland.org/denylist')
     })
 
     it('should create it without using the invalid url', async () => {
@@ -87,13 +89,15 @@ describe('when creating a denylist', () => {
         createReadStream: jest.fn(),
         existPath: jest.fn().mockResolvedValue(false)
       }
-      env.setConfig(EnvironmentConfig.DENYLIST_URLS, 'https://config.decentraland.org/denylist invalidUrl')
+      env.setConfig(EnvironmentConfig.DENYLIST_URLS, 'https://asset-bundle-registry.decentraland.org/denylist invalidUrl')
       const fetcher = {
-        fetch: jest.fn().mockResolvedValue({ text: () => Promise.resolve(`denied3\ndenied4`) } as Partial<Response>)
+        fetch: jest.fn().mockResolvedValue({
+          json: () => Promise.resolve([{ entity_id: 'denied3' }, { entity_id: 'denied4' }])
+        } as Partial<Response>)
       }
       denylist = await createDenylist({ env, logs, fs, fetcher })
       await denylist.start!()
-      expect(fetcher.fetch).toBeCalledWith('https://config.decentraland.org/denylist')
+      expect(fetcher.fetch).toBeCalledWith('https://asset-bundle-registry.decentraland.org/denylist')
       expect(fetcher.fetch).not.toBeCalledWith('invalidUrl')
     })
   })
@@ -104,15 +108,17 @@ describe('when creating a denylist', () => {
         createReadStream: jest.fn().mockReturnValue(Readable.from(`denied1\n denied2`)),
         existPath: jest.fn().mockResolvedValue(true)
       }
-      env.setConfig(EnvironmentConfig.DENYLIST_URLS, 'https://config.decentraland.org/denylist')
+      env.setConfig(EnvironmentConfig.DENYLIST_URLS, 'https://asset-bundle-registry.decentraland.org/denylist')
       const fetcher = {
-        fetch: jest.fn().mockResolvedValue({ text: () => Promise.resolve(`denied3\ndenied4`) } as Partial<Response>)
+        fetch: jest.fn().mockResolvedValue({
+          json: () => Promise.resolve([{ entity_id: 'denied3' }, { entity_id: 'denied4' }])
+        } as Partial<Response>)
       }
       denylist = await createDenylist({ env, logs, fs, fetcher })
       await denylist.start!()
 
       expect(['denied1', 'denied2', 'denied3', 'denied4'].every((line) => denylist!.isDenylisted(line))).toBe(true)
-      expect(fetcher.fetch).toBeCalledWith('https://config.decentraland.org/denylist')
+      expect(fetcher.fetch).toBeCalledWith('https://asset-bundle-registry.decentraland.org/denylist')
     })
 
     it('should create it with no denied content other than the specified in the denylists', async () => {
@@ -121,14 +127,16 @@ describe('when creating a denylist', () => {
         createReadStream: jest.fn().mockReturnValue(Readable.from(`denied1\n denied2`)),
         existPath: jest.fn().mockResolvedValue(true)
       }
-      env.setConfig(EnvironmentConfig.DENYLIST_URLS, 'https://config.decentraland.org/denylist')
+      env.setConfig(EnvironmentConfig.DENYLIST_URLS, 'https://asset-bundle-registry.decentraland.org/denylist')
       const fetcher = {
-        fetch: jest.fn().mockResolvedValue({ text: () => Promise.resolve(`denied3\ndenied4`) } as Partial<Response>)
+        fetch: jest.fn().mockResolvedValue({
+          json: () => Promise.resolve([{ entity_id: 'denied3' }, { entity_id: 'denied4' }])
+        } as Partial<Response>)
       }
       denylist = await createDenylist({ env, logs, fs, fetcher })
       await denylist.start!()
       expect(['otherDenied1', 'otherDenied2'].every((line) => denylist!.isDenylisted(line))).toBe(false)
-      expect(fetcher.fetch).toBeCalledWith('https://config.decentraland.org/denylist')
+      expect(fetcher.fetch).toBeCalledWith('https://asset-bundle-registry.decentraland.org/denylist')
     })
   })
 


### PR DESCRIPTION
## Summary

- Replaces the legacy `config.decentraland.org/denylist` plain-text endpoint with the new public `GET /denylist` endpoint on `asset-bundle-registry.decentraland.org` (see [asset-bundle-registry#114](https://github.com/decentraland/asset-bundle-registry/pull/114))
- Updates the fetch logic to parse the JSON response (`[{ entity_id, ... }]`) and extract `entity_id` from each entry
- Updates unit tests to mock the new JSON response format
- Adds `"root": true` to `.eslintrc.json` to prevent ESLint from traversing up past the repo root

## Test plan

- [ ] Run `npx jest test/unit/ports/denylist.spec.ts` — all 8 tests pass
- [ ] Deploy to a staging environment and verify the denylist is loaded correctly from asset-bundle-registry