### PR TITLE
chore: pin node 24 base image to sha256 digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24-alpine as base
+FROM node:24-alpine@sha256:5fa278c599dbba0c8f873d8717d50ecbb57c5ae6a53b7ab240c25135e0b65995 as base
 WORKDIR /app
 RUN apk add --no-cache git
 


### PR DESCRIPTION
pins the `node:24-alpine` base image in `Dockerfile` to an immutable sha256 digest for reproducible builds:

```
FROM node:24-alpine@sha256:5fa278c599dbba0c8f873d8717d50ecbb57c5ae6a53b7ab240c25135e0b65995 as base
```

all downstream multi-stage `FROM base` stages inherit the pinned digest. same digest used for the alpine base in decentraland/platform-actions#58.