### PR TITLE
fix: preserve original error info on unexpected deploy failures

### DIFF
--- a/content/src/logic/deployment-service/component.ts
+++ b/content/src/logic/deployment-service/component.ts
@@ -413,10 +413,12 @@ export function createDeploymentService(
 
         // TODO: review this
         return storeResult.auditInfoComplete.localTimestamp || Date.now()
-      } catch (error) {
+      } catch (error: any) {
         logger.error(`There was an error deploying the entity: ${error}`, { entityId })
+        const name = error?.name ?? 'Error'
+        const message = error?.message ?? 'unknown error'
         return InvalidResult({
-          errors: [`There was an error deploying the entity`]
+          errors: [`There was an error deploying the entity: ${name}: ${message}`]
         })
       } finally {
         components.pointerLockManager.release(entity.type, entity.pointers)


### PR DESCRIPTION
## Why

When a deployment hits the last-resort `catch` in `deployEntity` (`content/src/logic/deployment-service/component.ts`), the original exception was discarded and replaced with a constant string `"There was an error deploying the entity"` before returning an `InvalidResult`. That string is the only thing that propagates through `deployDownloadedEntity` (which wraps it as `Errors deploying entity(<id>):\n - <message>` and throws) into `batch-deployer`, where it gets persisted as `failed_deployments.error_description` via `err.toString()`.

The result: every unexpected deploy failure looked identical in `failed_deployments` and in the snapshot output, regardless of whether the cause was a database error, a storage write failure, or an unhandled throw out of `pointerManager` / `activeEntities`. The full error was logged to the server log on line 417, but once that log rotates the failure record is the only thing left — and it carries no diagnostic value. Investigations of old failures were effectively unrecoverable.

This catch only fires for genuinely unexpected throws. Known validator failures still flow through `validateDeployment`'s `{ok: false, errors}` return path (handled at line 360), so user-facing validation messages (`"does not have access to parcel ..."`, schema errors, etc.) are unaffected.

## How

Append `${error.name}: ${error.message}` to the persisted message:

```ts
} catch (error: any) {
  logger.error(`There was an error deploying the entity: ${error}`, { entityId })
  const name = error?.name ?? 'Error'
  const message = error?.message ?? 'unknown error'
  return InvalidResult({
    errors: [`There was an error deploying the entity: ${name}: ${message}`]
  })
}
```

- The full `${error}` interpolation in the server log is unchanged.
- Optional chaining + fallbacks handle the case where something non-Error was thrown (string, undefined, plain object).
- No tests assert on the old exact string (verified with `grep -rln "There was an error deploying the entity" src test`).

## Trade-off worth flagging in review

The new message surfaces `error.message` to `failed_deployments.error_description`, which is exposed via the failed-deployments endpoint and propagates to other catalysts in snapshots. The throwers reachable from this catch (`storeEntityContent`, the `tx_deploy_entity` transaction body, `pointerManager.referenceEntityFromPointers`, `activeEntities` updates) don't currently embed sensitive details (connection strings, internal hostnames, file paths) in their messages, so this is fine today — but if a future thrower does, that detail would leak. If the team prefers a conservative posture, an easy follow-up is to persist only `error.name` (or a category derived from it) and keep the full message log-only.

## Test plan

- [ ] Trigger a synthetic throw inside the wrapped block (e.g. force `storeEntityContent` to reject) and confirm `failed_deployments.error_description` contains the error name and message.
- [ ] Confirm a normal validator-rejected deployment still surfaces the validator's specific errors (this path is untouched but worth a sanity check).
- [ ] CI build / lint passes.