### PR TITLE
refactor: stop writing active_pointers from the read path

### DIFF
--- a/src/logic/active-entities/component.ts
+++ b/src/logic/active-entities/component.ts
@@ -193,12 +193,18 @@ export function createActiveEntitiesComponent(
     }
   }
 
-  async function updateCache(
-    database: DatabaseClient,
+  function updateCache(
     entities: Entity[],
     { pointers, entityIds }: { pointers?: string[]; entityIds?: string[] }
-  ): Promise<void> {
-    await Promise.all(entities.map((entity) => update(database, entity.pointers, entity)))
+  ): void {
+    // In-memory cache only — the read path does NOT write `active_pointers`. That table is a
+    // denormalized (active pointer → entity_id) index: it is backfilled at migration time and
+    // maintained transactionally by the deploy/sync write path, so re-writing it here was redundant
+    // and its fire-and-forget nature could clobber a concurrent deploy's fresh mapping with a stale
+    // one. Reads just refresh the in-process cache.
+    for (const entity of entities) {
+      updateInCache(entity.pointers, entity)
+    }
 
     // Check which pointers or ids doesn't have an active entity and set as NONE
     if (pointers) {
@@ -238,13 +244,9 @@ export function createActiveEntitiesComponent(
     }
 
     const entities = mapDeploymentsToEntities(deployments)
-    // Fire-and-forget the cache write so this read (GET /entities/active) doesn't block on — or fail
-    // with — an `active_pointers` write: the caller already has its result in `entities`. `.catch`
-    // handles the rejection that would otherwise be unhandled; awaiting it instead would turn a
-    // transient write error (deadlock, read-only replica) into a 500 on an otherwise-successful read.
-    void updateCache(database, entities, { pointers, entityIds }).catch((error) =>
-      logger.error(`Failed to update the active entities cache: ${error}`)
-    )
+    // Refresh the in-process cache only; the deploy/sync path owns `active_pointers` (see updateCache).
+    // This is synchronous and DB-free, so the read neither blocks on nor can fail from a cache write.
+    updateCache(entities, { pointers, entityIds })
 
     return entities
   }


### PR DESCRIPTION
## Summary

Stacked on #1945. Removes the `active_pointers` DB write from the active-entities **read** path, so that table is maintained exclusively by the deploy/sync **write** path.

## Why the read path was writing it

`active_pointers` is a denormalized index of *(active pointer → entity_id)*. It is:
- **backfilled** at migration time (`create_active_pointers`, `INSERT ... SELECT UNNEST(entity_pointers) ... WHERE deleter_deployment IS NULL`), and
- **maintained transactionally** by every deploy/sync (`updateInDatabase` inside the deploy transaction).

The read path (`findEntities → updateCache`) *also* upserted it on every cache miss. In a consistent DB this only ever rewrote rows that already existed — redundant — and because it was fire-and-forget it could land after a concurrent deploy and **clobber the deploy's fresh mapping with a stale one** (a real race flagged in the audit review).

## Why it's safe to remove

- The **primary** active-entity read (`getDeploymentsForActiveEntities`) reads from `deployments`, not `active_pointers` — unaffected.
- Overwrite detection's `overwrote` side (`calculateOverwrote`) reads from `deployments` — unaffected.
- `active_pointers` backs only: the **fast** overwrite check (`calculateOverwrittenByManyFast`, with a slow `deployments`-based fallback for scenes) and the **collection-prefix listings** (`getItemEntitiesIdsThatMatchCollectionUrnPrefix`). Both are kept current by the write path + migration backfill.

Net: `updateCache` becomes a synchronous, in-memory-only cache refresh; the read incurs no DB write, no floating promise, and no clobber race.

## Trade-off

Removes a lazy self-heal: if `active_pointers` ever drifted from `deployments` (past bug / manual surgery), a read would previously repair it. It no longer does. If that's a concern, a periodic reconciliation job is a better home for it than the hot read path.

## Testing

- `yarn build`, `yarn lint:check` — clean
- `yarn test:unit` — 343/343
- Integration: active-entities, active-pointers, all deployer specs (order/overlap/timestamp/concurrent), garbage-collection, deployment-filters — green
