### PR TITLE
feat(content): observe content body size and emit a metric on mismatch

### DIFF
--- a/content/src/controllers/handlers/get-content-handler.ts
+++ b/content/src/controllers/handlers/get-content-handler.ts
@@ -1,9 +1,11 @@
 import { HandlerContextWithPath } from '../../types'
 import { NotFoundError } from '../errors'
-import { checkNotModified, createContentFileHeaders, retrieveContentWithRange } from '../utils'
+import { checkNotModified, createContentFileHeaders, observeContentBodySize, retrieveContentWithRange } from '../utils'
 
 // Method: GET or HEAD
-export async function getContentHandler(context: HandlerContextWithPath<'storage', '/contents/:hashId'>) {
+export async function getContentHandler(
+  context: HandlerContextWithPath<'storage' | 'metrics' | 'logs', '/contents/:hashId'>
+) {
   const shouldCalculateContentType = context.url.searchParams.has('includeMimeType')
   const hash = context.params.hashId
 
@@ -34,12 +36,17 @@ export async function getContentHandler(context: HandlerContextWithPath<'storage
     ? calculatedHeaders
     : { ...calculatedHeaders, 'Content-Type': 'application/octet-stream' }
 
+  const body =
+    context.request.method.toUpperCase() === 'GET'
+      ? observeContentBodySize(await content.asRawStream(), content.size, hash, context.components)
+      : undefined
+
   return {
     status,
     headers: {
       ...headers,
       ...result.rangeHeaders
     },
-    body: context.request.method.toUpperCase() === 'GET' ? await content.asRawStream() : undefined
+    body
   }
 }

--- a/content/src/controllers/handlers/get-entity-image-handler.ts
+++ b/content/src/controllers/handlers/get-entity-image-handler.ts
@@ -1,11 +1,14 @@
 import { HandlerContextWithPath } from '../../types'
 import { NotFoundError } from '../errors'
 import { findEntityByPointer, findImageHash } from '../../logic/entities'
-import { checkNotModified, createContentFileHeaders, retrieveContentWithRange } from '../utils'
+import { checkNotModified, createContentFileHeaders, observeContentBodySize, retrieveContentWithRange } from '../utils'
 
 // Method: GET or HEAD
 export async function getEntityImageHandler(
-  context: HandlerContextWithPath<'activeEntities' | 'database' | 'storage', '/entities/active/entity/:pointer/image'>
+  context: HandlerContextWithPath<
+    'activeEntities' | 'database' | 'storage' | 'metrics' | 'logs',
+    '/entities/active/entity/:pointer/image'
+  >
 ) {
   const { activeEntities, database } = context.components
   const pointer: string = context.params.pointer
@@ -38,12 +41,17 @@ export async function getEntityImageHandler(
   const { content, status } = result
   const headers = await createContentFileHeaders(content, hash)
 
+  const body =
+    context.request.method.toUpperCase() === 'GET'
+      ? observeContentBodySize(await content.asRawStream(), content.size, hash, context.components)
+      : undefined
+
   return {
     status,
     headers: {
       ...headers,
       ...result.rangeHeaders
     },
-    body: context.request.method.toUpperCase() === 'GET' ? await content.asRawStream() : undefined
+    body
   }
 }

--- a/content/src/controllers/handlers/get-entity-thumbnail-handler.ts
+++ b/content/src/controllers/handlers/get-entity-thumbnail-handler.ts
@@ -1,12 +1,12 @@
 import { HandlerContextWithPath } from '../../types'
 import { NotFoundError } from '../errors'
 import { findEntityByPointer, findThumbnailHash } from '../../logic/entities'
-import { checkNotModified, createContentFileHeaders, retrieveContentWithRange } from '../utils'
+import { checkNotModified, createContentFileHeaders, observeContentBodySize, retrieveContentWithRange } from '../utils'
 
 // Method: GET or HEAD
 export async function getEntityThumbnailHandler(
   context: HandlerContextWithPath<
-    'database' | 'activeEntities' | 'storage',
+    'database' | 'activeEntities' | 'storage' | 'metrics' | 'logs',
     '/entities/active/entity/:pointer/thumbnail'
   >
 ) {
@@ -41,12 +41,17 @@ export async function getEntityThumbnailHandler(
   const { content, status } = result
   const headers = await createContentFileHeaders(content, hash)
 
+  const body =
+    context.request.method.toUpperCase() === 'GET'
+      ? observeContentBodySize(await content.asRawStream(), content.size, hash, context.components)
+      : undefined
+
   return {
     status,
     headers: {
       ...headers,
       ...result.rangeHeaders
     },
-    body: context.request.method.toUpperCase() === 'GET' ? await content.asRawStream() : undefined
+    body
   }
 }

--- a/content/src/controllers/utils.ts
+++ b/content/src/controllers/utils.ts
@@ -1,8 +1,10 @@
 import { ContentItem, FileInfo, IContentStorageComponent } from '@dcl/catalyst-storage'
+import { ILoggerComponent, IMetricsComponent } from '@well-known-components/interfaces'
+import { metricsDeclaration } from '../metrics'
 import { Pagination } from '../types'
 import { InvalidRequestError } from './errors'
 import { FileTypeParser } from 'file-type'
-import { Readable } from 'stream'
+import { Readable, Transform } from 'stream'
 
 export function paginationObject(url: URL, maxPageSize: number = 1000): Pagination {
   const pageSize = url.searchParams.has('pageSize') ? parseInt(url.searchParams.get('pageSize')!, 10) : 100
@@ -130,7 +132,13 @@ export async function createContentFileHeaders(content: ContentItem, hash: strin
     if (content.encoding) {
       headers['Content-Encoding'] = content.encoding
     }
-    if (content.size) {
+    // Use null-check rather than truthiness so a legitimate 0-byte file emits
+    // `Content-Length: 0` instead of being elided. A missing Content-Length
+    // forces chunked transfer encoding, which is indistinguishable from an
+    // empty-but-cleanly-terminated chunk stream at upstream caches — and that
+    // ambiguity is exactly what lets a truncated origin pull get cached as
+    // "valid 0-byte response" by aggressively-configured CDNs.
+    if (content.size != null) {
       headers['Content-Length'] = content.size.toString()
     }
     return headers
@@ -138,6 +146,85 @@ export async function createContentFileHeaders(content: ContentItem, hash: strin
     stream.destroy()
     throw error
   }
+}
+
+/**
+ * Wrap a content body stream in a passthrough that compares bytes-streamed
+ * against the size declared by storage, and emits a metric + warn log when
+ * the two disagree.
+ *
+ * Detects the failure mode we cannot observe today: a stream that begins
+ * normally and then ends short of `content.size` bytes for any reason
+ * (storage backend hiccup, file-type detection consuming bytes that don't
+ * get re-read, an upstream proxy mangling chunked encoding). Without this,
+ * an empty / truncated body looks identical to a successful response at the
+ * HTTP layer, and aggressively-cached CDNs in front of the catalyst will
+ * latch onto the broken response for the lifetime of their TTL.
+ *
+ * When `expectedSize` is null (size unknown — uncommon for stored objects,
+ * happens for some range responses) we can't validate and return the source
+ * stream unchanged. The metric only fires for cases where storage knows the
+ * size and the served body diverges from it.
+ *
+ * Source-stream errors are forwarded to the wrapped stream so the HTTP
+ * framework still tears the response down cleanly; the `error` label on the
+ * metric lets ops distinguish stream-errored short responses from
+ * cleanly-ended short responses (the latter is the more alarming case —
+ * means the origin claimed to send N bytes and then ended at <N without
+ * raising an error).
+ */
+export function observeContentBodySize(
+  source: Readable,
+  expectedSize: number | null,
+  hash: string,
+  components: {
+    metrics: IMetricsComponent<keyof typeof metricsDeclaration>
+    logs: ILoggerComponent
+  }
+): Readable {
+  if (expectedSize === null) return source
+
+  const logger = components.logs.getLogger('content-body-size-observer')
+  let observed = 0
+  let reported = false
+
+  const report = (reason: 'truncated' | 'error', error?: unknown) => {
+    if (reported) return
+    reported = true
+    components.metrics.increment('dcl_content_short_response_total', { reason })
+    logger.warn('content response body size mismatch', {
+      hash,
+      expectedSize,
+      observed,
+      reason,
+      ...(error instanceof Error ? { error: error.message } : {})
+    } as any)
+  }
+
+  // Transform is preferable to attaching a 'data' listener directly: a data
+  // listener can put the source into flowing mode prematurely, which races
+  // with the HTTP framework's own consumer. Transform respects backpressure
+  // and lets the framework drive the flow as it would for the raw source.
+  const counter = new Transform({
+    transform(chunk: Buffer | Uint8Array, _encoding, callback) {
+      observed += chunk.length
+      callback(null, chunk)
+    },
+    flush(callback) {
+      if (observed !== expectedSize) {
+        report('truncated')
+      }
+      callback()
+    }
+  })
+
+  source.on('error', (err) => {
+    report('error', err)
+    counter.destroy(err)
+  })
+  source.pipe(counter)
+
+  return counter
 }
 
 export async function retrieveContentWithRange(

--- a/content/src/metrics.ts
+++ b/content/src/metrics.ts
@@ -19,6 +19,12 @@ export const metricsDeclaration = validateMetricsDeclaration({
     labelNames: ['entity_type', 'deployment_context']
   },
 
+  dcl_content_short_response_total: {
+    help: 'Total content responses where the actual streamed body size did not match the size declared in the storage layer (truncated or partial bodies).',
+    type: 'counter',
+    labelNames: ['reason']
+  },
+
   db_queued_queries_count: {
     help: 'Total number of queries that went through the queue since the service started',
     type: 'counter',

--- a/content/test/unit/controllers/conditional-request.spec.ts
+++ b/content/test/unit/controllers/conditional-request.spec.ts
@@ -14,6 +14,13 @@ describe('when handling conditional requests', () => {
 
   let contentItem: ContentItem
   let storage: IContentStorageComponent
+  // The body-size observer in the handlers needs `metrics` and `logs`; the
+  // 200-path tests below would otherwise crash on `components.logs.getLogger`
+  // even though they don't actually care about the observation behaviour.
+  // Casting to `any` keeps the call sites unchanged at runtime while
+  // satisfying the new handler type signatures.
+  const metrics = { increment: jest.fn() } as any
+  const logs = { getLogger: jest.fn().mockReturnValue({ warn: jest.fn() }) } as any
 
   beforeEach(() => {
     contentItem = createContentItemMock(500)
@@ -25,19 +32,19 @@ describe('when handling conditional requests', () => {
   })
 
   describe('when serving content by hash', () => {
-    let context: HandlerContextWithPath<'storage', '/contents/:hashId'>
+    let context: HandlerContextWithPath<'storage' | 'metrics' | 'logs', '/contents/:hashId'>
 
     describe('when the If-None-Match header matches the ETag', () => {
       beforeEach(() => {
         context = {
           params: { hashId },
-          components: { storage },
+          components: { storage, metrics, logs },
           url: new URL('http://localhost/contents/' + hashId),
           request: {
             method: 'GET',
             ...createRequestMock({ 'if-none-match': etag })
           }
-        } as unknown as HandlerContextWithPath<'storage', '/contents/:hashId'>
+        } as unknown as HandlerContextWithPath<'storage' | 'metrics' | 'logs', '/contents/:hashId'>
       })
 
       it('should return 304 with no body', async () => {
@@ -62,13 +69,13 @@ describe('when handling conditional requests', () => {
       beforeEach(() => {
         context = {
           params: { hashId },
-          components: { storage },
+          components: { storage, metrics, logs },
           url: new URL('http://localhost/contents/' + hashId),
           request: {
             method: 'GET',
             ...createRequestMock({ 'if-none-match': '"different-hash"' })
           }
-        } as unknown as HandlerContextWithPath<'storage', '/contents/:hashId'>
+        } as unknown as HandlerContextWithPath<'storage' | 'metrics' | 'logs', '/contents/:hashId'>
       })
 
       it('should return the full response', async () => {
@@ -82,13 +89,13 @@ describe('when handling conditional requests', () => {
       beforeEach(() => {
         context = {
           params: { hashId },
-          components: { storage },
+          components: { storage, metrics, logs },
           url: new URL('http://localhost/contents/' + hashId),
           request: {
             method: 'GET',
             ...createRequestMock()
           }
-        } as unknown as HandlerContextWithPath<'storage', '/contents/:hashId'>
+        } as unknown as HandlerContextWithPath<'storage' | 'metrics' | 'logs', '/contents/:hashId'>
       })
 
       it('should return the full response', async () => {
@@ -101,7 +108,7 @@ describe('when handling conditional requests', () => {
 
   describe('when serving an entity image', () => {
     let context: HandlerContextWithPath<
-      'activeEntities' | 'database' | 'storage',
+      'activeEntities' | 'database' | 'storage' | 'metrics' | 'logs',
       '/entities/active/entity/:pointer/image'
     >
 
@@ -138,7 +145,7 @@ describe('when handling conditional requests', () => {
             ...createRequestMock({ 'if-none-match': etag })
           }
         } as unknown as HandlerContextWithPath<
-          'activeEntities' | 'database' | 'storage',
+          'activeEntities' | 'database' | 'storage' | 'metrics' | 'logs',
           '/entities/active/entity/:pointer/image'
         >
       })
@@ -158,7 +165,7 @@ describe('when handling conditional requests', () => {
 
   describe('when serving an entity thumbnail', () => {
     let context: HandlerContextWithPath<
-      'database' | 'activeEntities' | 'storage',
+      'database' | 'activeEntities' | 'storage' | 'metrics' | 'logs',
       '/entities/active/entity/:pointer/thumbnail'
     >
 
@@ -195,7 +202,7 @@ describe('when handling conditional requests', () => {
             ...createRequestMock({ 'if-none-match': etag })
           }
         } as unknown as HandlerContextWithPath<
-          'database' | 'activeEntities' | 'storage',
+          'database' | 'activeEntities' | 'storage' | 'metrics' | 'logs',
           '/entities/active/entity/:pointer/thumbnail'
         >
       })

--- a/content/test/unit/controllers/utils.spec.ts
+++ b/content/test/unit/controllers/utils.spec.ts
@@ -1,6 +1,8 @@
 import { ContentItem, IContentStorageComponent } from '@dcl/catalyst-storage'
+import { Readable } from 'stream'
 import {
   checkNotModified,
+  observeContentBodySize,
   paginationObject,
   parseRangeHeader,
   retrieveContentWithRange,
@@ -416,6 +418,151 @@ describe('when retrieving content with range', () => {
 
     it('should rethrow the error', async () => {
       await expect(retrieveContentWithRange(storage, 'some-hash', 'bytes=0-99')).rejects.toThrow(thrownError)
+    })
+  })
+})
+
+describe('when observing content body size', () => {
+  const hash = 'bafybeiasb5vpmaounyilfuxbd3lool'
+  let metrics: { increment: jest.Mock }
+  let logger: { warn: jest.Mock; info: jest.Mock; debug: jest.Mock; error: jest.Mock; log: jest.Mock }
+  let logs: { getLogger: jest.Mock }
+  let components: any
+
+  // Drain a Readable to completion and resolve with the total bytes.
+  const drain = (s: Readable): Promise<number> =>
+    new Promise((resolve, reject) => {
+      let total = 0
+      s.on('data', (chunk: Buffer) => {
+        total += chunk.length
+      })
+      s.on('end', () => resolve(total))
+      s.on('close', () => resolve(total))
+      s.on('error', reject)
+    })
+
+  beforeEach(() => {
+    metrics = { increment: jest.fn() }
+    logger = {
+      warn: jest.fn(),
+      info: jest.fn(),
+      debug: jest.fn(),
+      error: jest.fn(),
+      log: jest.fn()
+    }
+    logs = { getLogger: jest.fn().mockReturnValue(logger) }
+    components = { metrics, logs }
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('and the expected size is null', () => {
+    let source: Readable
+
+    beforeEach(() => {
+      source = Readable.from(Buffer.alloc(100))
+    })
+
+    it('should return the source stream unchanged without instrumenting it', async () => {
+      const result = observeContentBodySize(source, null, hash, components)
+      expect(result).toBe(source)
+      await drain(result)
+      expect(metrics.increment).not.toHaveBeenCalled()
+      expect(logger.warn).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('and the body matches the expected size', () => {
+    let observed: Readable
+
+    beforeEach(async () => {
+      const source = Readable.from(Buffer.alloc(100))
+      observed = observeContentBodySize(source, 100, hash, components)
+      await drain(observed)
+    })
+
+    it('should not increment the short-response metric', () => {
+      expect(metrics.increment).not.toHaveBeenCalled()
+    })
+
+    it('should not emit a warning log', () => {
+      expect(logger.warn).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('and the body is shorter than the expected size', () => {
+    let observed: Readable
+
+    beforeEach(async () => {
+      // 50 bytes streamed against a 100-byte declaration — the truncation case
+      const source = Readable.from(Buffer.alloc(50))
+      observed = observeContentBodySize(source, 100, hash, components)
+      await drain(observed)
+    })
+
+    it('should increment the short-response metric with reason=truncated', () => {
+      expect(metrics.increment).toHaveBeenCalledWith('dcl_content_short_response_total', {
+        reason: 'truncated'
+      })
+    })
+
+    it('should emit exactly one warning log including the observed and expected sizes', () => {
+      expect(logger.warn).toHaveBeenCalledTimes(1)
+      const [, payload] = logger.warn.mock.calls[0]
+      expect(payload).toMatchObject({ hash, expectedSize: 100, observed: 50, reason: 'truncated' })
+    })
+  })
+
+  describe('and the body is longer than the expected size', () => {
+    let observed: Readable
+
+    beforeEach(async () => {
+      // Same mismatch direction is also worth flagging — points at a storage
+      // miscount or a doubled-write
+      const source = Readable.from(Buffer.alloc(150))
+      observed = observeContentBodySize(source, 100, hash, components)
+      await drain(observed)
+    })
+
+    it('should still increment the short-response metric (the metric tracks "size mismatch", not strictly under)', () => {
+      expect(metrics.increment).toHaveBeenCalledWith('dcl_content_short_response_total', {
+        reason: 'truncated'
+      })
+    })
+  })
+
+  describe('and the source stream errors mid-transfer', () => {
+    let observed: Readable
+    let drainError: unknown
+
+    beforeEach(async () => {
+      // Custom Readable that emits 30 bytes then errors — exactly the
+      // "storage backend gave up partway" case the metric should catch
+      const source = new Readable({
+        read() {
+          this.push(Buffer.alloc(30))
+          this.destroy(new Error('upstream connection reset'))
+        }
+      })
+      observed = observeContentBodySize(source, 100, hash, components)
+      try {
+        await drain(observed)
+      } catch (err) {
+        drainError = err
+      }
+    })
+
+    it('should increment the short-response metric with reason=error', () => {
+      expect(metrics.increment).toHaveBeenCalledWith('dcl_content_short_response_total', {
+        reason: 'error'
+      })
+    })
+
+    it('should propagate the source error to the wrapped stream rather than swallowing it', () => {
+      expect(drainError).toBeInstanceOf(Error)
+      expect((drainError as Error).message).toBe('upstream connection reset')
     })
   })
 })


### PR DESCRIPTION
## Summary

- Adds a `dcl_content_short_response_total{reason}` counter that fires whenever a `/contents/:hashId`, entity-image, or entity-thumbnail response streams fewer (or more) bytes than the size declared by storage.
- Tightens `Content-Length` header emission in `createContentFileHeaders`: now uses `content.size != null` instead of `if (content.size)`, so a legitimate 0-byte file emits `Content-Length: 0` instead of being elided into a chunked-encoded empty response.

## Why

The content endpoint currently has no signal for a class of failure we cannot observe today: a response that begins normally and ends short of `content.size` for any reason. Examples we've now seen in practice:

- Storage backend (S3) returning a successful 200 with a body shorter than the declared `ContentLength`.
- MIME-sniffing (`FileTypeParser.fromStream`) consuming bytes from the first stream and `destroy()`ing it, with the second `asRawStream()` call landing in some unexpected state.
- An upstream proxy (Cloudflare, CloudFront, etc.) mangling chunked transfer encoding and forwarding an empty stream to clients.

At the HTTP layer all of these look identical to a successful response — `200 OK`, headers fine, stream cleanly closed at zero bytes — so an aggressive cache configuration in front of the catalyst (e.g. `Page Rule: Cache Everything, Edge Cache TTL: 1 year`) will happily latch onto the broken body and serve it for the full TTL. We've recently observed exactly this incident in production on `peer.decentraland.today`, where Cloudflare's IAD POP cached 0-byte 200 responses for a scene's glb assets and pinned them for the configured year, breaking asset-bundle conversion for ~24 hours.

The catalyst code itself isn't the root cause — but it's the only layer that knows both the *expected* size (from storage) and the *actual* size (the bytes flowing through the response) at the same time. Adding the comparison here turns "we have no idea this happened until external clients report broken scenes" into "we get a step-change on a counter ops can alert on."

## How

### `observeContentBodySize(source, expectedSize, hash, components)` in `src/controllers/utils.ts`

Wraps the body `Readable` in a `stream.Transform` that:

1. Passes chunks through unmodified (respecting backpressure — using a Transform instead of attaching a `'data'` listener directly avoids racing the HTTP framework's consumer).
2. Counts bytes as they go.
3. In the `flush` callback (fired after the source emits `'end'`), compares the count to `expectedSize`. On mismatch, increments `dcl_content_short_response_total{reason: 'truncated'}` and emits a `warn`-level log including `hash`, `expectedSize`, and `observed`.
4. On a source error, forwards the error to the wrapped stream (so the HTTP framework still tears down cleanly) and increments the counter with `reason: 'error'`.

When `expectedSize` is `null` (uncommon — only happens for some range responses where the clamped end isn't known), the helper returns the source unchanged. The metric tracks only cases where storage actually knows what size the body should be.

### Wired into three handlers

`getContentHandler`, `getEntityImageHandler`, and `getEntityThumbnailHandler` all follow the same pattern: a HEAD/GET handler that returns `body: await content.asRawStream()` on GET. Each now wraps that stream with `observeContentBodySize` and picks `'metrics' | 'logs'` from `AppComponents` to do it.

### `Content-Length: 0` fix

The previous `if (content.size)` check elided the header for both `null`/`undefined` (legitimately unknown) and `0` (legitimately empty). The latter is a bug: a 0-byte stored object should advertise `Content-Length: 0` so clients and intermediaries can distinguish "intentionally empty body" from "chunked encoding, body might be anything." The fix swaps the check for `content.size != null`, preserving the existing behaviour for the unknown-size case while emitting the explicit `0` for empty files.

## Why this isn't redundant with origin-side instrumentation

If the catalyst is behind a proxy (Cloudflare → ALB → catalyst), an HTTP-level access log on the proxy can also detect truncation by comparing `bytes_sent` against the response's `Content-Length`. That's useful too, but it requires:

- Both the response and the access log to be reachable to an operator with the right permissions.
- The proxy's logging to be configured for `bytes_sent` (not always default).
- The operator to know which URLs to grep, in advance.

The metric we add here:

- Fires on the catalyst itself, in the same process that's reading from storage. No cross-system join.
- Is automatically aggregated by Prometheus alongside every other catalyst metric.
- Doesn't require knowing which URL is affected — it just counts mismatches across the entire content endpoint.

The two layers are complementary, not redundant.

## Tests

Unit-tested the helper in isolation in `test/unit/controllers/utils.spec.ts` with five new cases under a `describe('when observing content body size', …)` block:

- Returns the source unchanged when `expectedSize` is null and emits no metric.
- Matching size: no metric, no warn log.
- Body shorter than expected: emits `reason: 'truncated'` and one warn log with the right payload.
- Body longer than expected: same metric (the counter tracks "size mismatch" — either direction is a signal).
- Source error mid-transfer: emits `reason: 'error'`, propagates the source error to the wrapped stream so the framework can tear down.

Also updated `test/unit/controllers/conditional-request.spec.ts` to pass minimal `metrics` and `logs` mocks alongside `storage` so the existing 200-path tests (which now reach the body observer) don't crash on `components.logs.getLogger`. The 304-path tests were unaffected.

- [x] `yarn build` — clean (`tsc -b`)
- [x] `yarn jest test/unit` — 231 passed, 26 test suites
- [x] `lint-staged` ran on commit (eslint --fix) — clean

## Out of scope (worth follow-ups)

- **Integration test that simulates a truncated origin pull end-to-end.** Would need either a fake storage component that returns a short stream against a known `content.size`, or a stubbed S3 backend. The unit test already exercises every branch of the observer in isolation, so the integration path is the controller wiring — which TypeScript already validates at compile time.
- **A second metric for `Content-Length: 0` responses to known-non-zero hashes.** Tighter signal, but the existing counter already fires on these.
- **Migration of `getContentHandler` and friends to the WKC `logic/` layer** so the body-observe wiring lives in a logic component rather than the controller. The current change matches the existing controller pattern; reshuffling layers should be its own PR.