### PR TITLE
fix: restore content/ runtime path and bump node base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24-alpine@sha256:5fa278c599dbba0c8f873d8717d50ecbb57c5ae6a53b7ab240c25135e0b65995 as base
+FROM node:24-alpine@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd as base
 WORKDIR /app
 RUN apk add --no-cache git
 
@@ -22,7 +22,10 @@ RUN apk update && apk upgrade
 
 COPY --from=dependencies /app/node_modules ./node_modules/
 
-COPY --from=catalyst-builder /app/dist/src ./
+# Emit the runtime under /app/content so the entrypoint stays at
+# /app/content/entrypoints/run-server.js, matching the peer deployment's start
+# command. blocks-cache CSVs live at /app and are read relative to cwd (/app).
+COPY --from=catalyst-builder /app/dist/src content/
 COPY --from=catalyst-builder /app/blocks-cache-*.csv /app/
 
 # https://docs.docker.com/engine/reference/builder/#arg
@@ -46,4 +49,4 @@ RUN apk add --no-cache tini
 ENTRYPOINT ["/sbin/tini", "--"]
 
 # Run the program under Tini
-CMD [ "/usr/local/bin/node", "--max-old-space-size=8192", "entrypoints/run-server.js" ]
+CMD [ "/usr/local/bin/node", "--max-old-space-size=8192", "content/entrypoints/run-server.js" ]


### PR DESCRIPTION
## Problem

The content server was crash-looping in prod (the peer node), never coming up:

```
Error: Cannot find module '/app/content/entrypoints/run-server.js'
  code: 'MODULE_NOT_FOUND'
```

While it was down, `lamb2` sat spinning on `isContentServerReady → http://content-server:6969/status`.

## Root cause

The peer deployment launches the content server with the command
`content/entrypoints/run-server.js` (cwd `/app`). PR #1934 (*remove lambdas
workspace and flatten monorepo*) changed the final image so the compiled output
lands at `/app` instead of `/app/content`, and updated the image `CMD` to
`entrypoints/run-server.js`:

```diff
-COPY --from=catalyst-builder /app/content/dist/src content/
+COPY --from=catalyst-builder /app/dist/src ./
-CMD [ ..., "content/entrypoints/run-server.js" ]
+CMD [ ..., "entrypoints/run-server.js" ]
```

The image is internally consistent, but the **deployment's start command still
uses the old `content/`-prefixed path**. Once the flattened image was rolled out,
that command pointed at a file that no longer existed → `MODULE_NOT_FOUND` →
permanent restart loop.

## Fix

Restore the pre-#1934 runtime layout so the image is self-sufficient regardless
of the orchestrator's start command (no coordinated deploy-repo change required):

- copy the compiled output to `/app/content` again
- run `content/entrypoints/run-server.js`
- `blocks-cache-*.csv` stay at `/app` — they're loaded via a bare relative path
  (`blocks-cache-${network}.csv` in `content-validator`) resolved against cwd `/app`,
  exactly as in the known-good pre-flatten setup

This reproduces the exact directory layout the server ran on for weeks before the
flatten.

## Node base image bump

Refreshed the pinned `node:24-alpine` digest to the current tag
(`sha256:a0b9bf06…`), which now provides **Node 24.18.0** (was 24.17.0). Verified
the multi-arch manifest-list digest matches `node:24.18.0-alpine`. Stays on the
major pinned in `.nvmrc` (24).

## Note

The longer-term alternative is to update the peer deployment's start command to the
flattened `entrypoints/run-server.js` and re-drop the `content/` prefix here. This PR
takes the image-self-sufficient route so a redeploy restores service without touching
the orchestrator.

## Out of scope

The `emoteDataADR74` validation rejections, the `ENOTFOUND *.decentraland.zone`
sync-bootstrap failures, and the parcel `(-133,-42)` access rejection in the logs
are pre-existing and unrelated to this crash loop.