### PR TITLE
fix: batch GC deletes, bound the pointer cache, LIMIT 1 on deploymentExists

### DIFF
--- a/src/adapters/content-files-repository/component.ts
+++ b/src/adapters/content-files-repository/component.ts
@@ -54,13 +54,12 @@ async function saveContentFiles(
   await database.queryWithValues(query)
 }
 
-async function findContentHashesNotBeingUsedAnymore(
+async function* streamContentHashesNotBeingUsedAnymore(
   database: DatabaseClient,
-  lastGarbageCollectionTimestamp: number
-): Promise<string[]> {
-  return (
-    await database.queryWithValues<{ content_hash: string }>(
-      SQL`
+  lastGarbageCollectionTimestamp: number,
+  options?: { batchSize?: number }
+): AsyncIterable<string> {
+  const query = SQL`
     SELECT content_files.content_hash
     FROM content_files
     INNER JOIN deployments ON content_files.deployment=id
@@ -68,10 +67,15 @@ async function findContentHashesNotBeingUsedAnymore(
     WHERE dd.local_timestamp IS NULL OR dd.local_timestamp > to_timestamp(${lastGarbageCollectionTimestamp} / 1000.0)
     GROUP BY content_files.content_hash
     HAVING bool_or(deployments.deleter_deployment IS NULL) = FALSE
-  `,
-      'garbage_collection'
-    )
-  ).rows.map((row) => row.content_hash)
+  `
+  // Stream the result so garbage collection never materializes every unused hash in memory at once.
+  for await (const row of database.streamQuery<{ content_hash: string }>(
+    query,
+    { batchSize: options?.batchSize ?? 1000 },
+    'garbage_collection'
+  )) {
+    yield row.content_hash
+  }
 }
 
 async function* streamAllDistinctContentFileHashes(database: DatabaseClient): AsyncIterable<string> {
@@ -86,7 +90,7 @@ export function createContentFilesRepository(): IContentFilesRepository {
   return {
     getContentFiles,
     saveContentFiles,
-    findContentHashesNotBeingUsedAnymore,
+    streamContentHashesNotBeingUsedAnymore,
     streamAllDistinctContentFileHashes
   }
 }

--- a/src/adapters/content-files-repository/types.ts
+++ b/src/adapters/content-files-repository/types.ts
@@ -12,6 +12,10 @@ export interface ContentFilesRow {
 export interface IContentFilesRepository {
   getContentFiles(db: DatabaseClient, deploymentIds: DeploymentId[]): Promise<Map<DeploymentId, DeploymentContent[]>>
   saveContentFiles(db: DatabaseClient, deploymentId: DeploymentId, content: ContentMapping[]): Promise<void>
-  findContentHashesNotBeingUsedAnymore(db: DatabaseClient, lastGarbageCollectionTimestamp: number): Promise<string[]>
+  streamContentHashesNotBeingUsedAnymore(
+    db: DatabaseClient,
+    lastGarbageCollectionTimestamp: number,
+    options?: { batchSize?: number }
+  ): AsyncIterable<string>
   streamAllDistinctContentFileHashes(db: DatabaseClient): AsyncIterable<string>
 }

--- a/src/adapters/deployments-repository/component.ts
+++ b/src/adapters/deployments-repository/component.ts
@@ -16,6 +16,7 @@ async function deploymentExists(database: DatabaseClient, entityId: string): Pro
     SELECT 1
     FROM deployments
     WHERE entity_id = ${entityId}
+    LIMIT 1
   `,
     'deployment_exists'
   )

--- a/src/logic/active-entities/component.ts
+++ b/src/logic/active-entities/component.ts
@@ -55,21 +55,31 @@ export function createActiveEntitiesComponent(
 
   const normalizePointerCacheKey = (pointer: string) => pointer.toLowerCase()
 
-  const createEntityByPointersCache = (): Map<string, string | NotActiveEntity> => {
-    const entityIdByPointers = new Map<string, string | NotActiveEntity>()
+  type PointersCache = {
+    get(pointer: string): string | NotActiveEntity | undefined
+    set(pointer: string, entity: string | NotActiveEntity): void
+    has(pointer: string): boolean
+    clear(): void
+  }
+
+  const createEntityByPointersCache = (): PointersCache => {
+    // LRU instead of an unbounded Map: this cache grows with every distinct pointer ever looked up,
+    // so cap it (to ENTITIES_CACHE_SIZE) to avoid unbounded memory growth under pointer churn.
+    const entityIdByPointers = new LRU<string, string | NotActiveEntity>({
+      max: components.env.getConfig(EnvironmentConfig.ENTITIES_CACHE_SIZE)
+    })
     return {
-      ...entityIdByPointers,
       get(pointer: string) {
         return entityIdByPointers.get(normalizePointerCacheKey(pointer))
       },
       set(pointer: string, entity: string | NotActiveEntity) {
-        return entityIdByPointers.set(normalizePointerCacheKey(pointer), entity)
+        entityIdByPointers.set(normalizePointerCacheKey(pointer), entity)
       },
       has(pointer: string) {
         return entityIdByPointers.has(normalizePointerCacheKey(pointer))
       },
       clear() {
-        return entityIdByPointers.clear()
+        entityIdByPointers.clear()
       }
     }
   }

--- a/src/logic/active-entities/component.ts
+++ b/src/logic/active-entities/component.ts
@@ -58,7 +58,6 @@ export function createActiveEntitiesComponent(
   type PointersCache = {
     get(pointer: string): string | NotActiveEntity | undefined
     set(pointer: string, entity: string | NotActiveEntity): void
-    has(pointer: string): boolean
     clear(): void
   }
 
@@ -74,9 +73,6 @@ export function createActiveEntitiesComponent(
       },
       set(pointer: string, entity: string | NotActiveEntity) {
         entityIdByPointers.set(normalizePointerCacheKey(pointer), entity)
-      },
-      has(pointer: string) {
-        return entityIdByPointers.has(normalizePointerCacheKey(pointer))
       },
       clear() {
         entityIdByPointers.clear()
@@ -100,9 +96,11 @@ export function createActiveEntitiesComponent(
   }
 
   function setPreviousEntityAsNone(pointer: string): void {
-    if (entityIdByPointers.has(pointer)) {
+    // Single get() instead of has()+get(): one lookup, and it refreshes the entry's LRU recency
+    // (lru-cache's has() does not). Cached values are never undefined, so undefined means absent.
+    const entityId = entityIdByPointers.get(pointer)
+    if (entityId !== undefined) {
       // pointer now have a different active entity, let's update the old one
-      const entityId = entityIdByPointers.get(pointer)
       if (isPointingToEntity(entityId)) {
         const entity = cache.get(entityId) // it should be present
         if (isEntityPresent(entity)) {
@@ -321,8 +319,9 @@ export function createActiveEntitiesComponent(
 
   async function clearPointers(pointers: string[]): Promise<void> {
     for (const pointer of pointers) {
-      if (entityIdByPointers.has(pointer)) {
-        const entityId = entityIdByPointers.get(pointer)!
+      // Single get() instead of has()+get(): one lookup, and it refreshes LRU recency (has() does not).
+      const entityId = entityIdByPointers.get(pointer)
+      if (entityId !== undefined) {
         cache.set(entityId, 'NOT_ACTIVE_ENTITY')
         entityIdByPointers.set(pointer, 'NOT_ACTIVE_ENTITY')
       }

--- a/src/logic/garbage-collection/component.ts
+++ b/src/logic/garbage-collection/component.ts
@@ -45,6 +45,9 @@ export function createGarbageCollectionComponent(
         return
       }
       await components.storage.delete(batch)
+      // Emit the metric per batch (after the delete) so progress is observable during a long sweep
+      // and a crash mid-sweep still records what was already deleted.
+      components.metrics.increment('dcl_content_garbage_collection_items_total', {}, batch.length)
       for (const hash of batch) {
         deletedHashes.add(hash)
       }
@@ -65,7 +68,6 @@ export function createGarbageCollectionComponent(
     }
     await flushBatch()
 
-    components.metrics.increment('dcl_content_garbage_collection_items_total', {}, deletedHashes.size)
     logger.debug(`Garbage collection deleted ${deletedHashes.size} unused content hashes`)
     return deletedHashes
   }

--- a/src/logic/garbage-collection/component.ts
+++ b/src/logic/garbage-collection/component.ts
@@ -8,6 +8,10 @@ import { GCStaleProfilesResult, IGarbageCollectionComponent, SweepResult } from 
 
 const PROFILE_CLEANUP_LIMIT = 10000
 
+// How many unused content hashes to delete from storage per batch. Bounds both the in-memory list
+// and the size of each storage.delete operation during a sweep.
+const GC_DELETE_BATCH_SIZE = 1000
+
 export function createGarbageCollectionComponent(
   components: Pick<
     AppComponents,
@@ -33,16 +37,37 @@ export function createGarbageCollectionComponent(
    * If they are not being used, then we will delete them.
    */
   async function gcUnusedHashes(): Promise<Set<string>> {
-    const hashes = await components.contentFilesRepository.findContentHashesNotBeingUsedAnymore(
+    const deletedHashes = new Set<string>()
+    let batch: string[] = []
+
+    const flushBatch = async (): Promise<void> => {
+      if (batch.length === 0) {
+        return
+      }
+      await components.storage.delete(batch)
+      for (const hash of batch) {
+        deletedHashes.add(hash)
+      }
+      batch = []
+    }
+
+    // Stream the unused hashes and delete them in fixed-size batches, so neither the in-memory list
+    // nor a single storage.delete grows unbounded with the number of overwritten deployments.
+    for await (const hash of components.contentFilesRepository.streamContentHashesNotBeingUsedAnymore(
       components.database,
-      lastTimeOfCollection
-    )
+      lastTimeOfCollection,
+      { batchSize: GC_DELETE_BATCH_SIZE }
+    )) {
+      batch.push(hash)
+      if (batch.length >= GC_DELETE_BATCH_SIZE) {
+        await flushBatch()
+      }
+    }
+    await flushBatch()
 
-    components.metrics.increment('dcl_content_garbage_collection_items_total', {}, hashes.length)
-
-    logger.debug(`Hashes to delete are: (${hashes.join(',')})`)
-    await components.storage.delete(hashes)
-    return new Set<string>(hashes)
+    components.metrics.increment('dcl_content_garbage_collection_items_total', {}, deletedHashes.size)
+    logger.debug(`Garbage collection deleted ${deletedHashes.size} unused content hashes`)
+    return deletedHashes
   }
 
   // NOTE: remove old profile deployments and their images,


### PR DESCRIPTION
## What

Lower-priority follow-ups from the performance review — items **1, 3, 4** (the ones flagged "worth doing" / "easy"). All behavior-preserving.

### #1 — Garbage collection: stream + batch instead of all-at-once
`gcUnusedHashes` previously called `findContentHashesNotBeingUsedAnymore`, which materialized **every** unused content hash into one array, then issued a **single** `storage.delete(allHashes)`. Both grow unbounded with the number of overwritten deployments between sweeps.

- The repository method is now `streamContentHashesNotBeingUsedAnymore` (an `AsyncIterable`, same query). Its only caller is GC.
- `gcUnusedHashes` consumes the stream and deletes in fixed-size batches (`GC_DELETE_BATCH_SIZE = 1000`), so neither the in-memory list nor any single `storage.delete` is unbounded. (Also drops the "log every hash" debug line, which was itself a problem on large result sets.)
- Same hashes are deleted as before — just streamed and chunked.

### #4 — active-entities pointer cache is now bounded
`entityIdByPointers` was an unbounded `Map` that grew with every distinct pointer ever looked up (a slow leak under pointer churn). It's now an `LRU` capped at `ENTITIES_CACHE_SIZE`, consistent with the other caches in the component. The facade also drops the no-op `...Map` spread / fake-`Map` return type in favor of a small explicit interface.

### #3 — `deploymentExists` gets `LIMIT 1`
`SELECT 1 FROM deployments WHERE entity_id = $1` → `… LIMIT 1`. `entity_id` is unique so the impact is small, but it's free and this is on the sync hot path (called per bloom-positive in `isEntityDeployed`).

## Testing
- `yarn build` clean, eslint clean.
- Unit: 301 pass.
- Integration: `garbage-collection` (validates GC still deletes exactly the unused hashes via the new streaming/batched path), `active-entities` (#4), and `batch-deployer` (exercises `deploymentExists`) all pass.

## Notes
- Branches from `main`. Overlaps `active-entities/component.ts` with the perf PR (#1939, which changed `updateCache`) but in a different region — trivial conflict at most.
- The remaining "lower" items were intentionally left out: **#2** (upload full-buffering — architectural) and **#5** (`/contents` double stat/HEAD — only meaningful on the S3 backend).
