### PR TITLE
fix: harden deploy write path and on-chain block validation

### DIFF
--- a/src/Environment.ts
+++ b/src/Environment.ts
@@ -13,6 +13,19 @@ const DECENTRALAND_ADDRESS: EthAddress = '0x1337e0507eb4ab47e08a179573ed4533d9e2
 
 const DEFAULT_FOLDER_MIGRATION_MAX_CONCURRENCY = 1000
 export const DEFAULT_ENTITIES_CACHE_SIZE = 150000
+// Default for PG_POOL_SIZE: max connections for the main pg pool. Sized above the deployment job
+// concurrency (batch deployer = 10) so concurrent deploy transactions — each holding a connection
+// for its whole tx — can't starve the read endpoints of connections. pg's own default is 10.
+export const DEFAULT_PG_POOL_SIZE = 20
+
+/**
+ * Parses the PG_POOL_SIZE env value: falls back to DEFAULT_PG_POOL_SIZE when unset or non-numeric,
+ * and floors at 1 to avoid a degenerate 0/negative pool. Exported for testing.
+ */
+export function parsePgPoolSize(raw: string | undefined): number {
+  const parsed = parseInt(raw ?? '', 10)
+  return Number.isNaN(parsed) ? DEFAULT_PG_POOL_SIZE : Math.max(parsed, 1)
+}
 // HTTP-layer DoS guard for POST /entities uploads. The per-entity business limits live in
 // `@dcl/content-validator` (e.g. 15 MB/parcel for scenes) and run *after* the body is buffered,
 // so these caps only bound how much an unauthenticated client can stream into memory per request.
@@ -451,14 +464,9 @@ export class EnvironmentBuilder {
     this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.PG_STREAM_QUERY_TIMEOUT, () =>
       process.env.PG_STREAM_QUERY_TIMEOUT ? ms(process.env.PG_STREAM_QUERY_TIMEOUT) : ms('10m')
     )
-    this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.PG_POOL_SIZE, () => {
-      // Max connections for the main pool. Sized above the deployment job concurrency (batch
-      // deployer = 10) so concurrent deploy transactions — each of which holds a connection for
-      // its whole duration — can't starve the read endpoints (e.g. /content/pointer-changes) of
-      // connections. Floor at 1 to avoid a degenerate 0/negative pool. pg's own default is 10.
-      const parsed = parseInt(process.env.PG_POOL_SIZE ?? '', 10)
-      return Number.isNaN(parsed) ? 20 : Math.max(parsed, 1)
-    })
+    this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.PG_POOL_SIZE, () =>
+      parsePgPoolSize(process.env.PG_POOL_SIZE)
+    )
     this.registerConfigIfNotAlreadySet(
       env,
       EnvironmentConfig.SNAPSHOT_FREQUENCY_IN_MILLISECONDS,

--- a/src/Environment.ts
+++ b/src/Environment.ts
@@ -174,6 +174,7 @@ export enum EnvironmentConfig {
   PG_IDLE_TIMEOUT,
   PG_QUERY_TIMEOUT,
   PG_STREAM_QUERY_TIMEOUT,
+  PG_POOL_SIZE,
   GARBAGE_COLLECTION,
   GARBAGE_COLLECTION_INTERVAL,
   BLOOM_FILTER_EXPECTED_ELEMENTS,
@@ -450,6 +451,14 @@ export class EnvironmentBuilder {
     this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.PG_STREAM_QUERY_TIMEOUT, () =>
       process.env.PG_STREAM_QUERY_TIMEOUT ? ms(process.env.PG_STREAM_QUERY_TIMEOUT) : ms('10m')
     )
+    this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.PG_POOL_SIZE, () => {
+      // Max connections for the main pool. Sized above the deployment job concurrency (batch
+      // deployer = 10) so concurrent deploy transactions — each of which holds a connection for
+      // its whole duration — can't starve the read endpoints (e.g. /content/pointer-changes) of
+      // connections. Floor at 1 to avoid a degenerate 0/negative pool. pg's own default is 10.
+      const parsed = parseInt(process.env.PG_POOL_SIZE ?? '', 10)
+      return Number.isNaN(parsed) ? 20 : Math.max(parsed, 1)
+    })
     this.registerConfigIfNotAlreadySet(
       env,
       EnvironmentConfig.SNAPSHOT_FREQUENCY_IN_MILLISECONDS,

--- a/src/adapters/content-validator/component.ts
+++ b/src/adapters/content-validator/component.ts
@@ -107,7 +107,11 @@ async function createOnChainValidateFn(
     blockRepository: createBlockRepository({
       metrics,
       logs,
-      ethereumProvider: createCachingEthereumProvider(createEthereumProvider(l1Provider))
+      ethereumProvider: createCachingEthereumProvider(
+        createEthereumProvider(l1Provider, () =>
+          metrics.increment('dcl_block_fetch_retries_total', { network: l1Network })
+        )
+      )
     }),
     metrics,
     logs
@@ -116,7 +120,11 @@ async function createOnChainValidateFn(
     blockRepository: createBlockRepository({
       metrics,
       logs,
-      ethereumProvider: createCachingEthereumProvider(createEthereumProvider(l2Provider))
+      ethereumProvider: createCachingEthereumProvider(
+        createEthereumProvider(l2Provider, () =>
+          metrics.increment('dcl_block_fetch_retries_total', { network: l2Network })
+        )
+      )
     }),
     metrics,
     logs

--- a/src/adapters/content-validator/component.ts
+++ b/src/adapters/content-validator/component.ts
@@ -25,6 +25,7 @@ import { Authenticator } from '@dcl/crypto'
 import { hashV0, hashV1 } from '@dcl/hashing'
 import { createSubgraphComponent } from '@well-known-components/thegraph-component'
 import RequestManager, { HTTPProvider } from 'eth-connect'
+import { sleep } from '@dcl/snapshots-fetcher/dist/utils'
 import { Readable } from 'stream'
 import { EnvironmentConfig } from '../../Environment'
 import { createItemChecker, createL1Checker, createL2Checker } from './checker'
@@ -40,14 +41,49 @@ type ContentValidatorDeps = Pick<
   l2Provider: HTTPProvider
 }
 
+// Block lookups during validation hit a single RPC provider that has no built-in retry. A
+// transient RPC error, or a momentarily-lagging replica that hasn't indexed the block yet,
+// would otherwise fail an otherwise-valid deployment with "Block <N> could not be retrieved".
+// This bounded retry sits BELOW the block-indexer LRU cache, so it only runs on an actual
+// cache-miss RPC call — cache hits are unaffected.
+const BLOCK_FETCH_MAX_RETRIES = 3
+const BLOCK_FETCH_BASE_DELAY_MS = 100
+
+async function withBlockFetchRetry<T>(operation: () => Promise<T>): Promise<T> {
+  let lastError: unknown
+  for (let attempt = 1; attempt <= BLOCK_FETCH_MAX_RETRIES; attempt++) {
+    try {
+      return await operation()
+    } catch (err) {
+      lastError = err
+      if (attempt < BLOCK_FETCH_MAX_RETRIES) {
+        // Exponential backoff with full jitter to avoid synchronized retries across the
+        // many block lookups that concurrent validations issue at once.
+        const base = BLOCK_FETCH_BASE_DELAY_MS * 2 ** (attempt - 1)
+        await sleep(base + Math.floor(Math.random() * base))
+      }
+    }
+  }
+  throw lastError
+}
+
 const createEthereumProvider = (httpProvider: HTTPProvider): EthereumProvider => {
   const reqMan = new RequestManager(httpProvider)
   return {
     getBlockNumber: async (): Promise<number> => {
-      return (await reqMan.eth_blockNumber()) as number
+      return withBlockFetchRetry(async () => (await reqMan.eth_blockNumber()) as number)
     },
     getBlock: async (block: number): Promise<{ timestamp: string | number }> => {
-      return await reqMan.eth_getBlockByNumber(block, false)
+      return withBlockFetchRetry(async () => {
+        const result = (await reqMan.eth_getBlockByNumber(block, false)) as { timestamp: string | number } | null
+        // An empty result is the symptom we actually observed in production (the RPC returned
+        // nothing for a recent block). Throw so it counts as a retryable attempt instead of
+        // propagating straight to a hard "could not be retrieved" failure on the first miss.
+        if (result == null || result.timestamp == null) {
+          throw new Error(`Block ${block} could not be retrieved`)
+        }
+        return result
+      })
     }
   }
 }

--- a/src/adapters/content-validator/component.ts
+++ b/src/adapters/content-validator/component.ts
@@ -1,7 +1,6 @@
 import {
   AvlTree,
   BlockInfo,
-  EthereumProvider,
   createAvlBlockSearch,
   createBlockRepository,
   createCachingEthereumProvider,
@@ -24,11 +23,11 @@ import { createTheGraphClient } from '@dcl/content-validator/dist/validations/ac
 import { Authenticator } from '@dcl/crypto'
 import { hashV0, hashV1 } from '@dcl/hashing'
 import { createSubgraphComponent } from '@well-known-components/thegraph-component'
-import RequestManager, { HTTPProvider } from 'eth-connect'
-import { sleep } from '@dcl/snapshots-fetcher/dist/utils'
+import { HTTPProvider } from 'eth-connect'
 import { Readable } from 'stream'
 import { EnvironmentConfig } from '../../Environment'
 import { createItemChecker, createL1Checker, createL2Checker } from './checker'
+import { createEthereumProvider } from './ethereum-provider'
 import { createThirdPartyItemChecker } from './third-party-item-checker'
 import { AppComponents } from '../../types'
 import { IContentValidator } from './types'
@@ -39,53 +38,6 @@ type ContentValidatorDeps = Pick<
 > & {
   l1Provider: HTTPProvider
   l2Provider: HTTPProvider
-}
-
-// Block lookups during validation hit a single RPC provider that has no built-in retry. A
-// transient RPC error, or a momentarily-lagging replica that hasn't indexed the block yet,
-// would otherwise fail an otherwise-valid deployment with "Block <N> could not be retrieved".
-// This bounded retry sits BELOW the block-indexer LRU cache, so it only runs on an actual
-// cache-miss RPC call — cache hits are unaffected.
-const BLOCK_FETCH_MAX_RETRIES = 3
-const BLOCK_FETCH_BASE_DELAY_MS = 100
-
-async function withBlockFetchRetry<T>(operation: () => Promise<T>): Promise<T> {
-  let lastError: unknown
-  for (let attempt = 1; attempt <= BLOCK_FETCH_MAX_RETRIES; attempt++) {
-    try {
-      return await operation()
-    } catch (err) {
-      lastError = err
-      if (attempt < BLOCK_FETCH_MAX_RETRIES) {
-        // Exponential backoff with full jitter to avoid synchronized retries across the
-        // many block lookups that concurrent validations issue at once.
-        const base = BLOCK_FETCH_BASE_DELAY_MS * 2 ** (attempt - 1)
-        await sleep(base + Math.floor(Math.random() * base))
-      }
-    }
-  }
-  throw lastError
-}
-
-const createEthereumProvider = (httpProvider: HTTPProvider): EthereumProvider => {
-  const reqMan = new RequestManager(httpProvider)
-  return {
-    getBlockNumber: async (): Promise<number> => {
-      return withBlockFetchRetry(async () => (await reqMan.eth_blockNumber()) as number)
-    },
-    getBlock: async (block: number): Promise<{ timestamp: string | number }> => {
-      return withBlockFetchRetry(async () => {
-        const result = (await reqMan.eth_getBlockByNumber(block, false)) as { timestamp: string | number } | null
-        // An empty result is the symptom we actually observed in production (the RPC returned
-        // nothing for a recent block). Throw so it counts as a retryable attempt instead of
-        // propagating straight to a hard "could not be retrieved" failure on the first miss.
-        if (result == null || result.timestamp == null) {
-          throw new Error(`Block ${block} could not be retrieved`)
-        }
-        return result
-      })
-    }
-  }
 }
 
 async function createExternalCallsBag(components: Pick<AppComponents, 'storage' | 'crypto'>): Promise<ExternalCalls> {

--- a/src/adapters/content-validator/ethereum-provider.ts
+++ b/src/adapters/content-validator/ethereum-provider.ts
@@ -10,7 +10,10 @@ import RequestManager, { HTTPProvider } from 'eth-connect'
 export const BLOCK_FETCH_MAX_RETRIES = 3
 const BLOCK_FETCH_BASE_DELAY_MS = 100
 
-export async function withBlockFetchRetry<T>(operation: () => Promise<T>): Promise<T> {
+export async function withBlockFetchRetry<T>(
+  operation: () => Promise<T>,
+  onRetry?: (attempt: number, error: unknown) => void
+): Promise<T> {
   let lastError: unknown
   for (let attempt = 1; attempt <= BLOCK_FETCH_MAX_RETRIES; attempt++) {
     try {
@@ -18,6 +21,9 @@ export async function withBlockFetchRetry<T>(operation: () => Promise<T>): Promi
     } catch (err) {
       lastError = err
       if (attempt < BLOCK_FETCH_MAX_RETRIES) {
+        // Notify before backing off so callers can observe how often the RPC is being retried
+        // (a chronically flaky provider otherwise only shows up as latency).
+        onRetry?.(attempt, err)
         // Exponential backoff with full jitter to avoid synchronized retries across the
         // many block lookups that concurrent validations issue at once.
         const base = BLOCK_FETCH_BASE_DELAY_MS * 2 ** (attempt - 1)
@@ -44,14 +50,29 @@ export async function readBlock(
   return result
 }
 
-export const createEthereumProvider = (httpProvider: HTTPProvider): EthereumProvider => {
+/**
+ * Reads the current block number, throwing on an empty result so withBlockFetchRetry treats it as
+ * a retryable attempt (mirrors readBlock for the binary search's upper bound). Exported for tests.
+ */
+export async function readBlockNumber(reqMan: { eth_blockNumber(): Promise<unknown> }): Promise<number> {
+  const blockNumber = (await reqMan.eth_blockNumber()) as number | null
+  if (blockNumber == null) {
+    throw new Error('Block number could not be retrieved')
+  }
+  return blockNumber
+}
+
+export const createEthereumProvider = (
+  httpProvider: HTTPProvider,
+  onRetry?: (attempt: number, error: unknown) => void
+): EthereumProvider => {
   const reqMan = new RequestManager(httpProvider)
   return {
     getBlockNumber: async (): Promise<number> => {
-      return withBlockFetchRetry(async () => (await reqMan.eth_blockNumber()) as number)
+      return withBlockFetchRetry(() => readBlockNumber(reqMan), onRetry)
     },
     getBlock: async (block: number): Promise<{ timestamp: string | number }> => {
-      return withBlockFetchRetry(() => readBlock(reqMan, block))
+      return withBlockFetchRetry(() => readBlock(reqMan, block), onRetry)
     }
   }
 }

--- a/src/adapters/content-validator/ethereum-provider.ts
+++ b/src/adapters/content-validator/ethereum-provider.ts
@@ -1,0 +1,57 @@
+import { EthereumProvider } from '@dcl/block-indexer'
+import { sleep } from '@dcl/snapshots-fetcher/dist/utils'
+import RequestManager, { HTTPProvider } from 'eth-connect'
+
+// Block lookups during validation hit a single RPC provider that has no built-in retry. A
+// transient RPC error, or a momentarily-lagging replica that hasn't indexed the block yet,
+// would otherwise fail an otherwise-valid deployment with "Block <N> could not be retrieved".
+// This bounded retry is composed below the block-indexer LRU cache (see createEthereumProvider),
+// so it only runs on an actual cache-miss RPC call — cache hits are unaffected.
+export const BLOCK_FETCH_MAX_RETRIES = 3
+const BLOCK_FETCH_BASE_DELAY_MS = 100
+
+export async function withBlockFetchRetry<T>(operation: () => Promise<T>): Promise<T> {
+  let lastError: unknown
+  for (let attempt = 1; attempt <= BLOCK_FETCH_MAX_RETRIES; attempt++) {
+    try {
+      return await operation()
+    } catch (err) {
+      lastError = err
+      if (attempt < BLOCK_FETCH_MAX_RETRIES) {
+        // Exponential backoff with full jitter to avoid synchronized retries across the
+        // many block lookups that concurrent validations issue at once.
+        const base = BLOCK_FETCH_BASE_DELAY_MS * 2 ** (attempt - 1)
+        await sleep(base + Math.floor(Math.random() * base))
+      }
+    }
+  }
+  throw lastError
+}
+
+/**
+ * Reads a block's timestamp via the RPC. Throws on an empty result — the symptom actually seen
+ * in production, where the RPC returned nothing for a recent block — so that withBlockFetchRetry
+ * treats it as a retryable attempt instead of a hard failure on the first miss. Exported for tests.
+ */
+export async function readBlock(
+  reqMan: { eth_getBlockByNumber(block: number, returnTransactionObjects: boolean): Promise<unknown> },
+  block: number
+): Promise<{ timestamp: string | number }> {
+  const result = (await reqMan.eth_getBlockByNumber(block, false)) as { timestamp: string | number } | null
+  if (result == null || result.timestamp == null) {
+    throw new Error(`Block ${block} could not be retrieved`)
+  }
+  return result
+}
+
+export const createEthereumProvider = (httpProvider: HTTPProvider): EthereumProvider => {
+  const reqMan = new RequestManager(httpProvider)
+  return {
+    getBlockNumber: async (): Promise<number> => {
+      return withBlockFetchRetry(async () => (await reqMan.eth_blockNumber()) as number)
+    },
+    getBlock: async (block: number): Promise<{ timestamp: string | number }> => {
+      return withBlockFetchRetry(() => readBlock(reqMan, block))
+    }
+  }
+}

--- a/src/adapters/database/component.ts
+++ b/src/adapters/database/component.ts
@@ -22,7 +22,8 @@ export async function createDatabaseComponent(
     user: components.env.getConfig<string>(EnvironmentConfig.PSQL_USER),
     password: components.env.getConfig<string>(EnvironmentConfig.PSQL_PASSWORD),
     idleTimeoutMillis: components.env.getConfig<number>(EnvironmentConfig.PG_IDLE_TIMEOUT),
-    query_timeout: components.env.getConfig<number>(EnvironmentConfig.PG_QUERY_TIMEOUT)
+    query_timeout: components.env.getConfig<number>(EnvironmentConfig.PG_QUERY_TIMEOUT),
+    max: components.env.getConfig<number>(EnvironmentConfig.PG_POOL_SIZE)
   }
   const streamQueryTimeout = components.env.getConfig<number>(EnvironmentConfig.PG_STREAM_QUERY_TIMEOUT)
 

--- a/src/logic/deployment-service/component.ts
+++ b/src/logic/deployment-service/component.ts
@@ -23,6 +23,11 @@ import * as serverValidator from './server-validator'
 import ms from 'ms'
 import { TestableDeploymentService } from './types'
 
+// Upper bound on concurrent content-file writes within a single deployment. Content files are
+// content-addressed and independent, so they can be written in parallel; the cap keeps a single
+// many-file entity from fanning out into an unbounded number of simultaneous storage writes.
+const CONTENT_STORE_CONCURRENCY = 10
+
 export function isIPFSHash(hash: string): boolean {
   return IPFSv2.validate(hash)
 }
@@ -254,15 +259,19 @@ export function createDeploymentService(
     return false
   }
 
-  async function storeEntityContent(hashes: Map<string, Uint8Array>): Promise<any> {
+  async function storeEntityContent(hashes: Map<string, Uint8Array>): Promise<void> {
     // Check for if content is already stored
     const alreadyStoredHashes: Map<string, boolean> = await components.storage.existMultiple(Array.from(hashes.keys()))
 
-    // If entity was committed, then store all it's content (that isn't already stored)
-    for (const [fileHash, content] of hashes) {
-      if (!alreadyStoredHashes.get(fileHash)) {
-        await components.storage.storeStream(fileHash, bufferToStream(content))
-      }
+    // Store all the entity's not-already-stored content. The files are independent
+    // (content-addressed) and this runs before/outside the deployment transaction, so write
+    // them in bounded-parallel batches instead of one at a time to speed up multi-file deploys.
+    const filesToStore = Array.from(hashes).filter(([fileHash]) => !alreadyStoredHashes.get(fileHash))
+    for (let i = 0; i < filesToStore.length; i += CONTENT_STORE_CONCURRENCY) {
+      const batch = filesToStore.slice(i, i + CONTENT_STORE_CONCURRENCY)
+      await Promise.all(
+        batch.map(([fileHash, content]) => components.storage.storeStream(fileHash, bufferToStream(content)))
+      )
     }
   }
 

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -19,6 +19,12 @@ export const metricsDeclaration = validateMetricsDeclaration({
     labelNames: ['entity_type', 'deployment_context']
   },
 
+  dcl_block_fetch_retries_total: {
+    help: 'Total retried block RPC reads during on-chain validation (per network)',
+    type: 'counter',
+    labelNames: ['network']
+  },
+
   db_queued_queries_count: {
     help: 'Total number of queries that went through the queue since the service started',
     type: 'counter',

--- a/test/unit/adapters/content-validator/ethereum-provider.spec.ts
+++ b/test/unit/adapters/content-validator/ethereum-provider.spec.ts
@@ -1,6 +1,7 @@
 import {
   BLOCK_FETCH_MAX_RETRIES,
   readBlock,
+  readBlockNumber,
   withBlockFetchRetry
 } from '../../../../src/adapters/content-validator/ethereum-provider'
 
@@ -80,6 +81,91 @@ describe('withBlockFetchRetry', () => {
       expect(operation).toHaveBeenCalledTimes(BLOCK_FETCH_MAX_RETRIES)
     })
   })
+
+  describe('when an onRetry callback is provided and the operation eventually succeeds', () => {
+    let operation: jest.Mock
+    let onRetry: jest.Mock
+
+    beforeEach(async () => {
+      operation = jest.fn().mockRejectedValueOnce(new Error('transient')).mockResolvedValueOnce('block')
+      onRetry = jest.fn()
+      await withBlockFetchRetry(operation, onRetry)
+    })
+
+    afterEach(() => {
+      jest.clearAllMocks()
+    })
+
+    it('should invoke the callback once for the single retry', () => {
+      expect(onRetry).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('when an onRetry callback is provided and the operation always fails', () => {
+    let operation: jest.Mock
+    let onRetry: jest.Mock
+
+    beforeEach(async () => {
+      operation = jest.fn().mockRejectedValue(new Error('persistent'))
+      onRetry = jest.fn()
+      try {
+        await withBlockFetchRetry(operation, onRetry)
+      } catch {
+        // expected to throw after exhausting retries
+      }
+    })
+
+    afterEach(() => {
+      jest.clearAllMocks()
+    })
+
+    it('should invoke the callback once per retry but not for the final failed attempt', () => {
+      expect(onRetry).toHaveBeenCalledTimes(BLOCK_FETCH_MAX_RETRIES - 1)
+    })
+  })
+})
+
+describe('readBlockNumber', () => {
+  describe('when the RPC returns a block number', () => {
+    let reqMan: { eth_blockNumber: jest.Mock }
+    let result: number
+
+    beforeEach(async () => {
+      reqMan = { eth_blockNumber: jest.fn().mockResolvedValue(88544241) }
+      result = await readBlockNumber(reqMan)
+    })
+
+    afterEach(() => {
+      jest.clearAllMocks()
+    })
+
+    it('should resolve with the block number', () => {
+      expect(result).toBe(88544241)
+    })
+  })
+
+  describe('when the RPC returns an empty result', () => {
+    let reqMan: { eth_blockNumber: jest.Mock }
+    let caughtError: Error | undefined
+
+    beforeEach(async () => {
+      reqMan = { eth_blockNumber: jest.fn().mockResolvedValue(null) }
+      caughtError = undefined
+      try {
+        await readBlockNumber(reqMan)
+      } catch (err) {
+        caughtError = err as Error
+      }
+    })
+
+    afterEach(() => {
+      jest.clearAllMocks()
+    })
+
+    it('should throw a "could not be retrieved" error', () => {
+      expect(caughtError?.message).toBe('Block number could not be retrieved')
+    })
+  })
 })
 
 describe('readBlock', () => {
@@ -124,7 +210,7 @@ describe('readBlock', () => {
     })
   })
 
-  describe('and an empty result is followed by a block when retried together', () => {
+  describe('when an empty result is followed by a block on retry', () => {
     let reqMan: { eth_getBlockByNumber: jest.Mock }
     let result: { timestamp: string | number }
 

--- a/test/unit/adapters/content-validator/ethereum-provider.spec.ts
+++ b/test/unit/adapters/content-validator/ethereum-provider.spec.ts
@@ -1,0 +1,150 @@
+import {
+  BLOCK_FETCH_MAX_RETRIES,
+  readBlock,
+  withBlockFetchRetry
+} from '../../../../src/adapters/content-validator/ethereum-provider'
+
+// Make the backoff instant so retry tests don't wait on real timers.
+jest.mock('@dcl/snapshots-fetcher/dist/utils', () => ({
+  sleep: jest.fn().mockResolvedValue(undefined)
+}))
+
+describe('withBlockFetchRetry', () => {
+  describe('when the operation succeeds on the first attempt', () => {
+    let operation: jest.Mock
+    let result: string
+
+    beforeEach(async () => {
+      operation = jest.fn().mockResolvedValue('block')
+      result = await withBlockFetchRetry(operation)
+    })
+
+    afterEach(() => {
+      jest.clearAllMocks()
+    })
+
+    it('should resolve with the operation result', () => {
+      expect(result).toBe('block')
+    })
+
+    it('should call the operation exactly once', () => {
+      expect(operation).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('when the operation fails once and then succeeds', () => {
+    let operation: jest.Mock
+    let result: string
+
+    beforeEach(async () => {
+      operation = jest.fn().mockRejectedValueOnce(new Error('transient')).mockResolvedValueOnce('block')
+      result = await withBlockFetchRetry(operation)
+    })
+
+    afterEach(() => {
+      jest.clearAllMocks()
+    })
+
+    it('should resolve with the eventual success value', () => {
+      expect(result).toBe('block')
+    })
+
+    it('should retry once before succeeding', () => {
+      expect(operation).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe('when the operation fails on every attempt', () => {
+    let operation: jest.Mock
+    let caughtError: Error | undefined
+
+    beforeEach(async () => {
+      operation = jest.fn().mockRejectedValue(new Error('persistent rpc failure'))
+      caughtError = undefined
+      try {
+        await withBlockFetchRetry(operation)
+      } catch (err) {
+        caughtError = err as Error
+      }
+    })
+
+    afterEach(() => {
+      jest.clearAllMocks()
+    })
+
+    it('should reject with the last error', () => {
+      expect(caughtError?.message).toBe('persistent rpc failure')
+    })
+
+    it('should attempt the operation BLOCK_FETCH_MAX_RETRIES times', () => {
+      expect(operation).toHaveBeenCalledTimes(BLOCK_FETCH_MAX_RETRIES)
+    })
+  })
+})
+
+describe('readBlock', () => {
+  describe('when the RPC returns a block with a timestamp', () => {
+    let reqMan: { eth_getBlockByNumber: jest.Mock }
+    let result: { timestamp: string | number }
+
+    beforeEach(async () => {
+      reqMan = { eth_getBlockByNumber: jest.fn().mockResolvedValue({ timestamp: 123 }) }
+      result = await readBlock(reqMan, 88544241)
+    })
+
+    afterEach(() => {
+      jest.clearAllMocks()
+    })
+
+    it('should resolve with the returned block', () => {
+      expect(result).toEqual({ timestamp: 123 })
+    })
+  })
+
+  describe('when the RPC returns an empty result', () => {
+    let reqMan: { eth_getBlockByNumber: jest.Mock }
+    let caughtError: Error | undefined
+
+    beforeEach(async () => {
+      reqMan = { eth_getBlockByNumber: jest.fn().mockResolvedValue(null) }
+      caughtError = undefined
+      try {
+        await readBlock(reqMan, 88544241)
+      } catch (err) {
+        caughtError = err as Error
+      }
+    })
+
+    afterEach(() => {
+      jest.clearAllMocks()
+    })
+
+    it('should throw a "could not be retrieved" error naming the block', () => {
+      expect(caughtError?.message).toBe('Block 88544241 could not be retrieved')
+    })
+  })
+
+  describe('and an empty result is followed by a block when retried together', () => {
+    let reqMan: { eth_getBlockByNumber: jest.Mock }
+    let result: { timestamp: string | number }
+
+    beforeEach(async () => {
+      reqMan = {
+        eth_getBlockByNumber: jest.fn().mockResolvedValueOnce(null).mockResolvedValueOnce({ timestamp: 456 })
+      }
+      result = await withBlockFetchRetry(() => readBlock(reqMan, 88544241))
+    })
+
+    afterEach(() => {
+      jest.clearAllMocks()
+    })
+
+    it('should recover and resolve with the block once the RPC returns it', () => {
+      expect(result).toEqual({ timestamp: 456 })
+    })
+
+    it('should have queried the RPC twice', () => {
+      expect(reqMan.eth_getBlockByNumber).toHaveBeenCalledTimes(2)
+    })
+  })
+})

--- a/test/unit/adapters/database/pool-size.spec.ts
+++ b/test/unit/adapters/database/pool-size.spec.ts
@@ -2,7 +2,7 @@ import { createTestMetricsComponent } from '@dcl/metrics'
 import { createConfigComponent } from '@well-known-components/env-config-provider'
 import { ILoggerComponent } from '@well-known-components/interfaces'
 import { createLogComponent } from '@well-known-components/logger'
-import { Environment, EnvironmentConfig } from '../../../../src/Environment'
+import { Environment, EnvironmentConfig, parsePgPoolSize } from '../../../../src/Environment'
 import { metricsDeclaration } from '../../../../src/metrics'
 
 // Capture the config every `new Pool(...)` is constructed with, without opening real connections.
@@ -45,6 +45,68 @@ describe('createDatabaseComponent', () => {
 
     it('should create the main pool with that value as its max connection count', () => {
       expect(mockPoolConfigs[0]).toEqual(expect.objectContaining({ max: 37 }))
+    })
+  })
+})
+
+describe('parsePgPoolSize', () => {
+  describe('when the value is unset', () => {
+    let result: number
+
+    beforeEach(() => {
+      result = parsePgPoolSize(undefined)
+    })
+
+    it('should default to 20', () => {
+      expect(result).toBe(20)
+    })
+  })
+
+  describe('when the value is a valid positive integer', () => {
+    let result: number
+
+    beforeEach(() => {
+      result = parsePgPoolSize('50')
+    })
+
+    it('should return the parsed value', () => {
+      expect(result).toBe(50)
+    })
+  })
+
+  describe('when the value is zero', () => {
+    let result: number
+
+    beforeEach(() => {
+      result = parsePgPoolSize('0')
+    })
+
+    it('should floor at 1', () => {
+      expect(result).toBe(1)
+    })
+  })
+
+  describe('when the value is negative', () => {
+    let result: number
+
+    beforeEach(() => {
+      result = parsePgPoolSize('-5')
+    })
+
+    it('should floor at 1', () => {
+      expect(result).toBe(1)
+    })
+  })
+
+  describe('when the value is not a number', () => {
+    let result: number
+
+    beforeEach(() => {
+      result = parsePgPoolSize('not-a-number')
+    })
+
+    it('should fall back to the default of 20', () => {
+      expect(result).toBe(20)
     })
   })
 })

--- a/test/unit/adapters/database/pool-size.spec.ts
+++ b/test/unit/adapters/database/pool-size.spec.ts
@@ -1,0 +1,50 @@
+import { createTestMetricsComponent } from '@dcl/metrics'
+import { createConfigComponent } from '@well-known-components/env-config-provider'
+import { ILoggerComponent } from '@well-known-components/interfaces'
+import { createLogComponent } from '@well-known-components/logger'
+import { Environment, EnvironmentConfig } from '../../../../src/Environment'
+import { metricsDeclaration } from '../../../../src/metrics'
+
+// Capture the config every `new Pool(...)` is constructed with, without opening real connections.
+const mockPoolConfigs: Array<Record<string, unknown>> = []
+jest.mock('pg', () => {
+  const actual = jest.requireActual('pg')
+  return {
+    ...actual,
+    Pool: jest.fn().mockImplementation((config: Record<string, unknown>) => {
+      mockPoolConfigs.push(config)
+      return { connect: jest.fn(), query: jest.fn(), end: jest.fn(), on: jest.fn() }
+    })
+  }
+})
+
+import { createDatabaseComponent } from '../../../../src/adapters/database'
+
+describe('createDatabaseComponent', () => {
+  let logs: ILoggerComponent
+  let metrics: ReturnType<typeof createTestMetricsComponent>
+
+  beforeEach(async () => {
+    mockPoolConfigs.length = 0
+    logs = await createLogComponent({ config: createConfigComponent({ LOG_LEVEL: 'DEBUG' }) })
+    metrics = createTestMetricsComponent(metricsDeclaration)
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('when PG_POOL_SIZE is configured', () => {
+    let env: Environment
+
+    beforeEach(async () => {
+      env = new Environment()
+      env.setConfig(EnvironmentConfig.PG_POOL_SIZE, 37)
+      await createDatabaseComponent({ logs, env, metrics })
+    })
+
+    it('should create the main pool with that value as its max connection count', () => {
+      expect(mockPoolConfigs[0]).toEqual(expect.objectContaining({ max: 37 }))
+    })
+  })
+})

--- a/test/unit/ports/deployer.spec.ts
+++ b/test/unit/ports/deployer.spec.ts
@@ -134,6 +134,28 @@ describe('Deployer', function () {
     expect(storeSpy).not.toHaveBeenCalledWith(randomFileHash, expect.anything())
   })
 
+  it(`When an entity has more content files than the storage concurrency limit, then all of them are stored`, async () => {
+    const service = await buildDeployer()
+
+    // More files than CONTENT_STORE_CONCURRENCY (10) so the storage loop spans multiple batches.
+    const files = Array.from({ length: 12 }, (_, i) => Buffer.from(`content-file-${i}`))
+    const fileHashes = await Promise.all(files.map((file) => hashV1(file)))
+    const content = new Map(fileHashes.map((hash, i) => [`file-${i}`, hash]))
+    const [multiFileEntity, multiFileEntityFile] = await buildEntityAndFile(
+      EntityType.SCENE,
+      ['X9,Y9'],
+      Date.now(),
+      content,
+      { metadata: 'metadata' }
+    )
+    const storageSpy = jest.spyOn(service.components.storage, 'storeStream')
+
+    await service.deployEntity([multiFileEntityFile, ...files], multiFileEntity.id, auditInfo, DeploymentContext.LOCAL)
+
+    const storedHashes = storageSpy.mock.calls.map((call) => call[0])
+    expect(storedHashes).toEqual(expect.arrayContaining(fileHashes))
+  })
+
   it(`Given a pointer with no deployment, when is asked twice, then the second time cached the result is returned`, async () => {
     const service = await buildDeployer()
     const serviceSpy = jest


### PR DESCRIPTION
## what

three independent hardening changes to the deployment + sync processes. no api or schema changes.

### 1. retry on-chain block lookups (validation reliability)
block lookups during validation hit a single l1/l2 rpc provider with no retry. a transient rpc error — or a load-balanced replica that hasn't indexed a recent block yet — surfaces as `Block <n> could not be retrieved` and fails an otherwise-valid deployment (observed on a live `POST /entities`). wrapped `getBlock`/`getBlockNumber` in a bounded retry (3 attempts, exponential backoff + full jitter) that sits *below* the block-indexer lru cache, so only real cache-miss rpc calls retry. empty results (the actual failure mode) are treated as retryable; on persistent failure the same error propagates as before. each retry increments `dcl_block_fetch_retries_total{network}`, so a chronically flaky provider is visible as a metric rather than only as latency.

`src/adapters/content-validator/ethereum-provider.ts`, `src/adapters/content-validator/component.ts`, `src/metrics.ts`

### 2. configurable pg pool size (read-path latency under load)
the main pg pool used pg's implicit default of 10 connections, shared by the deploy job concurrency (batch deployer = 10) and every read endpoint. during deploy bursts, deploy transactions — each holding a connection for the whole tx — can starve reads, a likely cause of the multi-second `request_time` spikes on `/content/pointer-changes` during sync. added `PG_POOL_SIZE` (default 20, floor 1) wired into the pool `max`.

`src/Environment.ts`, `src/adapters/database/component.ts`

### 3. parallel content-file writes (deploy throughput)
`storeEntityContent` wrote a deployment's files one at a time. they're content-addressed/independent and stored before the deployment transaction, so they're now written in bounded-parallel batches (cap 10). speeds up multi-file deploys (scenes/wearables); no change for single-file/profile deploys.

`src/logic/deployment-service/component.ts`

## ops note
`PG_POOL_SIZE` defaults to 20, up from pg's implicit 10 — this roughly doubles the main-pool connections each catalyst instance can open (it also holds a separate 4-connection stream pool). before rollout, confirm postgres `max_connections` has headroom across all catalyst instances pointing at the db, and tune `PG_POOL_SIZE` down per-env if needed.

## deliberately not included
- cross-entity transaction batching: would break per-entity failure isolation and the per-pointer locks. the per-deploy pointer writes are already set-based, so the serial file writes (#3) were the real win.
- collapsing the two `isEntityDeployed` checks in the batch deployer: it's already bloom-filter guarded, and the second check is a deliberate enqueue-vs-dequeue race guard — removing it trades correctness for ~nothing.

## new config
`PG_POOL_SIZE` — max main-pool connections, default 20. backward compatible (unset → 20).

## testing
- `tsc --noEmit`: clean
- `eslint` on changed files: clean
- unit suite: 318/318 pass, including dedicated specs for the block-fetch retry / empty-result / onRetry logic (`ethereum-provider.spec.ts`), the pool-size wiring (`pool-size.spec.ts`), and the multi-file storage batch boundary (`deployer.spec.ts`). the `multipart.spec.ts` suite fails to run due to a pre-existing busboy / node-22 worker crash unrelated to these files.