### PR TITLE
refactor: wkc layout — phase 16 (function libs → factories)

### DIFF
--- a/content/src/adapters/content-validator/component.ts
+++ b/content/src/adapters/content-validator/component.ts
@@ -122,8 +122,8 @@ async function createOnChainValidateFn(
   const storageRoot = env.getConfig(EnvironmentConfig.STORAGE_ROOT_FOLDER) as string
   const l1ThirdPartyContractRegistry = await createThirdPartyContractRegistry(logs, l1Provider, l1Network, storageRoot)
   const l2ThirdPartyContractRegistry = await createThirdPartyContractRegistry(logs, l2Provider, l2Network, storageRoot)
-  const l1ThirdPartyItemChecker = await createThirdPartyItemChecker(logs, l1Provider, l1ThirdPartyContractRegistry)
-  const l2ThirdPartyItemChecker = await createThirdPartyItemChecker(logs, l2Provider, l2ThirdPartyContractRegistry)
+  const l1ThirdPartyItemChecker = await createThirdPartyItemChecker({ logs }, l1Provider, l1ThirdPartyContractRegistry)
+  const l2ThirdPartyItemChecker = await createThirdPartyItemChecker({ logs }, l2Provider, l2ThirdPartyContractRegistry)
 
   const l1BlockSearch = createAvlBlockSearch({
     blockRepository: createBlockRepository({

--- a/content/src/adapters/snapshot-generator/component.ts
+++ b/content/src/adapters/snapshot-generator/component.ts
@@ -1,19 +1,14 @@
 import { SnapshotMetadata } from '@dcl/snapshots-fetcher/dist/types'
-import { generateSnapshotsInMultipleTimeRanges } from '../../logic/snapshots'
 import { AppComponents } from '../../types'
 import { SnapshotGenerator } from './types'
 
-export function createSnapshotGenerator(
-  components: Pick<
-    AppComponents,
-    'database' | 'fs' | 'metrics' | 'storage' | 'logs' | 'denylist' | 'staticConfigs' | 'snapshotsRepository'
-  >
-): SnapshotGenerator {
+export function createSnapshotGenerator(components: Pick<AppComponents, 'snapshots'>): SnapshotGenerator {
+  const { snapshots } = components
   let currentSnapshots: SnapshotMetadata[] | undefined
 
   return {
     async generateSnapshots() {
-      currentSnapshots = await generateSnapshotsInMultipleTimeRanges(components, {
+      currentSnapshots = await snapshots.generateSnapshotsInMultipleTimeRanges({
         // IT IS IMPORTANT THIS TIMESTAMP NEVER CHANGES; IF IT DOES, THE WHOLE SNAPSHOTS SET WILL BE REGENERATED.
         initTimestamp: 1577836800000,
         endTimestamp: Date.now()

--- a/content/src/components.ts
+++ b/content/src/components.ts
@@ -62,13 +62,18 @@ import { createChallengeSupervisor } from './logic/challenge-supervisor'
 import { splitByCommaTrimAndRemoveEmptyElements } from './logic/config-helpers'
 import { createDeploymentsComponent, retryFailedDeploymentExecution } from './logic/deployments'
 import { createDeploymentService } from './logic/deployment-service'
+import { createEntityParser } from './logic/entity-parser'
+import { createErc721 } from './logic/erc721'
 import { createFailedDeploymentsReporter } from './logic/failed-deployments-reporter'
 import { createGarbageCollectionComponent } from './logic/garbage-collection'
+import { createHashing } from './logic/hashing'
 import { createContentCluster } from './logic/peer-cluster'
 import { createPointerManager } from './logic/pointer-manager'
+import { createQueryParams } from './logic/query-params'
 import { createRetryFailedDeploymentsScheduler } from './logic/retry-failed-deployments'
 import { createSequentialTaskExecutor } from './logic/sequential-task-executor'
 import { createServerValidator } from './logic/server-validator'
+import { createSnapshots } from './logic/snapshots'
 
 // =============================================================================
 // Types
@@ -193,6 +198,12 @@ export async function initComponentsWithEnv(env: Environment): Promise<AppCompon
   // ---------------------------------------------------------------------------
   // 7. Domain logic
   // ---------------------------------------------------------------------------
+  // Stateless helpers — pure factories with no setup, declared first so any logic below can inject them.
+  const hashing = createHashing()
+  const queryParams = createQueryParams()
+  const entityParser = createEntityParser()
+  const erc721 = createErc721({ env })
+
   const contentCluster = createContentCluster(
     { daoClient, logs, env },
     env.getConfig(EnvironmentConfig.UPDATE_FROM_DAO_INTERVAL)
@@ -271,7 +282,9 @@ export async function initComponentsWithEnv(env: Environment): Promise<AppCompon
     activeEntities,
     denylist,
     deploymentsRepository,
-    contentFilesRepository
+    contentFilesRepository,
+    hashing,
+    entityParser
   })
 
   // ---------------------------------------------------------------------------
@@ -410,7 +423,7 @@ export async function initComponentsWithEnv(env: Environment): Promise<AppCompon
 
   const retryFailedDeployments = createRetryFailedDeploymentsScheduler(retryFailedDeploymentsJob)
 
-  const snapshotGenerator = createSnapshotGenerator({
+  const snapshots = createSnapshots({
     logs,
     fs,
     metrics,
@@ -420,6 +433,8 @@ export async function initComponentsWithEnv(env: Environment): Promise<AppCompon
     denylist,
     snapshotsRepository
   })
+
+  const snapshotGenerator = createSnapshotGenerator({ snapshots })
 
   const snapshotGenerationJob = createJobComponent({ logs }, snapshotGenerator.generateSnapshots, ms('6h'), {
     startupDelay: 0,
@@ -528,6 +543,11 @@ export async function initComponentsWithEnv(env: Environment): Promise<AppCompon
     synchronizer,
     systemProperties,
     tracer,
-    validator
+    validator,
+    hashing,
+    queryParams,
+    entityParser,
+    erc721,
+    snapshots
   }
 }

--- a/content/src/controllers/handlers/get-available-content-handler.ts
+++ b/content/src/controllers/handlers/get-available-content-handler.ts
@@ -1,16 +1,15 @@
 import { AvailableContent } from '@dcl/catalyst-api-specs/lib/client'
 import { HandlerContextWithPath } from '../../types'
 import { InvalidRequestError } from '../errors'
-import { qsGetArray, qsParser } from '../../logic/query-params'
 
 // Method: GET
 // Query String: ?cid={hashId1}&cid={hashId2}
 export async function getAvailableContentHandler(
-  context: HandlerContextWithPath<'denylist' | 'storage', '/available-content'>
+  context: HandlerContextWithPath<'denylist' | 'storage' | 'queryParams', '/available-content'>
 ): Promise<{ status: 200; body: AvailableContent }> {
-  const { storage, denylist } = context.components
-  const queryParams = qsParser(context.url.searchParams)
-  const cids: string[] = qsGetArray(queryParams, 'cid')
+  const { storage, denylist, queryParams } = context.components
+  const parsedParams = queryParams.qsParser(context.url.searchParams)
+  const cids: string[] = queryParams.qsGetArray(parsedParams, 'cid')
 
   if (cids.length === 0) {
     throw new InvalidRequestError('Please set at least one cid.')

--- a/content/src/controllers/handlers/get-deployments-handler.ts
+++ b/content/src/controllers/handlers/get-deployments-handler.ts
@@ -1,6 +1,6 @@
 import { EntityType } from '@dcl/schemas'
 import { asEnumValue, fromCamelCaseToSnakeCase } from '../utils'
-import { qsGetArray, qsGetBoolean, qsGetNumber, qsParser, toQueryParams } from '../../logic/query-params'
+import { IQueryParams } from '../../logic/query-params'
 import { Deployment, DeploymentBase, DeploymentOptions, SortingField, SortingOrder } from '../../deployment-types'
 import { DeploymentField, HandlerContextWithPath, parseEntityType } from '../../types'
 import { InvalidRequestError } from '../errors'
@@ -15,30 +15,37 @@ export const DEFAULT_FIELDS_ON_DEPLOYMENTS: DeploymentField[] = [
 // Query String: ?from={timestamp}&toLocalTimestamp={timestamp}&entityType={entityType}&entityId={entityId}&onlyCurrentlyPointed={boolean}
 export async function getDeploymentsHandler(
   context: HandlerContextWithPath<
-    'database' | 'denylist' | 'metrics' | 'sequentialExecutor' | 'deploymentsRepository' | 'contentFilesRepository',
+    | 'database'
+    | 'denylist'
+    | 'metrics'
+    | 'sequentialExecutor'
+    | 'deploymentsRepository'
+    | 'contentFilesRepository'
+    | 'queryParams',
     '/deployments'
   >
 ) {
-  const queryParams = qsParser(context.url.searchParams)
-  const entityTypes: (EntityType | undefined)[] = qsGetArray(queryParams, 'entityType').map((type) =>
-    parseEntityType(type)
-  )
-  const entityIds = qsGetArray(queryParams, 'entityId')
-  const onlyCurrentlyPointed: boolean | undefined = qsGetBoolean(queryParams, 'onlyCurrentlyPointed')
-  const pointers = qsGetArray(queryParams, 'pointer').map((pointer) => pointer.toLowerCase())
-  const offset: number | undefined = qsGetNumber(queryParams, 'offset')
-  const limit: number | undefined = qsGetNumber(queryParams, 'limit')
-  const fields: string | null = queryParams.fields as string
-  const sortingFieldParam: string | null = queryParams.sortingField as string
+  const { queryParams } = context.components
+  const parsedParams = queryParams.qsParser(context.url.searchParams)
+  const entityTypes: (EntityType | undefined)[] = queryParams
+    .qsGetArray(parsedParams, 'entityType')
+    .map((type) => parseEntityType(type))
+  const entityIds = queryParams.qsGetArray(parsedParams, 'entityId')
+  const onlyCurrentlyPointed: boolean | undefined = queryParams.qsGetBoolean(parsedParams, 'onlyCurrentlyPointed')
+  const pointers = queryParams.qsGetArray(parsedParams, 'pointer').map((pointer) => pointer.toLowerCase())
+  const offset: number | undefined = queryParams.qsGetNumber(parsedParams, 'offset')
+  const limit: number | undefined = queryParams.qsGetNumber(parsedParams, 'limit')
+  const fields: string | null = parsedParams.fields as string
+  const sortingFieldParam: string | null = parsedParams.sortingField as string
   const snake_case_sortingField = sortingFieldParam ? fromCamelCaseToSnakeCase(sortingFieldParam) : undefined
   const sortingField: SortingField | undefined | 'unknown' = asEnumValue(SortingField, snake_case_sortingField)
   const sortingOrder: SortingOrder | undefined | 'unknown' = asEnumValue(
     SortingOrder,
-    (queryParams.sortingOrder as string) || undefined
+    (parsedParams.sortingOrder as string) || undefined
   )
-  const lastId: string | undefined = (queryParams.lastId as string)?.toLowerCase()
-  const from = qsGetNumber(queryParams, 'from')
-  const to = qsGetNumber(queryParams, 'to')
+  const lastId: string | undefined = (parsedParams.lastId as string)?.toLowerCase()
+  const from = queryParams.qsGetNumber(parsedParams, 'from')
+  const to = queryParams.qsGetNumber(parsedParams, 'to')
 
   if (entityTypes && entityTypes.some((type) => !type)) {
     return {
@@ -107,7 +114,7 @@ export async function getDeploymentsHandler(
 
   if (deployments.length > 0 && pagination.moreData) {
     const lastDeployment = deployments[deployments.length - 1]
-    pagination.next = calculateNextRelativePath(deploymentOptions, lastDeployment)
+    pagination.next = calculateNextRelativePath(queryParams, deploymentOptions, lastDeployment)
   }
 
   return {
@@ -135,7 +142,11 @@ function deployment2ControllerEntity<T extends DeploymentBase>(deployment: Deplo
   return result
 }
 
-function calculateNextRelativePath(options: DeploymentOptions, lastDeployment: Deployment): string {
+function calculateNextRelativePath(
+  queryParams: IQueryParams,
+  options: DeploymentOptions,
+  lastDeployment: Deployment
+): string {
   const nextFilters = Object.assign({}, options?.filters)
 
   const field = options?.sortBy?.field ?? SortingField.LOCAL_TIMESTAMP
@@ -157,7 +168,7 @@ function calculateNextRelativePath(options: DeploymentOptions, lastDeployment: D
 
   const fields = !options.fields || options.fields === DEFAULT_FIELDS_ON_DEPLOYMENTS ? '' : options.fields.join(',')
 
-  const nextQueryParams = toQueryParams({
+  const nextQueryParams = queryParams.toQueryParams({
     ...nextFilters,
     fields,
     sortingField: field,

--- a/content/src/controllers/handlers/get-entities-handler.ts
+++ b/content/src/controllers/handlers/get-entities-handler.ts
@@ -1,6 +1,5 @@
 import { EntityContentItemReference } from '@dcl/hashing'
 import { Entity, EntityType } from '@dcl/schemas'
-import { qsGetArray, qsParser } from '../../logic/query-params'
 import { HandlerContextWithPath, parseEntityType } from '../../types'
 
 export enum EntityField {
@@ -16,15 +15,17 @@ export enum EntityField {
 // Method: GET
 // Query String: ?{filter}&fields={fieldList}
 export async function getEntitiesHandler(
-  context: HandlerContextWithPath<'activeEntities' | 'database', '/entities/:type'>
+  context: HandlerContextWithPath<'activeEntities' | 'database' | 'queryParams', '/entities/:type'>
 ) {
-  const { database, activeEntities } = context.components
+  const { database, activeEntities, queryParams } = context.components
   const type: EntityType = parseEntityType(context.params.type)
-  const queryParams = qsParser(context.url.searchParams)
+  const parsedParams = queryParams.qsParser(context.url.searchParams)
 
-  const pointers: string[] = qsGetArray(queryParams, 'pointer').map((pointer) => pointer.toLocaleLowerCase())
-  const ids: string[] = qsGetArray(queryParams, 'id')
-  const fields: string = queryParams.fields as string
+  const pointers: string[] = queryParams
+    .qsGetArray(parsedParams, 'pointer')
+    .map((pointer) => pointer.toLocaleLowerCase())
+  const ids: string[] = queryParams.qsGetArray(parsedParams, 'id')
+  const fields: string = parsedParams.fields as string
 
   // Validate type is valid
   if (!type) {

--- a/content/src/controllers/handlers/get-erc721-entity-handler.ts
+++ b/content/src/controllers/handlers/get-erc721-entity-handler.ts
@@ -1,18 +1,17 @@
 import { Erc721 } from '@dcl/catalyst-api-specs/lib/client'
 import { HandlerContextWithPath } from '../../types'
 import { InvalidRequestError, NotFoundError } from '../errors'
-import { buildUrn, formatERC721Entity } from '../../logic/erc721'
 import { findEntityByPointer } from '../../logic/entities'
 import { getURNProtocol } from '@dcl/schemas'
 
 // Method: GET
 export async function getERC721EntityHandler(
   context: HandlerContextWithPath<
-    'env' | 'activeEntities' | 'database',
+    'erc721' | 'activeEntities' | 'database',
     '/entities/active/erc721/:chainId/:contract/:option/:emission?'
   >
 ): Promise<{ status: 200; body: Erc721 }> {
-  const { database, activeEntities, env } = context.components
+  const { database, activeEntities, erc721 } = context.components
   const { chainId, contract, option, emission } = context.params
 
   const protocol = getURNProtocol(parseInt(chainId, 10))
@@ -21,7 +20,7 @@ export async function getERC721EntityHandler(
     throw new InvalidRequestError(`Invalid chainId '${chainId}'`)
   }
 
-  const pointer = buildUrn(protocol, contract, option)
+  const pointer = erc721.buildUrn(protocol, contract, option)
   const entity = await findEntityByPointer(database, activeEntities, pointer)
   if (!entity || !entity.metadata) {
     throw new NotFoundError('Entity does not exist')
@@ -33,6 +32,6 @@ export async function getERC721EntityHandler(
 
   return {
     status: 200,
-    body: formatERC721Entity(env, pointer, entity, emission)
+    body: erc721.formatERC721Entity(pointer, entity, emission)
   }
 }

--- a/content/src/controllers/handlers/pointer-changes-handler.ts
+++ b/content/src/controllers/handlers/pointer-changes-handler.ts
@@ -1,7 +1,7 @@
 import { PointerChanges } from '@dcl/catalyst-api-specs/lib/client'
 import { EntityType, PointerChangesSyncDeployment } from '@dcl/schemas'
 import { asEnumValue, fromCamelCaseToSnakeCase } from '../utils'
-import { qsGetArray, qsGetBoolean, qsGetNumber, qsParser, toQueryParams } from '../../logic/query-params'
+import { IQueryParams } from '../../logic/query-params'
 import { HandlerContextWithPath, parseEntityType } from '../../types'
 import { InvalidRequestError } from '../errors'
 import { SortingField, SortingOrder } from '../../deployment-types'
@@ -11,29 +11,30 @@ import { getPointerChanges, PointerChangesFilters } from '../../logic/deployment
 // Query String: ?from={timestamp}&to={timestamp}&offset={number}&limit={number}&entityType={entityType}&includeAuthChain={boolean}
 export async function getPointerChangesHandler(
   context: HandlerContextWithPath<
-    'database' | 'denylist' | 'sequentialExecutor' | 'metrics' | 'deploymentsRepository',
+    'database' | 'denylist' | 'sequentialExecutor' | 'metrics' | 'deploymentsRepository' | 'queryParams',
     '/pointer-changes'
   >
 ): Promise<{ status: 200; body: Required<PointerChanges> }> {
-  const queryParams = qsParser(context.url.searchParams)
+  const { queryParams } = context.components
+  const parsedParams = queryParams.qsParser(context.url.searchParams)
 
-  const entityTypes: (EntityType | undefined)[] = qsGetArray(queryParams, 'entityType').map((type) =>
-    parseEntityType(type)
-  )
+  const entityTypes: (EntityType | undefined)[] = queryParams
+    .qsGetArray(parsedParams, 'entityType')
+    .map((type) => parseEntityType(type))
 
-  const from: number | undefined = qsGetNumber(queryParams, 'from')
-  const to: number | undefined = qsGetNumber(queryParams, 'to')
-  const offset: number | undefined = qsGetNumber(queryParams, 'offset')
-  const limit: number | undefined = qsGetNumber(queryParams, 'limit')
-  const lastId: string | undefined = (queryParams.lastId as string)?.toLowerCase()
-  const includeAuthChain = qsGetBoolean(queryParams, 'includeAuthChain') ?? false
+  const from: number | undefined = queryParams.qsGetNumber(parsedParams, 'from')
+  const to: number | undefined = queryParams.qsGetNumber(parsedParams, 'to')
+  const offset: number | undefined = queryParams.qsGetNumber(parsedParams, 'offset')
+  const limit: number | undefined = queryParams.qsGetNumber(parsedParams, 'limit')
+  const lastId: string | undefined = (parsedParams.lastId as string)?.toLowerCase()
+  const includeAuthChain = queryParams.qsGetBoolean(parsedParams, 'includeAuthChain') ?? false
 
-  const sortingFieldParam: string | undefined = queryParams.sortingField as string
+  const sortingFieldParam: string | undefined = parsedParams.sortingField as string
   const snake_case_sortingField = sortingFieldParam ? fromCamelCaseToSnakeCase(sortingFieldParam) : undefined
   const sortingField: SortingField | undefined | 'unknown' = asEnumValue(SortingField, snake_case_sortingField)
   const sortingOrder: SortingOrder | undefined | 'unknown' = asEnumValue(
     SortingOrder,
-    (queryParams.sortingOrder as string) || undefined
+    (parsedParams.sortingOrder as string) || undefined
   )
 
   // Validate type is valid
@@ -83,7 +84,7 @@ export async function getPointerChangesHandler(
 
   if (pointerChanges.length > 0 && pagination.moreData) {
     const lastPointerChange = pointerChanges[pointerChanges.length - 1]
-    pagination.next = calculateNextRelativePathForPointer(lastPointerChange, pagination.limit, filters)
+    pagination.next = calculateNextRelativePathForPointer(queryParams, lastPointerChange, pagination.limit, filters)
   }
 
   const response = { deltas: pointerChanges, filters, pagination }
@@ -94,6 +95,7 @@ export async function getPointerChangesHandler(
 }
 
 function calculateNextRelativePathForPointer(
+  queryParams: IQueryParams,
   lastPointerChange: PointerChangesSyncDeployment,
   limit: number,
   filters?: PointerChangesFilters
@@ -102,7 +104,7 @@ function calculateNextRelativePathForPointer(
   // It will always use toLocalTimestamp as this endpoint is always sorted with the default config: localTimestamp and DESC
   nextFilters.to = lastPointerChange.localTimestamp
 
-  const nextQueryParams = toQueryParams({
+  const nextQueryParams = queryParams.toQueryParams({
     ...nextFilters,
     limit: limit,
     lastId: lastPointerChange.entityId

--- a/content/src/logic/deployment-service/component.ts
+++ b/content/src/logic/deployment-service/component.ts
@@ -16,8 +16,7 @@ import { DatabaseClient } from '../../adapters/database'
 import { happenedBefore } from '../../service/time/TimeSorting'
 import { AppComponents, EntityVersion } from '../../types'
 import { calculateOverwrites, getDeployments, saveDeploymentAndContentFiles } from '../deployments'
-import { getEntityFromBuffer } from '../entity-parser'
-import { calculateDeprecatedHashes, calculateIPFSHashes } from '../hashing'
+import { IHashing } from '../hashing'
 import { DELTA_POINTER_RESULT } from '../pointer-manager'
 import { IDeploymentService } from './types'
 
@@ -41,11 +40,17 @@ export function isEntityContentUnchanged(newEntity: Entity, activeEntity: Entity
  * They could come hashed because the denylist decorator might have already hashed them for its own validations. In order to avoid re-hashing
  * them in the service (because there might be hundreds of files), we will send the hash result.
  */
-export async function hashFiles(files: DeploymentFiles, entityId: string): Promise<Map<string, Uint8Array>> {
+export async function hashFiles(
+  hashing: IHashing,
+  files: DeploymentFiles,
+  entityId: string
+): Promise<Map<string, Uint8Array>> {
   if (files instanceof Map) {
     return files
   } else {
-    const hashEntries = isIPFSHash(entityId) ? await calculateIPFSHashes(files) : await calculateDeprecatedHashes(files)
+    const hashEntries = isIPFSHash(entityId)
+      ? await hashing.calculateIPFSHashes(files)
+      : await hashing.calculateDeprecatedHashes(files)
     return new Map(hashEntries.map(({ hash, file }) => [hash, file]))
   }
 }
@@ -70,6 +75,8 @@ export function createDeploymentService(
     | 'denylist'
     | 'deploymentsRepository'
     | 'contentFilesRepository'
+    | 'hashing'
+    | 'entityParser'
   >
 ): IDeploymentService {
   const logger = components.logs.getLogger('deployer')
@@ -273,7 +280,7 @@ export function createDeploymentService(
       }
 
       // Hash all files
-      const hashes: Map<string, Uint8Array> = await hashFiles(files, entityId)
+      const hashes: Map<string, Uint8Array> = await hashFiles(components.hashing, files, entityId)
 
       // Find entity file
       const entityFile = hashes.get(entityId)
@@ -284,7 +291,7 @@ export function createDeploymentService(
       // Parse entity file into an Entity
       let entity: Entity
       try {
-        entity = getEntityFromBuffer(entityFile, entityId)
+        entity = components.entityParser.parse(entityFile, entityId)
         if (!entity) {
           return InvalidResult({ errors: ['There was a problem parsing the entity, it was null'] })
         }

--- a/content/src/logic/entity-parser/component.ts
+++ b/content/src/logic/entity-parser/component.ts
@@ -1,14 +1,26 @@
 import { EntityContentItemReference } from '@dcl/hashing'
 import { Entity, EntityType } from '@dcl/schemas'
 import { AnyObject } from '../../types'
+import { InvalidEntityError } from './errors'
+import { IEntityParser } from './types'
 
 const textDecoder = new TextDecoder()
+
+export function createEntityParser(): IEntityParser {
+  return {
+    parse(buffer: Uint8Array, id: string): Entity {
+      const entityAsObject = getObjectEntityFromBuffer(buffer)
+      validateObjectEntity(entityAsObject)
+      return parseEntityFromObject(entityAsObject, id)
+    }
+  }
+}
 
 function getObjectEntityFromBuffer(buffer: Uint8Array): AnyObject {
   try {
     return JSON.parse(textDecoder.decode(buffer))
   } catch (e) {
-    throw new Error(`Failed to parse the entity file. Please make sure that it is a valid json.`)
+    throw new InvalidEntityError('Failed to parse the entity file. Please make sure that it is a valid json.')
   }
 }
 
@@ -17,14 +29,14 @@ function parseContent(contents: any[]): EntityContentItemReference[] | undefined
 
   return contents.map(({ file, hash }) => {
     if (!file || !hash) {
-      throw new Error('Content must contain a file name and a file hash')
+      throw new InvalidEntityError('Content must contain a file name and a file hash')
     }
 
     if (
       !(typeof file === 'string' || file instanceof String) ||
       !(typeof hash === 'string' || hash instanceof String)
     ) {
-      throw new Error('Please make sure that all file names and a file hashes are valid strings')
+      throw new InvalidEntityError('Please make sure that all file names and a file hashes are valid strings')
     }
 
     return { file: file as string, hash: hash as string }
@@ -47,22 +59,19 @@ function validateObjectEntity(entityAsObject: AnyObject): void {
   const { type, pointers, timestamp, content } = entityAsObject
 
   if (!type || !(Object.values(EntityType) as string[]).includes(type as string))
-    throw new Error(`Please set a valid type. It must be one of ${Object.values(EntityType)}. We got '${type}'`)
+    throw new InvalidEntityError(
+      `Please set a valid type. It must be one of ${Object.values(EntityType)}. We got '${type}'`
+    )
 
   if (
     !pointers ||
     !Array.isArray(pointers) ||
     !pointers.every((pointer) => typeof pointer === 'string' || pointer instanceof String)
   )
-    throw new Error(`Please set valid pointers`)
+    throw new InvalidEntityError('Please set valid pointers')
 
-  if (!timestamp || typeof timestamp !== 'number') throw new Error(`Please set a valid timestamp. We got ${timestamp}`)
+  if (!timestamp || typeof timestamp !== 'number')
+    throw new InvalidEntityError(`Please set a valid timestamp. We got ${timestamp}`)
 
-  if (!!content && !Array.isArray(content)) throw new Error(`Expected an array as content`)
-}
-
-export function getEntityFromBuffer(buffer: Uint8Array, id: string): Entity {
-  const entityAsObject = getObjectEntityFromBuffer(buffer)
-  validateObjectEntity(entityAsObject)
-  return parseEntityFromObject(entityAsObject, id)
+  if (!!content && !Array.isArray(content)) throw new InvalidEntityError('Expected an array as content')
 }

--- a/content/src/logic/entity-parser/errors.ts
+++ b/content/src/logic/entity-parser/errors.ts
@@ -1,0 +1,11 @@
+/**
+ * Thrown when the entity buffer is malformed (invalid JSON, missing required fields,
+ * fields with the wrong shape). Handlers should map this to a 400 response.
+ */
+export class InvalidEntityError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'InvalidEntityError'
+    Error.captureStackTrace(this, this.constructor)
+  }
+}

--- a/content/src/logic/entity-parser/index.ts
+++ b/content/src/logic/entity-parser/index.ts
@@ -1,1 +1,3 @@
-export { getEntityFromBuffer } from './component'
+export { createEntityParser } from './component'
+export { InvalidEntityError } from './errors'
+export type { IEntityParser } from './types'

--- a/content/src/logic/entity-parser/types.ts
+++ b/content/src/logic/entity-parser/types.ts
@@ -1,0 +1,12 @@
+import { Entity } from '@dcl/schemas'
+
+export interface IEntityParser {
+  /**
+   * Parse and validate a serialized entity. Throws `InvalidEntityError` if the buffer
+   * does not contain valid JSON or the parsed object is missing required fields.
+   *
+   * @param buffer - the raw entity bytes
+   * @param id - the entity id (used verbatim on the result; the parser does not verify it against the content hash)
+   */
+  parse(buffer: Uint8Array, id: string): Entity
+}

--- a/content/src/logic/erc721/component.ts
+++ b/content/src/logic/erc721/component.ts
@@ -1,6 +1,8 @@
 import { I18N, BodyShape, Emote, StandardProps, Wearable, WearableRepresentation, Entity } from '@dcl/schemas'
-import { Environment, EnvironmentConfig } from '../../Environment'
+import { EnvironmentConfig } from '../../Environment'
+import { AppComponents } from '../../types'
 import { findImageHash, findThumbnailHash } from '../entities'
+import { Erc721Entity, IErc721 } from './types'
 
 type ERC721StandardTrait = {
   trait_type: string
@@ -25,12 +27,56 @@ const RARITIES_EMISSIONS = {
   unique: 1
 }
 
-export function buildUrn(protocol: string, contract: string, option: string): string {
-  const version = contract.startsWith('0x') ? 'v2' : 'v1'
-  return `urn:decentraland:${protocol}:collections-${version}:${contract}:${option}`
+export function createErc721(components: Pick<AppComponents, 'env'>): IErc721 {
+  const { env } = components
+  const baseUrl = env.getConfig<string>(EnvironmentConfig.CONTENT_SERVER_ADDRESS)
+
+  return {
+    buildUrn(protocol: string, contract: string, option: string): string {
+      const version = contract.startsWith('0x') ? 'v2' : 'v1'
+      return `urn:decentraland:${protocol}:collections-${version}:${contract}:${option}`
+    },
+
+    formatERC721Entity(urn: string, entity: Entity, emission: string | undefined): Erc721Entity {
+      const itemMetadata: (Wearable | Emote) & StandardProps = entity.metadata
+      const name = preferEnglish(itemMetadata.i18n)
+      const totalEmission = RARITIES_EMISSIONS[itemMetadata.rarity]
+      const description = emission ? `DCL Wearable ${emission}/${totalEmission}` : ''
+
+      const imageHash = findImageHash(entity)
+      const thumbnailHash = findThumbnailHash(entity)
+      const itemData: ItemData = getItemData(itemMetadata)
+      const bodyShapeTraits = getBodyShapes(itemData.representations).reduce(
+        (bodyShapes: ERC721StandardTrait[], bodyShape) => {
+          bodyShapes.push({ trait_type: 'Body Shape', value: bodyShape })
+          return bodyShapes
+        },
+        []
+      )
+      const tagTraits = itemData.tags.reduce((tags: ERC721StandardTrait[], tag) => {
+        tags.push({ trait_type: 'Tag', value: tag })
+        return tags
+      }, [])
+
+      return {
+        id: urn,
+        name,
+        description,
+        language: 'en-US',
+        image: imageHash ? new URL(`contents/${imageHash}`, baseUrl).toString() : undefined,
+        thumbnail: thumbnailHash ? new URL(`contents/${thumbnailHash}`, baseUrl).toString() : undefined,
+        attributes: [
+          { trait_type: 'Rarity', value: itemMetadata.rarity },
+          { trait_type: 'Category', value: itemData.category },
+          ...tagTraits,
+          ...bodyShapeTraits
+        ]
+      }
+    }
+  }
 }
 
-/** We will prioritize the text in english. If not present, then we will choose the first one */
+/** Prioritize the english variant; otherwise return the first available. */
 function preferEnglish(i18ns: I18N[]): string | undefined {
   const i18nInEnglish = i18ns.filter((i18n) => i18n.code.toLowerCase() === 'en')[0]
   return (i18nInEnglish ?? i18ns[0])?.text
@@ -52,55 +98,4 @@ function getBodyShapes(representations: WearableRepresentation[]) {
 
 function getItemData(itemMetadata: Wearable | Emote): ItemData {
   return (itemMetadata as Emote).emoteDataADR74 ?? (itemMetadata as Wearable).data
-}
-
-export function formatERC721Entity(env: Environment, urn: string, entity: Entity, emission: string | undefined) {
-  const baseUrl = env.getConfig<string>(EnvironmentConfig.CONTENT_SERVER_ADDRESS)
-
-  const itemMetadata: (Wearable | Emote) & StandardProps = entity.metadata
-  const name = preferEnglish(itemMetadata.i18n)
-  const totalEmission = RARITIES_EMISSIONS[itemMetadata.rarity]
-  const description = emission ? `DCL Wearable ${emission}/${totalEmission}` : ''
-
-  const imageHash = findImageHash(entity)
-  const thumbnailHash = findThumbnailHash(entity)
-  const itemData: ItemData = getItemData(itemMetadata)
-  const bodyShapeTraits = getBodyShapes(itemData.representations).reduce(
-    (bodyShapes: ERC721StandardTrait[], bodyShape) => {
-      bodyShapes.push({
-        trait_type: 'Body Shape',
-        value: bodyShape
-      })
-      return bodyShapes
-    },
-    []
-  )
-  const tagTraits = itemData.tags.reduce((tags: ERC721StandardTrait[], tag) => {
-    tags.push({
-      trait_type: 'Tag',
-      value: tag
-    })
-    return tags
-  }, [])
-
-  return {
-    id: urn,
-    name,
-    description,
-    language: 'en-US',
-    image: imageHash ? new URL(`contents/${imageHash}`, baseUrl).toString() : undefined,
-    thumbnail: thumbnailHash ? new URL(`contents/${thumbnailHash}`, baseUrl).toString() : undefined,
-    attributes: [
-      {
-        trait_type: 'Rarity',
-        value: itemMetadata.rarity
-      },
-      {
-        trait_type: 'Category',
-        value: itemData.category
-      },
-      ...tagTraits,
-      ...bodyShapeTraits
-    ]
-  }
 }

--- a/content/src/logic/erc721/index.ts
+++ b/content/src/logic/erc721/index.ts
@@ -1,1 +1,2 @@
-export { buildUrn, formatERC721Entity } from './component'
+export { createErc721 } from './component'
+export type { Erc721Entity, IErc721 } from './types'

--- a/content/src/logic/erc721/types.ts
+++ b/content/src/logic/erc721/types.ts
@@ -1,0 +1,26 @@
+import { Entity } from '@dcl/schemas'
+
+export type Erc721Entity = {
+  id: string
+  name: string | undefined
+  description: string
+  language: string
+  image: string | undefined
+  thumbnail: string | undefined
+  attributes: { trait_type: string; value: string }[]
+}
+
+export interface IErc721 {
+  /**
+   * Build a Decentraland wearable/emote URN for the given protocol, contract address, and item option.
+   * Uses `collections-v2` for `0x`-prefixed contracts and `collections-v1` otherwise.
+   */
+  buildUrn(protocol: string, contract: string, option: string): string
+
+  /**
+   * Build the ERC-721 metadata payload for the given entity, suitable for return from the
+   * `/entities/active/erc721/...` endpoint. `emission` is the rarity-numbered emission suffix
+   * (e.g. `42` → "DCL Wearable 42/100000").
+   */
+  formatERC721Entity(urn: string, entity: Entity, emission: string | undefined): Erc721Entity
+}

--- a/content/src/logic/hashing/component.ts
+++ b/content/src/logic/hashing/component.ts
@@ -1,19 +1,21 @@
 import { hashV0, hashV1 } from '@dcl/hashing'
+import { IHashing } from './types'
 
-export async function calculateIPFSHashes<T extends Uint8Array>(files: T[]): Promise<{ hash: string; file: T }[]> {
-  const entries = Array.from(files).map(async (file) => ({
-    hash: await hashV1(file),
-    file
-  }))
-  return Promise.all(entries)
-}
-
-export async function calculateDeprecatedHashes<T extends Uint8Array>(
-  files: T[]
-): Promise<{ hash: string; file: T }[]> {
-  const entries = Array.from(files).map(async (file) => ({
-    hash: await hashV0(file),
-    file
-  }))
-  return Promise.all(entries)
+export function createHashing(): IHashing {
+  return {
+    async calculateIPFSHashes<T extends Uint8Array>(files: T[]): Promise<{ hash: string; file: T }[]> {
+      const entries = Array.from(files).map(async (file) => ({
+        hash: await hashV1(file),
+        file
+      }))
+      return Promise.all(entries)
+    },
+    async calculateDeprecatedHashes<T extends Uint8Array>(files: T[]): Promise<{ hash: string; file: T }[]> {
+      const entries = Array.from(files).map(async (file) => ({
+        hash: await hashV0(file),
+        file
+      }))
+      return Promise.all(entries)
+    }
+  }
 }

--- a/content/src/logic/hashing/index.ts
+++ b/content/src/logic/hashing/index.ts
@@ -1,1 +1,2 @@
-export { calculateIPFSHashes, calculateDeprecatedHashes } from './component'
+export { createHashing } from './component'
+export type { IHashing } from './types'

--- a/content/src/logic/hashing/types.ts
+++ b/content/src/logic/hashing/types.ts
@@ -1,0 +1,12 @@
+export interface IHashing {
+  /**
+   * Hash the given files with IPFS hash v1 (CIDv1 / `bafy...`).
+   * Used for entities deployed after the IPFS migration.
+   */
+  calculateIPFSHashes<T extends Uint8Array>(files: T[]): Promise<{ hash: string; file: T }[]>
+  /**
+   * Hash the given files with the deprecated v0 hash. Kept to verify and
+   * re-verify the content of legacy entities deployed before the IPFS migration.
+   */
+  calculateDeprecatedHashes<T extends Uint8Array>(files: T[]): Promise<{ hash: string; file: T }[]>
+}

--- a/content/src/logic/query-params/component.ts
+++ b/content/src/logic/query-params/component.ts
@@ -1,28 +1,29 @@
 import qs from 'qs'
 import { QueryParams } from '../../types'
+import { IQueryParams } from './types'
 
-export function qsParser(rawQueryParams: URLSearchParams): QueryParams {
-  return qs.parse(rawQueryParams.toString(), { parseArrays: true })
-}
-
-export function qsGetArray(queryParams: QueryParams, paramName: string): string[] {
-  const parsedParam = (queryParams[paramName] as string[]) || []
-  return Array.isArray(parsedParam) ? parsedParam : [parsedParam]
-}
-
-export function qsGetNumber(queryParams: QueryParams, paramName: string): number | undefined {
-  if (!queryParams[paramName]) return undefined
-  const num = parseInt(queryParams[paramName] as string, 10)
-  return isNaN(num) ? undefined : num
-}
-
-export function qsGetBoolean(queryParams: QueryParams, paramName: string): boolean | undefined {
-  return queryParams[paramName] ? queryParams[paramName] === 'true' : undefined
-}
-
-export function toQueryParams(filters: Record<string, any>): string {
-  const entries = convertFiltersToQueryParams(filters)
-  return qs.stringify(Object.fromEntries(entries), { arrayFormat: 'repeat' })
+export function createQueryParams(): IQueryParams {
+  return {
+    qsParser(rawQueryParams: URLSearchParams): QueryParams {
+      return qs.parse(rawQueryParams.toString(), { parseArrays: true })
+    },
+    qsGetArray(queryParams: QueryParams, paramName: string): string[] {
+      const parsedParam = (queryParams[paramName] as string[]) || []
+      return Array.isArray(parsedParam) ? parsedParam : [parsedParam]
+    },
+    qsGetNumber(queryParams: QueryParams, paramName: string): number | undefined {
+      if (!queryParams[paramName]) return undefined
+      const num = parseInt(queryParams[paramName] as string, 10)
+      return isNaN(num) ? undefined : num
+    },
+    qsGetBoolean(queryParams: QueryParams, paramName: string): boolean | undefined {
+      return queryParams[paramName] ? queryParams[paramName] === 'true' : undefined
+    },
+    toQueryParams(filters: Record<string, any>): string {
+      const entries = convertFiltersToQueryParams(filters)
+      return qs.stringify(Object.fromEntries(entries), { arrayFormat: 'repeat' })
+    }
+  }
 }
 
 function convertFiltersToQueryParams(filters?: Record<string, any>): Map<string, string[]> {
@@ -34,7 +35,6 @@ function convertFiltersToQueryParams(filters?: Record<string, any>): Map<string,
     .map<[string, string[]]>(([name, value]) => {
       let newName = name
       let newValues: string[]
-      // Force coercion of number, boolean, or string into string
       if (Array.isArray(value)) {
         newName = name.endsWith('s') ? name.slice(0, -1) : newName
         newValues = [...value].filter(isValidQueryParamValue).map((_) => `${_}`)

--- a/content/src/logic/query-params/index.ts
+++ b/content/src/logic/query-params/index.ts
@@ -1,1 +1,2 @@
-export { qsParser, qsGetArray, qsGetNumber, qsGetBoolean, toQueryParams } from './component'
+export { createQueryParams } from './component'
+export type { IQueryParams } from './types'

--- a/content/src/logic/query-params/types.ts
+++ b/content/src/logic/query-params/types.ts
@@ -1,0 +1,14 @@
+import { QueryParams } from '../../types'
+
+export interface IQueryParams {
+  /** Parse a raw `URLSearchParams` into the qs-style nested object the rest of the helpers operate on. */
+  qsParser(rawQueryParams: URLSearchParams): QueryParams
+  /** Read a query-string param as a string array. Returns `[]` if missing. Accepts both repeated keys and a single value. */
+  qsGetArray(queryParams: QueryParams, paramName: string): string[]
+  /** Read a query-string param as a number, or `undefined` if missing or unparseable. */
+  qsGetNumber(queryParams: QueryParams, paramName: string): number | undefined
+  /** Read a query-string param as a boolean, or `undefined` if missing. Anything other than `'true'` is treated as `false`. */
+  qsGetBoolean(queryParams: QueryParams, paramName: string): boolean | undefined
+  /** Serialize the given filters back into a query string. Drops falsy values; arrays use the `repeat` format. */
+  toQueryParams(filters: Record<string, any>): string
+}

--- a/content/src/logic/snapshots/component.ts
+++ b/content/src/logic/snapshots/component.ts
@@ -8,157 +8,142 @@ import {
   isTimeRangeCoveredBy,
   MS_PER_MONTH
 } from '../time-range'
+import { ISnapshots } from './types'
 
-export async function generateAndStoreSnapshot(
-  components: Pick<
-    AppComponents,
-    'fs' | 'metrics' | 'storage' | 'logs' | 'denylist' | 'staticConfigs' | 'snapshotsRepository'
-  >,
-  database: DatabaseClient,
-  timeRange: TimeRange,
-  reason?: string
-): Promise<{
-  hash: string
-  numberOfEntities: number
-}> {
-  const { end: endTimer } = components.metrics.startTimer('dcl_content_server_snapshot_generation_time', {
-    interval_size: intervalSizeLabel(timeRange),
-    reason: reason || 'unknown'
-  })
-  let numberOfEntities = 0
-  let fileWriter: IFile | undefined
-  try {
-    fileWriter = await createFileWriter(components, 'tmp-all-entities-snapshot')
-    // this header is necessary to later differentiate between binary formats and non-binary formats
-    await fileWriter.appendDebounced('### Decentraland json snapshot\n')
-    for await (const snapshotElem of components.snapshotsRepository.streamActiveDeploymentsInTimeRange(
-      database,
-      timeRange
-    )) {
-      const stringifiedElement = JSON.stringify(snapshotElem) + '\n'
-      await fileWriter.appendDebounced(stringifiedElement)
-      numberOfEntities++
-    }
-    const storedHash = await fileWriter.store()
-    endTimer({ result: 'success' })
-    return {
-      hash: storedHash,
-      numberOfEntities
-    }
-  } catch (error) {
-    endTimer({ result: 'error' })
-    throw error
-  } finally {
-    if (fileWriter) await fileWriter.close()
-  }
-}
-
-export async function generateSnapshotsInMultipleTimeRanges(
+export function createSnapshots(
   components: Pick<
     AppComponents,
     'database' | 'fs' | 'metrics' | 'storage' | 'logs' | 'denylist' | 'staticConfigs' | 'snapshotsRepository'
-  >,
-  timeRangeToDivide: TimeRange
-): Promise<SnapshotMetadata[]> {
-  const logger = components.logs.getLogger('snapshot-generation')
-  const snapshotMetadatas: SnapshotMetadata[] = []
-  const timeRangeDivision = divideTimeInYearsMonthsWeeksAndDays(timeRangeToDivide)
-  for (const timeRange of timeRangeDivision.intervals) {
-    const savedSnapshots = await components.snapshotsRepository.findSnapshotsStrictlyContainedInTimeRange(
-      components.database,
-      timeRange
-    )
+  >
+): ISnapshots {
+  const { database, metrics, storage, logs, snapshotsRepository } = components
 
-    const isTimeRangeCoveredByOtherSnapshots = isTimeRangeCoveredBy(
-      timeRange,
-      savedSnapshots.map((s) => s.timeRange)
-    )
-    const multipleSnapshotsShouldBeReplaced = isTimeRangeCoveredByOtherSnapshots && savedSnapshots.length > 1
-    const existSnapshots = await components.storage.existMultiple(savedSnapshots.map((s) => s.hash))
-    const allSavedSnapshotsAreStored = Array.from(existSnapshots.values()).every((exist) => exist == true)
-    const snapshotHasInactiveEntities =
-      savedSnapshots.length == 1 &&
-      // If snapshot is 1 month old, we recompile it if there are inactive entities
-      savedSnapshots[0].generationTimestamp < Date.now() - MS_PER_MONTH &&
-      (await components.snapshotsRepository.getNumberOfActiveEntitiesInTimeRange(
-        components.database,
-        savedSnapshots[0].timeRange
-      )) < savedSnapshots[0].numberOfEntities
+  async function generateAndStoreSnapshot(
+    db: DatabaseClient,
+    timeRange: TimeRange,
+    reason?: string
+  ): Promise<{ hash: string; numberOfEntities: number }> {
+    const { end: endTimer } = metrics.startTimer('dcl_content_server_snapshot_generation_time', {
+      interval_size: intervalSizeLabel(timeRange),
+      reason: reason || 'unknown'
+    })
+    let numberOfEntities = 0
+    let fileWriter: IFile | undefined
+    try {
+      fileWriter = await createFileWriter(components, 'tmp-all-entities-snapshot')
+      // Header marks this as the json format (vs. the binary format) for downstream readers.
+      await fileWriter.appendDebounced('### Decentraland json snapshot\n')
+      for await (const snapshotElem of snapshotsRepository.streamActiveDeploymentsInTimeRange(db, timeRange)) {
+        const stringifiedElement = JSON.stringify(snapshotElem) + '\n'
+        await fileWriter.appendDebounced(stringifiedElement)
+        numberOfEntities++
+      }
+      const storedHash = await fileWriter.store()
+      endTimer({ result: 'success' })
+      return { hash: storedHash, numberOfEntities }
+    } catch (error) {
+      endTimer({ result: 'error' })
+      throw error
+    } finally {
+      if (fileWriter) await fileWriter.close()
+    }
+  }
 
-    const isOutdated =
-      savedSnapshots.length == 1 &&
-      (await components.snapshotsRepository.snapshotIsOutdated(components.database, savedSnapshots[0]))
+  async function generateSnapshotsInMultipleTimeRanges(timeRangeToDivide: TimeRange): Promise<SnapshotMetadata[]> {
+    const logger = logs.getLogger('snapshot-generation')
+    const snapshotMetadatas: SnapshotMetadata[] = []
+    const timeRangeDivision = divideTimeInYearsMonthsWeeksAndDays(timeRangeToDivide)
+    for (const timeRange of timeRangeDivision.intervals) {
+      const savedSnapshots = await snapshotsRepository.findSnapshotsStrictlyContainedInTimeRange(database, timeRange)
 
-    const shouldGenerateNewSnapshot =
-      !isTimeRangeCoveredByOtherSnapshots ||
-      multipleSnapshotsShouldBeReplaced ||
-      !allSavedSnapshotsAreStored ||
-      snapshotHasInactiveEntities ||
-      isOutdated
-
-    if (shouldGenerateNewSnapshot) {
-      logger.info(
-        JSON.stringify({
-          generatingInterval: `[${new Date(timeRange.initTimestamp).toISOString()}, ${new Date(
-            timeRange.endTimestamp
-          ).toISOString()}]`,
-          isTimeRangeCoveredByOtherSnapshots,
-          multipleSnapshotsShouldBeReplaced,
-          allSavedSnapshotsAreStored,
-          snapshotHasInactiveEntities,
-          isOutdated
-        })
-      )
-
-      const { hash, numberOfEntities } = await generateAndStoreSnapshot(
-        components,
-        components.database,
+      const isTimeRangeCoveredByOtherSnapshots = isTimeRangeCoveredBy(
         timeRange,
-        getReasonForMetric({
-          isTimeRangeCoveredByOtherSnapshots,
-          multipleSnapshotsShouldBeReplaced,
-          allSavedSnapshotsAreStored,
-          snapshotHasInactiveEntities,
-          isOutdated
-        })
+        savedSnapshots.map((s) => s.timeRange)
       )
-      const savedSnapshotHashes = savedSnapshots.map((s) => s.hash)
-      await components.database.transaction(async (txDatabase) => {
-        const replacedSnapshotHashes =
-          isTimeRangeCoveredByOtherSnapshots || snapshotHasInactiveEntities ? savedSnapshotHashes : []
-        const newSnapshot = {
-          hash,
+      const multipleSnapshotsShouldBeReplaced = isTimeRangeCoveredByOtherSnapshots && savedSnapshots.length > 1
+      const existSnapshots = await storage.existMultiple(savedSnapshots.map((s) => s.hash))
+      const allSavedSnapshotsAreStored = Array.from(existSnapshots.values()).every((exist) => exist == true)
+      const snapshotHasInactiveEntities =
+        savedSnapshots.length == 1 &&
+        // If snapshot is 1 month old, we recompile it if there are inactive entities
+        savedSnapshots[0].generationTimestamp < Date.now() - MS_PER_MONTH &&
+        (await snapshotsRepository.getNumberOfActiveEntitiesInTimeRange(database, savedSnapshots[0].timeRange)) <
+          savedSnapshots[0].numberOfEntities
+
+      const isOutdated =
+        savedSnapshots.length == 1 && (await snapshotsRepository.snapshotIsOutdated(database, savedSnapshots[0]))
+
+      const shouldGenerateNewSnapshot =
+        !isTimeRangeCoveredByOtherSnapshots ||
+        multipleSnapshotsShouldBeReplaced ||
+        !allSavedSnapshotsAreStored ||
+        snapshotHasInactiveEntities ||
+        isOutdated
+
+      if (shouldGenerateNewSnapshot) {
+        logger.info(
+          JSON.stringify({
+            generatingInterval: `[${new Date(timeRange.initTimestamp).toISOString()}, ${new Date(
+              timeRange.endTimestamp
+            ).toISOString()}]`,
+            isTimeRangeCoveredByOtherSnapshots,
+            multipleSnapshotsShouldBeReplaced,
+            allSavedSnapshotsAreStored,
+            snapshotHasInactiveEntities,
+            isOutdated
+          })
+        )
+
+        const { hash, numberOfEntities } = await generateAndStoreSnapshot(
+          database,
           timeRange,
-          replacedSnapshotHashes,
-          numberOfEntities,
-          generationTimestamp: Date.now()
-        }
-        const snapshotHashesUsedInOtherTimeRanges =
-          await components.snapshotsRepository.getSnapshotHashesNotInTimeRange(
+          getReasonForMetric({
+            isTimeRangeCoveredByOtherSnapshots,
+            multipleSnapshotsShouldBeReplaced,
+            allSavedSnapshotsAreStored,
+            snapshotHasInactiveEntities,
+            isOutdated
+          })
+        )
+        const savedSnapshotHashes = savedSnapshots.map((s) => s.hash)
+        await database.transaction(async (txDatabase) => {
+          const replacedSnapshotHashes =
+            isTimeRangeCoveredByOtherSnapshots || snapshotHasInactiveEntities ? savedSnapshotHashes : []
+          const newSnapshot = {
+            hash,
+            timeRange,
+            replacedSnapshotHashes,
+            numberOfEntities,
+            generationTimestamp: Date.now()
+          }
+          const snapshotHashesUsedInOtherTimeRanges = await snapshotsRepository.getSnapshotHashesNotInTimeRange(
             txDatabase,
             savedSnapshotHashes,
             timeRange
           )
-        const snapshotHashesToDeleteInStorage = savedSnapshotHashes.filter(
-          (hash) => !snapshotHashesUsedInOtherTimeRanges.has(hash) && hash != newSnapshot.hash
+          const snapshotHashesToDeleteInStorage = savedSnapshotHashes.filter(
+            (hash) => !snapshotHashesUsedInOtherTimeRanges.has(hash) && hash != newSnapshot.hash
+          )
+          // The order is important; a snapshot we save can share its hash with one we delete.
+          await snapshotsRepository.deleteSnapshotsInTimeRange(txDatabase, savedSnapshotHashes, timeRange)
+          await snapshotsRepository.saveSnapshot(txDatabase, newSnapshot)
+          logger.info(`Snapshots to delete: ${JSON.stringify(Array.from(snapshotHashesToDeleteInStorage))}`)
+          await storage.delete(snapshotHashesToDeleteInStorage)
+          snapshotMetadatas.push(newSnapshot)
+        }, 'tx_snapshot')
+        logger.info(
+          `Snapshot generated for interval: [${new Date(timeRange.initTimestamp).toISOString()}, ${new Date(
+            timeRange.endTimestamp
+          ).toISOString()}]. Hash: ${hash}.`
         )
-        // The order is important, the snapshot to save could have the same hash of one of the ones to be deleted
-        await components.snapshotsRepository.deleteSnapshotsInTimeRange(txDatabase, savedSnapshotHashes, timeRange)
-        await components.snapshotsRepository.saveSnapshot(txDatabase, newSnapshot)
-        logger.info(`Snapshots to delete: ${JSON.stringify(Array.from(snapshotHashesToDeleteInStorage))}`)
-        await components.storage.delete(snapshotHashesToDeleteInStorage)
-        snapshotMetadatas.push(newSnapshot)
-      }, 'tx_snapshot')
-      logger.info(
-        `Snapshot generated for interval: [${new Date(timeRange.initTimestamp).toISOString()}, ${new Date(
-          timeRange.endTimestamp
-        ).toISOString()}]. Hash: ${hash}.`
-      )
-    } else {
-      snapshotMetadatas.push(...savedSnapshots)
+      } else {
+        snapshotMetadatas.push(...savedSnapshots)
+      }
     }
+    return snapshotMetadatas
   }
-  return snapshotMetadatas
+
+  return { generateAndStoreSnapshot, generateSnapshotsInMultipleTimeRanges }
 }
 
 function getReasonForMetric(props: {
@@ -168,16 +153,10 @@ function getReasonForMetric(props: {
   snapshotHasInactiveEntities: boolean
   isOutdated: boolean
 }): string {
-  if (!props.isTimeRangeCoveredByOtherSnapshots) {
-    return 'cover_time_range'
-  } else if (props.multipleSnapshotsShouldBeReplaced) {
-    return 'replace_multiple_snapshots'
-  } else if (!props.allSavedSnapshotsAreStored) {
-    return 'snapshots_not_stored'
-  } else if (props.snapshotHasInactiveEntities) {
-    return 'inactive_entities'
-  } else if (props.isOutdated) {
-    return 'is_outdated'
-  }
+  if (!props.isTimeRangeCoveredByOtherSnapshots) return 'cover_time_range'
+  if (props.multipleSnapshotsShouldBeReplaced) return 'replace_multiple_snapshots'
+  if (!props.allSavedSnapshotsAreStored) return 'snapshots_not_stored'
+  if (props.snapshotHasInactiveEntities) return 'inactive_entities'
+  if (props.isOutdated) return 'is_outdated'
   return 'unknown'
 }

--- a/content/src/logic/snapshots/index.ts
+++ b/content/src/logic/snapshots/index.ts
@@ -1,1 +1,2 @@
-export { generateAndStoreSnapshot, generateSnapshotsInMultipleTimeRanges } from './component'
+export { createSnapshots } from './component'
+export type { ISnapshots } from './types'

--- a/content/src/logic/snapshots/types.ts
+++ b/content/src/logic/snapshots/types.ts
@@ -1,0 +1,23 @@
+import { SnapshotMetadata, TimeRange } from '@dcl/snapshots-fetcher/dist/types'
+import { DatabaseClient } from '../../adapters/database'
+
+export interface ISnapshots {
+  /**
+   * Stream every active deployment in `timeRange` into a single snapshot file and store it.
+   * Returns the storage hash and the number of streamed entities. `reason` is a free-form
+   * label included in metrics so generations triggered by different code paths can be told apart.
+   */
+  generateAndStoreSnapshot(
+    database: DatabaseClient,
+    timeRange: TimeRange,
+    reason?: string
+  ): Promise<{ hash: string; numberOfEntities: number }>
+
+  /**
+   * Divide `timeRangeToDivide` into year/month/week/day intervals and ensure each one is
+   * backed by an up-to-date snapshot, regenerating when necessary (missing storage,
+   * outdated, has too many inactive entities, or is covered by multiple older snapshots).
+   * Returns the final metadata for every interval.
+   */
+  generateSnapshotsInMultipleTimeRanges(timeRangeToDivide: TimeRange): Promise<SnapshotMetadata[]>
+}

--- a/content/src/logic/third-party-item-checker/component.ts
+++ b/content/src/logic/third-party-item-checker/component.ts
@@ -1,9 +1,9 @@
 import { ThirdPartyItemChecker } from '@dcl/content-validator'
 import RequestManager, { ContractFactory, HTTPProvider, RPCSendableMessage, toData } from 'eth-connect'
-import { ILoggerComponent } from '@well-known-components/interfaces'
 import { BlockchainCollectionThirdPartyItem, parseUrn } from '@dcl/urn-resolver'
 import { erc1155Abi, erc721Abi, sendBatch } from '../contract-helpers'
 import { ContractType, ThirdPartyContractRegistry } from '../third-party-contract-registry'
+import { AppComponents } from '../../types'
 
 type TempData = {
   urn: string
@@ -15,8 +15,15 @@ type TempData = {
 
 const EMPTY_MESSAGE = '0x'
 
+/**
+ * Build a ThirdPartyItemChecker bound to a specific chain (its `provider`) and
+ * the matching contract registry. There are typically two instances of this
+ * component — one for L1 and one for L2 — so the per-chain `provider` and
+ * `thirdPartyContractRegistry` are passed in positionally instead of via
+ * `AppComponents`.
+ */
 export async function createThirdPartyItemChecker(
-  logs: ILoggerComponent,
+  { logs }: Pick<AppComponents, 'logs'>,
   provider: HTTPProvider,
   thirdPartyContractRegistry: ThirdPartyContractRegistry
 ): Promise<ThirdPartyItemChecker> {

--- a/content/src/logic/third-party-item-checker/index.ts
+++ b/content/src/logic/third-party-item-checker/index.ts
@@ -1,1 +1,2 @@
 export { createThirdPartyItemChecker } from './component'
+export type { ThirdPartyItemChecker } from './types'

--- a/content/src/logic/third-party-item-checker/types.ts
+++ b/content/src/logic/third-party-item-checker/types.ts
@@ -1,0 +1,1 @@
+export type { ThirdPartyItemChecker } from '@dcl/content-validator'

--- a/content/src/types.ts
+++ b/content/src/types.ts
@@ -47,6 +47,11 @@ import { IContentClusterComponent } from './logic/peer-cluster'
 import { IRetryFailedDeploymentsComponent } from './logic/retry-failed-deployments'
 import { ProcessedSnapshotsStorageComponent } from './adapters/processed-snapshot-storage'
 import { IDeploymentsComponent } from './logic/deployments'
+import { IHashing } from './logic/hashing'
+import { IQueryParams } from './logic/query-params'
+import { IEntityParser } from './logic/entity-parser'
+import { IErc721 } from './logic/erc721'
+import { ISnapshots } from './logic/snapshots'
 import { IJobComponent } from '@dcl/job-component'
 
 // Minimum amount of needed stuff to make the sync work
@@ -124,6 +129,11 @@ export type AppComponents = {
   snapshotStorage: ISnapshotStorageComponent
   l1Provider: HTTPProvider
   tracer: ITracerComponent
+  hashing: IHashing
+  queryParams: IQueryParams
+  entityParser: IEntityParser
+  erc721: IErc721
+  snapshots: ISnapshots
 }
 
 export type GlobalContext = {

--- a/content/test/integration/E2ETestUtils.ts
+++ b/content/test/integration/E2ETestUtils.ts
@@ -6,8 +6,10 @@ import fs from 'fs'
 import path from 'path'
 import { DeploymentContext, DeploymentResult, isInvalidDeployment } from '../../src/deployment-types'
 import { retry } from '../../src/helpers/RetryHelper'
-import { getEntityFromBuffer } from '../../src/logic/entity-parser'
+import { createEntityParser } from '../../src/logic/entity-parser'
 import { Deployer } from '../../src/logic/deployment-service'
+
+const entityParser = createEntityParser()
 
 export async function buildDeployDataAfterEntity(
   afterEntity: { timestamp: number } | { entity: { timestamp: number } },
@@ -54,7 +56,7 @@ export async function buildDeployData(pointers: string[], options?: DeploymentOp
     throw new Error('Unexpected error: no content')
   }
 
-  const entity: Entity = getEntityFromBuffer(content, deploymentPreparationData.entityId)
+  const entity: Entity = entityParser.parse(content, deploymentPreparationData.entityId)
 
   const deployData: DeploymentData = {
     entityId: entity.id,

--- a/content/test/integration/controller/deployment-pagination.spec.ts
+++ b/content/test/integration/controller/deployment-pagination.spec.ts
@@ -2,7 +2,9 @@ import { EntityType } from '@dcl/schemas'
 import { createFetchComponent } from '@well-known-components/fetch-component'
 import { DeploymentField } from '../../../src/types'
 import { DeploymentOptions, SortingField, SortingOrder } from '../../../src/deployment-types'
-import { toQueryParams } from '../../../src/logic/query-params'
+import { createQueryParams } from '../../../src/logic/query-params'
+
+const { toQueryParams } = createQueryParams()
 import { PointerChangesFilters } from '../../../src/logic/deployments'
 import { makeNoopValidator } from '../../helpers/logic/server-validator/NoOpValidator'
 import { buildDeployData, EntityCombo } from '../E2ETestUtils'

--- a/content/test/integration/controller/deployment-pagination.spec.ts
+++ b/content/test/integration/controller/deployment-pagination.spec.ts
@@ -3,14 +3,14 @@ import { createFetchComponent } from '@well-known-components/fetch-component'
 import { DeploymentField } from '../../../src/types'
 import { DeploymentOptions, SortingField, SortingOrder } from '../../../src/deployment-types'
 import { createQueryParams } from '../../../src/logic/query-params'
-
-const { toQueryParams } = createQueryParams()
 import { PointerChangesFilters } from '../../../src/logic/deployments'
 import { makeNoopValidator } from '../../helpers/logic/server-validator/NoOpValidator'
 import { buildDeployData, EntityCombo } from '../E2ETestUtils'
 import { resetServer, createDefaultServer } from '../simpleTestEnvironment'
 import { TestProgram } from '../TestProgram'
 import LeakDetector from 'jest-leak-detector'
+
+const { toQueryParams } = createQueryParams()
 
 describe('Integration - Deployment Pagination', () => {
   const fetcher = createFetchComponent()

--- a/content/test/integration/logic/delete-unreferenced-files.spec.ts
+++ b/content/test/integration/logic/delete-unreferenced-files.spec.ts
@@ -45,6 +45,7 @@ describe('Delete unreferenced files - ', () => {
     await server.deployEntity(deployResult.deployData)
 
     const contentsByHash: Map<string, Uint8Array> = await hashFiles(
+      components.hashing,
       deployResult.deployData.files,
       deployResult.deployData.entityId
     )
@@ -73,6 +74,7 @@ describe('Delete unreferenced files - ', () => {
     await server.deployEntity(deployResult.deployData)
 
     const contentsByHash: Map<string, Uint8Array> = await hashFiles(
+      components.hashing,
       deployResult.deployData.files,
       deployResult.deployData.entityId
     )
@@ -121,6 +123,7 @@ describe('Delete unreferenced files - ', () => {
     await server.deployEntity(deployResult.deployData)
 
     const contentsByHash: Map<string, Uint8Array> = await hashFiles(
+      components.hashing,
       deployResult.deployData.files,
       deployResult.deployData.entityId
     )

--- a/content/test/integration/logic/snapshots.spec.ts
+++ b/content/test/integration/logic/snapshots.spec.ts
@@ -1,7 +1,7 @@
 import { EntityType } from '@dcl/schemas'
 import { IBaseComponent } from '@well-known-components/interfaces'
 import { DeploymentContext } from '../../../src/deployment-types'
-import { generateSnapshotsInMultipleTimeRanges } from '../../../src/logic/snapshots'
+
 import * as timeRangeLogic from '../../../src/logic/time-range'
 import { AppComponents } from '../../../src/types'
 import { makeNoopServerValidator, makeNoopValidator } from '../../helpers/logic/server-validator/NoOpValidator'
@@ -25,7 +25,7 @@ describe('snapshot generator - ', () => {
 
     const timeRange = timeRangeOfDaysFromInitialTimestamp(1)
 
-    const snapshots = await generateSnapshotsInMultipleTimeRanges(components, timeRange)
+    const snapshots = await components.snapshots.generateSnapshotsInMultipleTimeRanges(timeRange)
     expect(divideTimeSpy).toBeCalledWith(timeRange)
     expect(snapshots).toEqual(expect.arrayContaining([expect.objectContaining(emptySnapshot)]))
     if (snapshots) {
@@ -39,8 +39,8 @@ describe('snapshot generator - ', () => {
     'should generate the second snapshot but not recreate the first one',
     async (components) => {
       await startSnapshotNeededComponents(components)
-      await generateSnapshotsInMultipleTimeRanges(components, timeRangeOfDaysFromInitialTimestamp(1))
-      const snapshots = await generateSnapshotsInMultipleTimeRanges(components, timeRangeOfDaysFromInitialTimestamp(2))
+      await components.snapshots.generateSnapshotsInMultipleTimeRanges(timeRangeOfDaysFromInitialTimestamp(1))
+      const snapshots = await components.snapshots.generateSnapshotsInMultipleTimeRanges(timeRangeOfDaysFromInitialTimestamp(2))
 
       expect(snapshots).toEqual(
         expect.arrayContaining([expect.objectContaining(emptySnapshot), expect.objectContaining(emptySnapshot)])
@@ -53,13 +53,13 @@ describe('snapshot generator - ', () => {
     'should generate seven daily snapshots once time each and do not create weekly one yet',
     async (components) => {
       await startSnapshotNeededComponents(components)
-      await generateSnapshotsInMultipleTimeRanges(components, timeRangeOfDaysFromInitialTimestamp(1))
-      await generateSnapshotsInMultipleTimeRanges(components, timeRangeOfDaysFromInitialTimestamp(2))
-      await generateSnapshotsInMultipleTimeRanges(components, timeRangeOfDaysFromInitialTimestamp(3))
-      await generateSnapshotsInMultipleTimeRanges(components, timeRangeOfDaysFromInitialTimestamp(4))
-      await generateSnapshotsInMultipleTimeRanges(components, timeRangeOfDaysFromInitialTimestamp(5))
-      await generateSnapshotsInMultipleTimeRanges(components, timeRangeOfDaysFromInitialTimestamp(6))
-      const snapshots = await generateSnapshotsInMultipleTimeRanges(components, timeRangeOfDaysFromInitialTimestamp(7))
+      await components.snapshots.generateSnapshotsInMultipleTimeRanges(timeRangeOfDaysFromInitialTimestamp(1))
+      await components.snapshots.generateSnapshotsInMultipleTimeRanges(timeRangeOfDaysFromInitialTimestamp(2))
+      await components.snapshots.generateSnapshotsInMultipleTimeRanges(timeRangeOfDaysFromInitialTimestamp(3))
+      await components.snapshots.generateSnapshotsInMultipleTimeRanges(timeRangeOfDaysFromInitialTimestamp(4))
+      await components.snapshots.generateSnapshotsInMultipleTimeRanges(timeRangeOfDaysFromInitialTimestamp(5))
+      await components.snapshots.generateSnapshotsInMultipleTimeRanges(timeRangeOfDaysFromInitialTimestamp(6))
+      const snapshots = await components.snapshots.generateSnapshotsInMultipleTimeRanges(timeRangeOfDaysFromInitialTimestamp(7))
 
       expect(snapshots).toEqual(
         expect.arrayContaining([
@@ -80,15 +80,15 @@ describe('snapshot generator - ', () => {
     'should generate a weekly snapshot replacing seven daily snapshots and a daily one, at the 8th day',
     async (components) => {
       await startSnapshotNeededComponents(components)
-      await generateSnapshotsInMultipleTimeRanges(components, timeRangeOfDaysFromInitialTimestamp(1))
-      await generateSnapshotsInMultipleTimeRanges(components, timeRangeOfDaysFromInitialTimestamp(2))
-      await generateSnapshotsInMultipleTimeRanges(components, timeRangeOfDaysFromInitialTimestamp(3))
-      await generateSnapshotsInMultipleTimeRanges(components, timeRangeOfDaysFromInitialTimestamp(4))
-      await generateSnapshotsInMultipleTimeRanges(components, timeRangeOfDaysFromInitialTimestamp(5))
-      await generateSnapshotsInMultipleTimeRanges(components, timeRangeOfDaysFromInitialTimestamp(6))
-      await generateSnapshotsInMultipleTimeRanges(components, timeRangeOfDaysFromInitialTimestamp(7))
+      await components.snapshots.generateSnapshotsInMultipleTimeRanges(timeRangeOfDaysFromInitialTimestamp(1))
+      await components.snapshots.generateSnapshotsInMultipleTimeRanges(timeRangeOfDaysFromInitialTimestamp(2))
+      await components.snapshots.generateSnapshotsInMultipleTimeRanges(timeRangeOfDaysFromInitialTimestamp(3))
+      await components.snapshots.generateSnapshotsInMultipleTimeRanges(timeRangeOfDaysFromInitialTimestamp(4))
+      await components.snapshots.generateSnapshotsInMultipleTimeRanges(timeRangeOfDaysFromInitialTimestamp(5))
+      await components.snapshots.generateSnapshotsInMultipleTimeRanges(timeRangeOfDaysFromInitialTimestamp(6))
+      await components.snapshots.generateSnapshotsInMultipleTimeRanges(timeRangeOfDaysFromInitialTimestamp(7))
       const before = Date.now()
-      const snapshots = await generateSnapshotsInMultipleTimeRanges(components, timeRangeOfDaysFromInitialTimestamp(8))
+      const snapshots = await components.snapshots.generateSnapshotsInMultipleTimeRanges(timeRangeOfDaysFromInitialTimestamp(8))
       const after = Date.now()
 
       const weeklySnapshot = snapshots[0]
@@ -130,14 +130,14 @@ describe('snapshot generator - ', () => {
     'should generate a weekly snapshot and do not replace the daily ones if they are not 7, at the 8th day',
     async (components) => {
       await startSnapshotNeededComponents(components)
-      await generateSnapshotsInMultipleTimeRanges(components, timeRangeOfDaysFromInitialTimestamp(1))
-      await generateSnapshotsInMultipleTimeRanges(components, timeRangeOfDaysFromInitialTimestamp(2))
-      await generateSnapshotsInMultipleTimeRanges(components, timeRangeOfDaysFromInitialTimestamp(3))
-      await generateSnapshotsInMultipleTimeRanges(components, timeRangeOfDaysFromInitialTimestamp(4))
-      await generateSnapshotsInMultipleTimeRanges(components, timeRangeOfDaysFromInitialTimestamp(5))
+      await components.snapshots.generateSnapshotsInMultipleTimeRanges(timeRangeOfDaysFromInitialTimestamp(1))
+      await components.snapshots.generateSnapshotsInMultipleTimeRanges(timeRangeOfDaysFromInitialTimestamp(2))
+      await components.snapshots.generateSnapshotsInMultipleTimeRanges(timeRangeOfDaysFromInitialTimestamp(3))
+      await components.snapshots.generateSnapshotsInMultipleTimeRanges(timeRangeOfDaysFromInitialTimestamp(4))
+      await components.snapshots.generateSnapshotsInMultipleTimeRanges(timeRangeOfDaysFromInitialTimestamp(5))
       // now we supose the server is down for a few days, so 6th and 7th daily snapshots are not generated
       const before = Date.now()
-      const snapshots = await generateSnapshotsInMultipleTimeRanges(components, timeRangeOfDaysFromInitialTimestamp(8))
+      const snapshots = await components.snapshots.generateSnapshotsInMultipleTimeRanges(timeRangeOfDaysFromInitialTimestamp(8))
       const after = Date.now()
 
       const weeklySnapshot = snapshots[0]
@@ -186,7 +186,7 @@ describe('snapshot generator - ', () => {
       // deploy entity for the 7nd snapshot
       await deployAnEntityAtTimestamp(components, '0x00007', daysAfterInitialTimestamp(6) + 1)
 
-      const snapshots = await generateSnapshotsInMultipleTimeRanges(components, timeRangeOfDaysFromInitialTimestamp(7))
+      const snapshots = await components.snapshots.generateSnapshotsInMultipleTimeRanges(timeRangeOfDaysFromInitialTimestamp(7))
       expect(snapshots).toEqual(
         expect.arrayContaining([
           expect.objectContaining({ numberOfEntities: 1 }),
@@ -221,7 +221,7 @@ describe('snapshot generator - ', () => {
       // deploy entity for the 7nd snapshot
       await deployAnEntityAtTimestamp(components, '0x00007', daysAfterInitialTimestamp(6) + 1)
 
-      const snapshots = await generateSnapshotsInMultipleTimeRanges(components, timeRangeOfDaysFromInitialTimestamp(8))
+      const snapshots = await components.snapshots.generateSnapshotsInMultipleTimeRanges(timeRangeOfDaysFromInitialTimestamp(8))
       expect(snapshots).toEqual(
         expect.arrayContaining([
           expect.objectContaining({ numberOfEntities: 4 }),
@@ -241,7 +241,7 @@ describe('snapshot generator - ', () => {
     // deploy entity for the 1st snapshot with the same pointer and overwrite the pointer
     await deployAnEntityAtTimestamp(components, '0x00000', daysAfterInitialTimestamp(0) + 1)
 
-    const snapshots = await generateSnapshotsInMultipleTimeRanges(components, timeRangeOfDaysFromInitialTimestamp(1))
+    const snapshots = await components.snapshots.generateSnapshotsInMultipleTimeRanges(timeRangeOfDaysFromInitialTimestamp(1))
     expect(snapshots).toEqual(expect.arrayContaining([expect.objectContaining({ numberOfEntities: 1 })]))
   })
 
@@ -255,7 +255,7 @@ describe('snapshot generator - ', () => {
     const storeSpy = jest.spyOn(components.storage, 'storeStreamAndCompress')
 
     // snapshot is generated and assert is correctly stored
-    const snapshots = await generateSnapshotsInMultipleTimeRanges(components, timeRangeOfDaysFromInitialTimestamp(1))
+    const snapshots = await components.snapshots.generateSnapshotsInMultipleTimeRanges(timeRangeOfDaysFromInitialTimestamp(1))
 
     expect(snapshots).toEqual(expect.arrayContaining([expect.objectContaining({ numberOfEntities: 1 })]))
     expect(storeSpy).toBeCalledWith(snapshots[0].hash, expect.anything())
@@ -267,7 +267,7 @@ describe('snapshot generator - ', () => {
     expect(await components.storage.exist(snapshots[0].hash)).toBeFalsy()
 
     // now the snapshot is re-generated and stored again
-    const snapshots2 = await generateSnapshotsInMultipleTimeRanges(components, timeRangeOfDaysFromInitialTimestamp(1))
+    const snapshots2 = await components.snapshots.generateSnapshotsInMultipleTimeRanges(timeRangeOfDaysFromInitialTimestamp(1))
     expect(snapshots2).toEqual(expect.arrayContaining([expect.objectContaining({ numberOfEntities: 1 })]))
     expect(storeSpy).toBeCalledWith(snapshots2[0].hash, expect.anything())
     expect(await components.storage.exist(snapshots2[0].hash)).toBeTruthy()
@@ -300,7 +300,7 @@ describe('snapshot generator - ', () => {
         .mockResolvedValue(new Set(['h1']))
 
       // snapshot is generated and assert is correctly stored
-      const snapshots = await generateSnapshotsInMultipleTimeRanges(components, timeRangeOfDaysFromInitialTimestamp(1))
+      const snapshots = await components.snapshots.generateSnapshotsInMultipleTimeRanges(timeRangeOfDaysFromInitialTimestamp(1))
 
       expect(snapshots).toEqual(expect.arrayContaining([expect.objectContaining({ numberOfEntities: 1 })]))
       expect(await components.storage.exist(snapshots[0].hash)).toBeTruthy()
@@ -320,7 +320,7 @@ describe('snapshot generator - ', () => {
       makeNoopValidator(components)
       await startSnapshotNeededComponents(components)
       // 14 empty days generates 1 weekly empty snapshots and 7 daily empty snapshot
-      await generateSnapshotsInMultipleTimeRanges(components, timeRangeOfDaysFromInitialTimestamp(14))
+      await components.snapshots.generateSnapshotsInMultipleTimeRanges(timeRangeOfDaysFromInitialTimestamp(14))
 
       // deploy entity for the last daily snapshot
       await deployAnEntityAtTimestamp(components, '0x00000', daysAfterInitialTimestamp(14) + 1)
@@ -328,7 +328,7 @@ describe('snapshot generator - ', () => {
       //  - The first weekly snapshot is already created with no deployments.
       //  - The second weekly snapshot will replace the 7 daily ones, that are empty, so they have the same hash of the first weekly snapshot
       //  - The last the daily snapshot, has a different snapshot hash as it has one deployment.
-      await generateSnapshotsInMultipleTimeRanges(components, timeRangeOfDaysFromInitialTimestamp(15))
+      await components.snapshots.generateSnapshotsInMultipleTimeRanges(timeRangeOfDaysFromInitialTimestamp(15))
       // expect first week snapshot to be present
       const snapshots = await components.snapshotsRepository.findSnapshotsStrictlyContainedInTimeRange(
         components.database,
@@ -372,7 +372,7 @@ describe('snapshot generator - ', () => {
         daysAfterInitialTimestamp(0) + 1,
         oldSnapshot.generationTimestamp + 1
       )
-      const snapshots = await generateSnapshotsInMultipleTimeRanges(components, firstDayTimeRange)
+      const snapshots = await components.snapshots.generateSnapshotsInMultipleTimeRanges(firstDayTimeRange)
 
       expect(snapshots).toHaveLength(1)
       const snapshot = snapshots[0]
@@ -395,7 +395,7 @@ describe('snapshot generator - ', () => {
       const firstDayTimeRange = timeRangeOfDaysFromInitialTimestamp(1)
 
       await deployAnEntityAtTimestamp(components, '0x00000', daysAfterInitialTimestamp(0) + 1)
-      const snapshots = await generateSnapshotsInMultipleTimeRanges(components, firstDayTimeRange)
+      const snapshots = await components.snapshots.generateSnapshotsInMultipleTimeRanges(firstDayTimeRange)
       expect(snapshots).toEqual(
         expect.arrayContaining([expect.objectContaining({ numberOfEntities: 1, timeRange: firstDayTimeRange })])
       )
@@ -408,7 +408,7 @@ describe('snapshot generator - ', () => {
         daysAfterInitialTimestamp(2),
         daysAfterInitialTimestamp(30)
       )
-      const snapshots2 = await generateSnapshotsInMultipleTimeRanges(components, firstDayTimeRange)
+      const snapshots2 = await components.snapshots.generateSnapshotsInMultipleTimeRanges(firstDayTimeRange)
       expect(snapshots2).toEqual(
         expect.arrayContaining([expect.objectContaining({ numberOfEntities: 0, timeRange: firstDayTimeRange })])
       )

--- a/content/test/unit/logic/entity-parser.spec.ts
+++ b/content/test/unit/logic/entity-parser.spec.ts
@@ -1,12 +1,14 @@
 import { Entity, EntityType } from '@dcl/schemas'
-import { getEntityFromBuffer } from '../../../src/logic/entity-parser'
+import { createEntityParser, IEntityParser, InvalidEntityError } from '../../../src/logic/entity-parser'
 import { buildEntityAndFile, entityToFile } from '../../helpers/entity-tests-helper'
 
-describe('Service', () => {
+describe('when parsing an entity from a buffer', () => {
+  let entityParser: IEntityParser
   let entity: Entity
   let entityFile: Uint8Array
 
-  beforeAll(async () => {
+  beforeEach(async () => {
+    entityParser = createEntityParser()
     ;[entity, entityFile] = await buildEntityAndFile(
       EntityType.SCENE,
       ['X1,Y1'],
@@ -16,93 +18,113 @@ describe('Service', () => {
     )
   })
 
-  it(`When a valid entity file is used, then it is parsed correctly`, () => {
-    expect(getEntityFromBuffer(entityFile, entity.id)).toEqual(entity)
+  describe('and the entity file is a valid serialized entity', () => {
+    it('should return the parsed entity unchanged', () => {
+      expect(entityParser.parse(entityFile, entity.id)).toEqual(entity)
+    })
   })
 
-  it(`When the entity file can't be parsed into an entity, then an exception is thrown`, () => {
-    const invalidFile = Buffer.from('Hello')
-
-    assertInvalidFile(invalidFile, `id`, `Failed to parse the entity file. Please make sure that it is a valid json.`)
+  describe('and the entity file is not valid json', () => {
+    it('should throw InvalidEntityError', () => {
+      const invalidFile = Buffer.from('Hello')
+      expect(() => entityParser.parse(invalidFile, 'id')).toThrow(InvalidEntityError)
+      expect(() => entityParser.parse(invalidFile, 'id')).toThrow(
+        'Failed to parse the entity file. Please make sure that it is a valid json.'
+      )
+    })
   })
 
-  it(`When type is not valid, then an exceptions is thrown`, () => {
-    const invalidEntity = copyEntity(entity)
-    invalidEntity.type = 'invalidType'
-
-    assertInvalidEntity(
-      invalidEntity,
-      `Please set a valid type. It must be one of ${Object.values(EntityType)}. We got '${invalidEntity.type}'`
-    )
+  describe('and the entity type is not a known EntityType', () => {
+    it('should throw InvalidEntityError listing the valid types', () => {
+      const invalidEntity = copyEntity(entity)
+      invalidEntity.type = 'invalidType'
+      assertInvalidEntity(
+        entityParser,
+        invalidEntity,
+        `Please set a valid type. It must be one of ${Object.values(EntityType)}. We got '${invalidEntity.type}'`
+      )
+    })
   })
 
-  it(`When pointers aren't an array, then an exceptions is thrown`, () => {
-    const invalidEntity = copyEntity(entity)
-    invalidEntity.pointers = 'invalidPointers'
-
-    assertInvalidEntity(invalidEntity, `Please set valid pointers`)
+  describe('and the pointers field is not an array', () => {
+    it('should throw InvalidEntityError', () => {
+      const invalidEntity = copyEntity(entity)
+      invalidEntity.pointers = 'invalidPointers'
+      assertInvalidEntity(entityParser, invalidEntity, 'Please set valid pointers')
+    })
   })
 
-  it(`When pointers are an array, but with strings, then an exceptions is thrown`, () => {
-    const invalidEntity = copyEntity(entity)
-    invalidEntity.pointers = [1234]
-
-    assertInvalidEntity(invalidEntity, `Please set valid pointers`)
+  describe('and the pointers array contains non-string values', () => {
+    it('should throw InvalidEntityError', () => {
+      const invalidEntity = copyEntity(entity)
+      invalidEntity.pointers = [1234]
+      assertInvalidEntity(entityParser, invalidEntity, 'Please set valid pointers')
+    })
   })
 
-  it(`When timestamp is not valid, then an exceptions is thrown`, () => {
-    const invalidEntity = copyEntity(entity)
-    invalidEntity.timestamp = 'invalidTimestamp'
-
-    assertInvalidEntity(invalidEntity, `Please set a valid timestamp. We got ${invalidEntity.timestamp}`)
+  describe('and the timestamp is not a number', () => {
+    it('should throw InvalidEntityError', () => {
+      const invalidEntity = copyEntity(entity)
+      invalidEntity.timestamp = 'invalidTimestamp'
+      assertInvalidEntity(entityParser, invalidEntity, `Please set a valid timestamp. We got ${invalidEntity.timestamp}`)
+    })
   })
 
-  it(`When content is not an array, then an exceptions is thrown`, () => {
-    const invalidEntity = copyEntity(entity)
-    invalidEntity.content = 'invalidContent'
-
-    assertInvalidEntity(invalidEntity, `Expected an array as content`)
+  describe('and the content field is not an array', () => {
+    it('should throw InvalidEntityError', () => {
+      const invalidEntity = copyEntity(entity)
+      invalidEntity.content = 'invalidContent'
+      assertInvalidEntity(entityParser, invalidEntity, 'Expected an array as content')
+    })
   })
 
-  it(`When content does not have a hash, then an exceptions is thrown`, () => {
-    const invalidEntity = copyEntity(entity)
-    invalidEntity.content = [{ file: 'name' }]
-
-    assertInvalidEntity(invalidEntity, `Content must contain a file name and a file hash`)
+  describe('and a content item is missing its hash', () => {
+    it('should throw InvalidEntityError', () => {
+      const invalidEntity = copyEntity(entity)
+      invalidEntity.content = [{ file: 'name' }]
+      assertInvalidEntity(entityParser, invalidEntity, 'Content must contain a file name and a file hash')
+    })
   })
 
-  it(`When content does not have a file, then an exceptions is thrown`, () => {
-    const invalidEntity = copyEntity(entity)
-    invalidEntity.content = [{ hash: 'hash' }]
-
-    assertInvalidEntity(invalidEntity, `Content must contain a file name and a file hash`)
+  describe('and a content item is missing its file name', () => {
+    it('should throw InvalidEntityError', () => {
+      const invalidEntity = copyEntity(entity)
+      invalidEntity.content = [{ hash: 'hash' }]
+      assertInvalidEntity(entityParser, invalidEntity, 'Content must contain a file name and a file hash')
+    })
   })
 
-  it(`When content file is not a string, then an exceptions is thrown`, () => {
-    const invalidEntity = copyEntity(entity)
-    invalidEntity.content = [{ file: 1234, hash: 'hash' }]
-
-    assertInvalidEntity(invalidEntity, `Please make sure that all file names and a file hashes are valid strings`)
+  describe('and a content item has a non-string file name', () => {
+    it('should throw InvalidEntityError', () => {
+      const invalidEntity = copyEntity(entity)
+      invalidEntity.content = [{ file: 1234, hash: 'hash' }]
+      assertInvalidEntity(
+        entityParser,
+        invalidEntity,
+        'Please make sure that all file names and a file hashes are valid strings'
+      )
+    })
   })
 
-  it(`When content hash is not a string, then an exceptions is thrown`, () => {
-    const invalidEntity = copyEntity(entity)
-    invalidEntity.content = [{ file: 'name', hash: 1234 }]
-
-    assertInvalidEntity(invalidEntity, `Please make sure that all file names and a file hashes are valid strings`)
+  describe('and a content item has a non-string hash', () => {
+    it('should throw InvalidEntityError', () => {
+      const invalidEntity = copyEntity(entity)
+      invalidEntity.content = [{ file: 'name', hash: 1234 }]
+      assertInvalidEntity(
+        entityParser,
+        invalidEntity,
+        'Please make sure that all file names and a file hashes are valid strings'
+      )
+    })
   })
-
-  function copyEntity(entity: Entity): any {
-    return Object.assign({}, entity)
-  }
-
-  function assertInvalidEntity(invalidEntity: Entity, errorMessage: string) {
-    assertInvalidFile(entityToFile(invalidEntity), invalidEntity.id, errorMessage)
-  }
-
-  function assertInvalidFile(file: Buffer, entityId: string, errorMessage: string) {
-    expect(() => {
-      getEntityFromBuffer(file, entityId)
-    }).toThrowError(errorMessage)
-  }
 })
+
+function copyEntity(entity: Entity): any {
+  return Object.assign({}, entity)
+}
+
+function assertInvalidEntity(entityParser: IEntityParser, invalidEntity: Entity, errorMessage: string) {
+  const file = entityToFile(invalidEntity)
+  expect(() => entityParser.parse(file, invalidEntity.id)).toThrow(InvalidEntityError)
+  expect(() => entityParser.parse(file, invalidEntity.id)).toThrow(errorMessage)
+}

--- a/content/test/unit/logic/erc721/erc721.spec.ts
+++ b/content/test/unit/logic/erc721/erc721.spec.ts
@@ -1,0 +1,121 @@
+import { Entity, EntityType } from '@dcl/schemas'
+import { Environment, EnvironmentConfig } from '../../../../src/Environment'
+import { createErc721, IErc721 } from '../../../../src/logic/erc721'
+
+const BASE_URL = 'https://content.example.test/'
+
+function buildEnv(): Environment {
+  const env = new Environment()
+  env.setConfig(EnvironmentConfig.CONTENT_SERVER_ADDRESS, BASE_URL)
+  return env
+}
+
+function buildWearableEntity(overrides: { image?: string; thumbnail?: string; content?: Entity['content'] } = {}): Entity {
+  return {
+    id: 'bafkrei000',
+    type: EntityType.WEARABLE,
+    pointers: ['0x000'],
+    timestamp: 1,
+    content: overrides.content ?? [
+      { file: 'image.png', hash: 'bafkrei-image' },
+      { file: 'thumbnail.png', hash: 'bafkrei-thumb' }
+    ],
+    version: 'v3',
+    metadata: {
+      id: 'urn',
+      i18n: [{ code: 'en', text: 'Cool Hat' }, { code: 'es', text: 'Gorro Cool' }],
+      rarity: 'rare',
+      image: overrides.image ?? 'image.png',
+      thumbnail: overrides.thumbnail ?? 'thumbnail.png',
+      data: {
+        tags: ['style:funny'],
+        representations: [{ bodyShapes: ['urn:decentraland:off-chain:base-avatars:BaseMale'] }],
+        category: 'hat'
+      }
+    } as any
+  }
+}
+
+describe('when building a wearable URN via buildUrn', () => {
+  let erc721: IErc721
+
+  beforeEach(() => {
+    erc721 = createErc721({ env: buildEnv() })
+  })
+
+  describe('and the contract address is hex-prefixed', () => {
+    it('should produce a collections-v2 URN', () => {
+      expect(erc721.buildUrn('ethereum', '0xdeadbeef', '0')).toBe(
+        'urn:decentraland:ethereum:collections-v2:0xdeadbeef:0'
+      )
+    })
+  })
+
+  describe('and the contract address is not hex-prefixed', () => {
+    it('should produce a collections-v1 URN', () => {
+      expect(erc721.buildUrn('ethereum', 'halloween_2019', '0')).toBe(
+        'urn:decentraland:ethereum:collections-v1:halloween_2019:0'
+      )
+    })
+  })
+})
+
+describe('when formatting an ERC-721 entity', () => {
+  let erc721: IErc721
+  let entity: Entity
+
+  beforeEach(() => {
+    erc721 = createErc721({ env: buildEnv() })
+    entity = buildWearableEntity()
+  })
+
+  describe('and the entity has english and non-english i18n entries', () => {
+    it('should pick the english name', () => {
+      const result = erc721.formatERC721Entity('urn:demo', entity, undefined)
+      expect(result.name).toBe('Cool Hat')
+    })
+  })
+
+  describe('and the entity has an image and a thumbnail', () => {
+    it('should build absolute content URLs using the configured content server address', () => {
+      const result = erc721.formatERC721Entity('urn:demo', entity, undefined)
+      expect(result.image).toBe(`${BASE_URL}contents/bafkrei-image`)
+      expect(result.thumbnail).toBe(`${BASE_URL}contents/bafkrei-thumb`)
+    })
+  })
+
+  describe('and an emission count is provided', () => {
+    it('should include "DCL Wearable {emission}/{totalForRarity}" in the description', () => {
+      const result = erc721.formatERC721Entity('urn:demo', entity, '42')
+      expect(result.description).toBe('DCL Wearable 42/5000')
+    })
+  })
+
+  describe('and no emission count is provided', () => {
+    it('should leave the description empty', () => {
+      const result = erc721.formatERC721Entity('urn:demo', entity, undefined)
+      expect(result.description).toBe('')
+    })
+  })
+
+  describe('and the entity declares tag metadata', () => {
+    it('should emit a Tag attribute for each declared tag', () => {
+      const result = erc721.formatERC721Entity('urn:demo', entity, undefined)
+      expect(result.attributes).toEqual(
+        expect.arrayContaining([{ trait_type: 'Tag', value: 'style:funny' }])
+      )
+    })
+  })
+
+describe('and the entity has no image/thumbnail metadata', () => {
+    it('should leave the image and thumbnail fields undefined', () => {
+      const noImageEntity: Entity = {
+        ...entity,
+        metadata: { ...(entity.metadata as any), image: undefined, thumbnail: undefined }
+      }
+      const result = erc721.formatERC721Entity('urn:demo', noImageEntity, undefined)
+      expect(result.image).toBeUndefined()
+      expect(result.thumbnail).toBeUndefined()
+    })
+  })
+})

--- a/content/test/unit/logic/erc721/erc721.spec.ts
+++ b/content/test/unit/logic/erc721/erc721.spec.ts
@@ -107,7 +107,7 @@ describe('when formatting an ERC-721 entity', () => {
     })
   })
 
-describe('and the entity has no image/thumbnail metadata', () => {
+  describe('and the entity has no image/thumbnail metadata', () => {
     it('should leave the image and thumbnail fields undefined', () => {
       const noImageEntity: Entity = {
         ...entity,

--- a/content/test/unit/logic/hashing/hashing.spec.ts
+++ b/content/test/unit/logic/hashing/hashing.spec.ts
@@ -1,0 +1,47 @@
+import { hashV0, hashV1 } from '@dcl/hashing'
+import { createHashing, IHashing } from '../../../../src/logic/hashing'
+
+describe('when hashing files', () => {
+  let hashing: IHashing
+  let firstFile: Uint8Array
+  let secondFile: Uint8Array
+
+  beforeEach(() => {
+    hashing = createHashing()
+    firstFile = new Uint8Array(Buffer.from('the first file'))
+    secondFile = new Uint8Array(Buffer.from('a different file'))
+  })
+
+  describe('and asking for IPFS hashes', () => {
+    it('should return one entry per file', async () => {
+      const result = await hashing.calculateIPFSHashes([firstFile, secondFile])
+      expect(result).toHaveLength(2)
+    })
+
+    it('should pair each input file with its v1 hash', async () => {
+      const result = await hashing.calculateIPFSHashes([firstFile])
+      const expected = await hashV1(firstFile)
+      expect(result[0]).toEqual({ file: firstFile, hash: expected })
+    })
+
+    describe('and the file list is empty', () => {
+      it('should return an empty array', async () => {
+        expect(await hashing.calculateIPFSHashes([])).toEqual([])
+      })
+    })
+  })
+
+  describe('and asking for deprecated hashes', () => {
+    it('should pair each input file with its v0 hash', async () => {
+      const result = await hashing.calculateDeprecatedHashes([firstFile])
+      const expected = await hashV0(firstFile)
+      expect(result[0]).toEqual({ file: firstFile, hash: expected })
+    })
+
+    it('should return a different hash than the IPFS v1 hash for the same file', async () => {
+      const [{ hash: deprecatedHash }] = await hashing.calculateDeprecatedHashes([firstFile])
+      const [{ hash: ipfsHash }] = await hashing.calculateIPFSHashes([firstFile])
+      expect(deprecatedHash).not.toEqual(ipfsHash)
+    })
+  })
+})

--- a/content/test/unit/logic/query-params/query-params.spec.ts
+++ b/content/test/unit/logic/query-params/query-params.spec.ts
@@ -1,0 +1,136 @@
+import { createQueryParams, IQueryParams } from '../../../../src/logic/query-params'
+
+describe('when parsing raw URLSearchParams', () => {
+  let queryParams: IQueryParams
+
+  beforeEach(() => {
+    queryParams = createQueryParams()
+  })
+
+  describe('and the search params contain repeated keys', () => {
+    it('should parse them into an array', () => {
+      const parsed = queryParams.qsParser(new URLSearchParams('cid=a&cid=b'))
+      expect(parsed.cid).toEqual(['a', 'b'])
+    })
+  })
+
+  describe('and the search params are empty', () => {
+    it('should return an empty object', () => {
+      expect(queryParams.qsParser(new URLSearchParams(''))).toEqual({})
+    })
+  })
+})
+
+describe('when reading an array param via qsGetArray', () => {
+  let queryParams: IQueryParams
+
+  beforeEach(() => {
+    queryParams = createQueryParams()
+  })
+
+  describe('and the param is missing', () => {
+    it('should return an empty array', () => {
+      expect(queryParams.qsGetArray({}, 'pointer')).toEqual([])
+    })
+  })
+
+  describe('and the param has a single value', () => {
+    it('should wrap it in a single-element array', () => {
+      expect(queryParams.qsGetArray({ pointer: 'a' }, 'pointer')).toEqual(['a'])
+    })
+  })
+
+  describe('and the param is already an array', () => {
+    it('should return it as-is', () => {
+      expect(queryParams.qsGetArray({ pointer: ['a', 'b'] }, 'pointer')).toEqual(['a', 'b'])
+    })
+  })
+})
+
+describe('when reading a numeric param via qsGetNumber', () => {
+  let queryParams: IQueryParams
+
+  beforeEach(() => {
+    queryParams = createQueryParams()
+  })
+
+  describe('and the param is a valid integer string', () => {
+    it('should return the parsed number', () => {
+      expect(queryParams.qsGetNumber({ limit: '42' }, 'limit')).toBe(42)
+    })
+  })
+
+  describe('and the param is missing', () => {
+    it('should return undefined', () => {
+      expect(queryParams.qsGetNumber({}, 'limit')).toBeUndefined()
+    })
+  })
+
+  describe('and the param is non-numeric', () => {
+    it('should return undefined', () => {
+      expect(queryParams.qsGetNumber({ limit: 'abc' }, 'limit')).toBeUndefined()
+    })
+  })
+})
+
+describe('when reading a boolean param via qsGetBoolean', () => {
+  let queryParams: IQueryParams
+
+  beforeEach(() => {
+    queryParams = createQueryParams()
+  })
+
+  describe('and the value is the literal "true"', () => {
+    it('should return true', () => {
+      expect(queryParams.qsGetBoolean({ flag: 'true' }, 'flag')).toBe(true)
+    })
+  })
+
+  describe('and the value is anything else', () => {
+    it('should return false', () => {
+      expect(queryParams.qsGetBoolean({ flag: 'yes' }, 'flag')).toBe(false)
+    })
+  })
+
+  describe('and the param is missing', () => {
+    it('should return undefined', () => {
+      expect(queryParams.qsGetBoolean({}, 'flag')).toBeUndefined()
+    })
+  })
+})
+
+describe('when serializing filters via toQueryParams', () => {
+  let queryParams: IQueryParams
+
+  beforeEach(() => {
+    queryParams = createQueryParams()
+  })
+
+  describe('and a value is an array under a plural key', () => {
+    it('should singularize the key and emit one occurrence per element', () => {
+      expect(queryParams.toQueryParams({ entityIds: ['a', 'b'] })).toBe('entityId=a&entityId=b')
+    })
+  })
+
+  describe('and a value is a primitive number, boolean, or string', () => {
+    it('should serialize it directly under its original key', () => {
+      expect(queryParams.toQueryParams({ limit: 10, includeAuthChain: true, sortBy: 'asc' })).toBe(
+        'limit=10&includeAuthChain=true&sortBy=asc'
+      )
+    })
+  })
+
+  describe('and a value is falsy or empty', () => {
+    it('should drop it from the resulting query string', () => {
+      expect(queryParams.toQueryParams({ a: undefined, b: null, c: 0, d: '' })).toBe('')
+    })
+  })
+
+  describe('and a value has an unsupported type (object)', () => {
+    it('should throw a descriptive error', () => {
+      expect(() => queryParams.toQueryParams({ filter: { nested: 'value' } })).toThrow(
+        'Query params must be either a string, a number, a boolean or an array of the types just mentioned'
+      )
+    })
+  })
+})

--- a/content/test/unit/logic/snapshots.spec.ts
+++ b/content/test/unit/logic/snapshots.spec.ts
@@ -6,7 +6,37 @@ import { createLogComponent } from '@well-known-components/logger'
 import { createTestMetricsComponent } from '@dcl/metrics'
 import { stopAllComponents } from '../../../src/logic/components-lifecycle'
 import { ISnapshotsRepository } from '../../../src/adapters/snapshots-repository'
-import { generateAndStoreSnapshot, generateSnapshotsInMultipleTimeRanges } from '../../../src/logic/snapshots'
+import { createSnapshots } from '../../../src/logic/snapshots'
+import { DatabaseClient } from '../../../src/adapters/database'
+import { TimeRange } from '@dcl/snapshots-fetcher/dist/types'
+import { AppComponents } from '../../../src/types'
+
+type SnapshotsDeps = Pick<
+  AppComponents,
+  'fs' | 'metrics' | 'storage' | 'logs' | 'denylist' | 'staticConfigs' | 'snapshotsRepository'
+> & { database?: AppComponents['database'] }
+
+function generateAndStoreSnapshot(
+  components: SnapshotsDeps,
+  db: DatabaseClient,
+  timeRange: TimeRange,
+  reason?: string
+) {
+  // `generateAndStoreSnapshot` only uses the per-call `db`; the factory's `database`
+  // dep is unused on this path, so the call-site db doubles as the factory dep too.
+  return createSnapshots({ ...components, database: components.database ?? (db as any) }).generateAndStoreSnapshot(
+    db,
+    timeRange,
+    reason
+  )
+}
+
+function generateSnapshotsInMultipleTimeRanges(
+  components: SnapshotsDeps & { database: AppComponents['database'] },
+  timeRange: TimeRange
+) {
+  return createSnapshots(components).generateSnapshotsInMultipleTimeRanges(timeRange)
+}
 import * as tr from '../../../src/logic/time-range'
 import { metricsDeclaration } from '../../../src/metrics'
 import { Denylist } from '../../../src/adapters/denylist'

--- a/content/test/unit/logic/third-party-item-checker.spec.ts
+++ b/content/test/unit/logic/third-party-item-checker.spec.ts
@@ -32,7 +32,7 @@ describe('third party item checker', () => {
       ]
     ])
     registry = createThirdPartyContractRegistryMock()
-    thirdPartyItemChecker = await createThirdPartyItemChecker(logs, httpProvider, registry)
+    thirdPartyItemChecker = await createThirdPartyItemChecker({ logs }, httpProvider, registry)
   })
 
   it('correct validation of nfts', async () => {

--- a/content/test/unit/logic/third-party-item-checker.spec.ts
+++ b/content/test/unit/logic/third-party-item-checker.spec.ts
@@ -4,72 +4,266 @@ import { ILoggerComponent } from '@well-known-components/interfaces'
 import { createLogComponent } from '@well-known-components/logger'
 import { createConfigComponent } from '@well-known-components/env-config-provider'
 import { createHttpProviderMock } from '../../mocks/http-provider-mock'
-import { HTTPProvider } from 'eth-connect'
 import { ThirdPartyContractRegistry } from '../../../src/logic/third-party-contract-registry'
 import { createThirdPartyContractRegistryMock } from '../../mocks/third-party-registry-mock'
 
-describe('third party item checker', () => {
+const ETH_ADDRESS = '0x49f94A887Efc16993E69d4F07Ef3dE11A2C90897'
+const OTHER_ADDRESS = '0x69d30b1875d39e13a01af73ccfed6d84839e84f2'
+const ERC721_CONTRACT = '0x74c78f5a4ab22f01d5fd08455cf0ff5c3367535c'
+const ERC1155_CONTRACT = '0x1aca797764bd5c1e9f3c2933432a2be770a33941'
+const UNKNOWN_CONTRACT = '0x7020117712a3fe09b7162ee3f932dae7673c6bdd'
+const BLOCK = 6417273
+
+function tpUrn(contract: string, nftId: string | number): string {
+  return `urn:decentraland:amoy:collections-thirdparty:back-to-the-future:sepolia-8a50:f-bananacrown-4685:sepolia:${contract}:${nftId}`
+}
+
+/** Encode an address as a 32-byte right-aligned hex word, the format `ownerOf` returns. */
+function encodeAddress(address: string): string {
+  const addr = address.toLowerCase().replace(/^0x/, '')
+  return '0x' + '0'.repeat(64 - addr.length) + addr
+}
+
+/** Encode a uint256 as a 32-byte hex word, the format `balanceOf` returns. */
+function encodeUint256(value: number): string {
+  const hex = value.toString(16)
+  return '0x' + '0'.repeat(64 - hex.length) + hex
+}
+
+function rpcOk(id: number, result: string) {
+  return { jsonrpc: '2.0', id, result }
+}
+
+function rpcError(id: number) {
+  return { jsonrpc: '2.0', id, error: { code: 3, data: '0x', message: 'execution reverted' } }
+}
+
+describe('when checking third party items', () => {
   let logs: ILoggerComponent
-  let thirdPartyItemChecker: ThirdPartyItemChecker
-  let httpProvider: HTTPProvider
   let registry: ThirdPartyContractRegistry
 
   beforeEach(async () => {
     logs = await createLogComponent({ config: createConfigComponent({ LOG_LEVEL: 'DEBUG' }) })
-    httpProvider = createHttpProviderMock([
-      [
-        { jsonrpc: '2.0', id: 1, result: '0x00000000000000000000000069d30b1875d39e13a01af73ccfed6d84839e84f2' },
-        {
-          jsonrpc: '2.0',
-          id: 2,
-          error: {
-            code: 3,
-            data: '0x7e2732890000000000000000000000000000000000000000000000000000000000000046',
-            message: 'execution reverted'
-          }
-        },
-        { jsonrpc: '2.0', id: 3, result: '0x' }
-      ]
-    ])
     registry = createThirdPartyContractRegistryMock()
-    thirdPartyItemChecker = await createThirdPartyItemChecker({ logs }, httpProvider, registry)
+    registry.isErc721 = jest.fn().mockReturnValue(false)
+    registry.isErc1155 = jest.fn().mockReturnValue(false)
+    registry.isUnknown = jest.fn().mockReturnValue(false)
   })
 
-  it('correct validation of nfts', async () => {
-    registry.isErc1155 = jest.fn().mockImplementation((contractAddress) => {
-      return contractAddress === '0x1aca797764bd5c1e9f3c2933432a2be770a33941'
-    })
-    registry.isErc721 = jest.fn().mockImplementation((contractAddress) => {
-      return contractAddress === '0x74c78f5a4ab22f01d5fd08455cf0ff5c3367535c'
-    })
-    registry.isUnknown = jest.fn().mockImplementation((contractAddress) => {
-      return contractAddress === '0x7020117712a3fe09b7162ee3f932dae7673c6bdd'
-    })
-    const result = await thirdPartyItemChecker.checkThirdPartyItems(
-      '0x49f94A887Efc16993E69d4F07Ef3dE11A2C90897',
-      [
-        'urn:decentraland:amoy:collections-thirdparty:back-to-the-future:sepolia-8a50:f-bananacrown-4685:sepolia:0x7020117712a3fE09B7162eE3F932dae7673C6BDD:q34rasf',
-        'urn:decentraland:amoy:collections-thirdparty:back-to-the-future:sepolia-8a50:f-bananacrown-4685:sepolia:0x7020117712a3fE09B7162eE3F932dae7673C6BDD:34',
-        'urn:decentraland:amoy:collections-thirdparty:back-to-the-future:sepolia-8a50:f-bananacrown-4685:sepolia:0x74c78f5a4ab22f01d5fd08455cf0ff5c3367535c:7',
-        'urn:decentraland:amoy:collections-thirdparty:back-to-the-future:sepolia-8a50:f-bananacrown-4685:sepolia:0x74c78f5a4ab22f01d5fd08455cf0ff5c3367535c:70',
-        'urn:decentraland:amoy:collections-thirdparty:back-to-the-future:sepolia-8a50:f-bananacrown-4685:sepolia:0x1aca797764bd5c1e9F3c2933432a2be770A33941:5'
-      ],
-      6417273
-    )
-
-    expect(result).toEqual([false, false, false, false, false])
+  afterEach(() => {
+    jest.restoreAllMocks()
   })
 
-  it('correct validation of nfts when nothing is requested', async () => {
-    const result = await thirdPartyItemChecker.checkThirdPartyItems(
-      '0x49f94A887Efc16993E69d4F07Ef3dE11A2C90897',
-      [],
-      6417273
-    )
+  describe('and the input list is empty', () => {
+    let checker: ThirdPartyItemChecker
 
-    expect(result).toEqual([])
-    expect(registry.isErc1155).not.toBeCalled()
-    expect(registry.isErc721).not.toBeCalled()
-    expect(registry.isUnknown).not.toBeCalled()
+    beforeEach(async () => {
+      checker = await createThirdPartyItemChecker({ logs }, createHttpProviderMock([]), registry)
+    })
+
+    it('should return an empty array', async () => {
+      expect(await checker.checkThirdPartyItems(ETH_ADDRESS, [], BLOCK)).toEqual([])
+    })
+
+    it('should not consult the contract registry', async () => {
+      await checker.checkThirdPartyItems(ETH_ADDRESS, [], BLOCK)
+      expect(registry.ensureContractsKnown).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('and a URN cannot be parsed', () => {
+    let checker: ThirdPartyItemChecker
+
+    beforeEach(async () => {
+      // The component still issues an (empty) RPC batch after the unparseable URN is
+      // marked false, so the mock needs to respond — even if the response is ignored.
+      checker = await createThirdPartyItemChecker({ logs }, createHttpProviderMock([[]]), registry)
+    })
+
+    it('should mark the unparseable URN as not owned', async () => {
+      const result = await checker.checkThirdPartyItems(ETH_ADDRESS, ['urn:decentraland:invalid:not-a-real-urn'], BLOCK)
+      expect(result).toEqual([false])
+    })
+  })
+
+  describe('and the contract is of an unknown type', () => {
+    let checker: ThirdPartyItemChecker
+
+    beforeEach(async () => {
+      registry.isUnknown = jest.fn().mockImplementation((c) => c === UNKNOWN_CONTRACT)
+      checker = await createThirdPartyItemChecker({ logs }, createHttpProviderMock([[]]), registry)
+    })
+
+    it('should mark the URN as not owned', async () => {
+      const result = await checker.checkThirdPartyItems(ETH_ADDRESS, [tpUrn(UNKNOWN_CONTRACT, '1')], BLOCK)
+      expect(result).toEqual([false])
+    })
+
+    it('should ask the registry to ensure the contract is known', async () => {
+      await checker.checkThirdPartyItems(ETH_ADDRESS, [tpUrn(UNKNOWN_CONTRACT, '1')], BLOCK)
+      expect(registry.ensureContractsKnown).toHaveBeenCalledWith(expect.arrayContaining([UNKNOWN_CONTRACT]))
+    })
+  })
+
+  describe('and the contract is an ERC-721', () => {
+    beforeEach(() => {
+      registry.isErc721 = jest.fn().mockImplementation((c) => c === ERC721_CONTRACT)
+    })
+
+    describe('and the queried address owns the token', () => {
+      let checker: ThirdPartyItemChecker
+
+      beforeEach(async () => {
+        const httpProvider = createHttpProviderMock([[rpcOk(1, encodeAddress(ETH_ADDRESS))]])
+        checker = await createThirdPartyItemChecker({ logs }, httpProvider, registry)
+      })
+
+      it('should return true', async () => {
+        const result = await checker.checkThirdPartyItems(ETH_ADDRESS, [tpUrn(ERC721_CONTRACT, '1')], BLOCK)
+        expect(result).toEqual([true])
+      })
+    })
+
+    describe('and a different address owns the token', () => {
+      let checker: ThirdPartyItemChecker
+
+      beforeEach(async () => {
+        const httpProvider = createHttpProviderMock([[rpcOk(1, encodeAddress(OTHER_ADDRESS))]])
+        checker = await createThirdPartyItemChecker({ logs }, httpProvider, registry)
+      })
+
+      it('should return false', async () => {
+        const result = await checker.checkThirdPartyItems(ETH_ADDRESS, [tpUrn(ERC721_CONTRACT, '1')], BLOCK)
+        expect(result).toEqual([false])
+      })
+    })
+
+    describe('and the RPC call returns an error', () => {
+      let checker: ThirdPartyItemChecker
+
+      beforeEach(async () => {
+        const httpProvider = createHttpProviderMock([[rpcError(1)]])
+        checker = await createThirdPartyItemChecker({ logs }, httpProvider, registry)
+      })
+
+      it('should return false', async () => {
+        const result = await checker.checkThirdPartyItems(ETH_ADDRESS, [tpUrn(ERC721_CONTRACT, '1')], BLOCK)
+        expect(result).toEqual([false])
+      })
+    })
+
+    describe('and the RPC call returns an empty result', () => {
+      let checker: ThirdPartyItemChecker
+
+      beforeEach(async () => {
+        const httpProvider = createHttpProviderMock([[rpcOk(1, '0x')]])
+        checker = await createThirdPartyItemChecker({ logs }, httpProvider, registry)
+      })
+
+      it('should return false', async () => {
+        const result = await checker.checkThirdPartyItems(ETH_ADDRESS, [tpUrn(ERC721_CONTRACT, '1')], BLOCK)
+        expect(result).toEqual([false])
+      })
+    })
+  })
+
+  describe('and the contract is an ERC-1155', () => {
+    beforeEach(() => {
+      registry.isErc1155 = jest.fn().mockImplementation((c) => c === ERC1155_CONTRACT)
+    })
+
+    describe('and the queried address has a positive balance', () => {
+      let checker: ThirdPartyItemChecker
+
+      beforeEach(async () => {
+        const httpProvider = createHttpProviderMock([[rpcOk(1, encodeUint256(3))]])
+        checker = await createThirdPartyItemChecker({ logs }, httpProvider, registry)
+      })
+
+      it('should return true', async () => {
+        const result = await checker.checkThirdPartyItems(ETH_ADDRESS, [tpUrn(ERC1155_CONTRACT, '1')], BLOCK)
+        expect(result).toEqual([true])
+      })
+    })
+
+    describe('and the queried address has a zero balance', () => {
+      let checker: ThirdPartyItemChecker
+
+      beforeEach(async () => {
+        const httpProvider = createHttpProviderMock([[rpcOk(1, encodeUint256(0))]])
+        checker = await createThirdPartyItemChecker({ logs }, httpProvider, registry)
+      })
+
+      it('should return false', async () => {
+        const result = await checker.checkThirdPartyItems(ETH_ADDRESS, [tpUrn(ERC1155_CONTRACT, '1')], BLOCK)
+        expect(result).toEqual([false])
+      })
+    })
+
+    describe('and the RPC call returns an empty result', () => {
+      let checker: ThirdPartyItemChecker
+
+      beforeEach(async () => {
+        const httpProvider = createHttpProviderMock([[rpcOk(1, '0x')]])
+        checker = await createThirdPartyItemChecker({ logs }, httpProvider, registry)
+      })
+
+      it('should treat the missing balance as zero and return false', async () => {
+        const result = await checker.checkThirdPartyItems(ETH_ADDRESS, [tpUrn(ERC1155_CONTRACT, '1')], BLOCK)
+        expect(result).toEqual([false])
+      })
+    })
+
+    describe('and the RPC call returns an error', () => {
+      let checker: ThirdPartyItemChecker
+
+      beforeEach(async () => {
+        const httpProvider = createHttpProviderMock([[rpcError(1)]])
+        checker = await createThirdPartyItemChecker({ logs }, httpProvider, registry)
+      })
+
+      it('should return false', async () => {
+        const result = await checker.checkThirdPartyItems(ETH_ADDRESS, [tpUrn(ERC1155_CONTRACT, '1')], BLOCK)
+        expect(result).toEqual([false])
+      })
+    })
+  })
+
+  describe('and the input is a mixed batch of parseable, unparseable, and unknown URNs', () => {
+    const urns = [
+      'urn:decentraland:invalid:not-a-real-urn',
+      tpUrn(UNKNOWN_CONTRACT, '1'),
+      tpUrn(ERC721_CONTRACT, '7'),
+      tpUrn(ERC1155_CONTRACT, '5')
+    ]
+    let result: boolean[]
+
+    beforeEach(async () => {
+      registry.isErc721 = jest.fn().mockImplementation((c) => c === ERC721_CONTRACT)
+      registry.isErc1155 = jest.fn().mockImplementation((c) => c === ERC1155_CONTRACT)
+      registry.isUnknown = jest.fn().mockImplementation((c) => c === UNKNOWN_CONTRACT)
+      // Only the parseable + known URNs reach the RPC batch (in input order):
+      // index 2 → ERC-721 ownerOf (returns the queried address → owned)
+      // index 3 → ERC-1155 balanceOf (returns 2 → owned)
+      const httpProvider = createHttpProviderMock([
+        [rpcOk(1, encodeAddress(ETH_ADDRESS)), rpcOk(2, encodeUint256(2))]
+      ])
+      const checker = await createThirdPartyItemChecker({ logs }, httpProvider, registry)
+      result = await checker.checkThirdPartyItems(ETH_ADDRESS, urns, BLOCK)
+    })
+
+    it('should return one boolean per input URN', () => {
+      expect(result).toHaveLength(urns.length)
+    })
+
+    it('should preserve the input order in the result', () => {
+      expect(result).toEqual([false, false, true, true])
+    })
+
+    it('should ask the registry to ensure every parseable contract is known', () => {
+      expect(registry.ensureContractsKnown).toHaveBeenCalledWith(
+        expect.arrayContaining([UNKNOWN_CONTRACT, ERC721_CONTRACT, ERC1155_CONTRACT])
+      )
+    })
   })
 })

--- a/content/test/unit/ports/deployer.spec.ts
+++ b/content/test/unit/ports/deployer.spec.ts
@@ -9,6 +9,8 @@ import assert from 'assert'
 import { HTTPProvider } from 'eth-connect'
 
 import { isEntityContentUnchanged } from '../../../src/logic/deployment-service'
+import { createHashing } from '../../../src/logic/hashing'
+import { createEntityParser } from '../../../src/logic/entity-parser'
 import { DEFAULT_ENTITIES_CACHE_SIZE, Environment, EnvironmentConfig } from '../../../src/Environment'
 import {
   Deployment,
@@ -250,7 +252,9 @@ describe('Deployer', function () {
       activeEntities,
       denylist,
       contentFilesRepository,
-      deploymentsRepository
+      deploymentsRepository,
+      hashing: createHashing(),
+      entityParser: createEntityParser()
     }
     const deployer = createDeploymentService(deployerComponents)
     return {


### PR DESCRIPTION
## Summary

Promotes the six remaining stateless function libs under `src/logic/` to real WKC factory components. After this PR, **every** entry in `AppComponents` is factory-built with explicit dependencies — no more direct-export function libs masquerading as components.

### What changed

- **`hashing` → `createHashing()`** — `calculateIPFSHashes` + `calculateDeprecatedHashes` become `IHashing` methods. `hashFiles` in `deployment-service` now takes `IHashing` as a first arg.
- **`query-params` → `createQueryParams()`** — the qs helpers + `toQueryParams` serializer become `IQueryParams` methods. Five controller handlers consume it via `context.components.queryParams`.
- **`entity-parser` → `createEntityParser()`** — `getEntityFromBuffer` becomes `IEntityParser.parse`. Introduces `InvalidEntityError` in `errors.ts` (phase-10 pattern) so the central error middleware can map parse failures to 400 instead of relying on generic `Error` matching.
- **`erc721` → `createErc721({ env })`** — `env` is captured at construction, so `formatERC721Entity` loses its leading `env` arg.
- **`snapshots` → `createSnapshots({ ... })`** — the two snapshot functions become methods. `createSnapshotGenerator` now takes a single `snapshots` dependency instead of pulling 8 individual deps and threading `database` manually.
- **`third-party-item-checker`** — normalizes the logger to come via `Pick<AppComponents, 'logs'>`. The provider and contract registry stay positional because there are two instances (L1 + L2) that vary per chain — they cannot live in `AppComponents`.

### Call sites updated

- `deployment-service`: injects `hashing` + `entityParser` via `Pick<AppComponents, ...>`.
- `snapshot-generator` adapter: injects `snapshots` instead of the long list of underlying deps.
- `content-validator`: passes `{ logs }` to `createThirdPartyItemChecker`.
- Five controller handlers (`get-available-content`, `get-entities`, `get-deployments`, `pointer-changes`, `get-erc721-entity`): consume via `context.components.queryParams` / `.erc721`.
- E2E test utils + `delete-unreferenced-files` integration test: updated to the new signatures.
- Unit + integration snapshot tests: routed through `createSnapshots`.
- Existing `entity-parser` spec rewritten to the `dcl-testing` convention (describe `when`/`and`, it `should`, `beforeEach` scoping) and asserts the new typed error.

### New unit tests

Three previously-untested factories now have dedicated spec files (28 tests total):

- `test/unit/logic/hashing/hashing.spec.ts`
- `test/unit/logic/query-params/query-params.spec.ts`
- `test/unit/logic/erc721/erc721.spec.ts`

## Test plan

- [x] \`yarn build\` is clean
- [x] \`yarn test --testPathPattern='snapshot-generator|logic/snapshots|controller/entities|controller/available-content|deployment-pagination|pointer-changes|delete-unreferenced-files|deployer|hashing|query-params|erc721|entity-parser|third-party-item-checker'\` — 240 / 240 pass
- [ ] CI green