### PR TITLE
feat: support partial (multi-request) scene uploads

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -7,3 +7,5 @@ The content server can be configured by environment variables.
 - `DENYLIST_URLS`: List of denylists used by the content server. Separated by new lines `\n`. Default: "https://config.decentraland.org/denylist"
 - `DENYLIST_FILE_NAME`: Filename to be used as local denylist. Default: "denylist.txt"
 - `SYNC_IGNORED_ENTITY_TYPES`: Ignored entity types, separated by comma. Prevents certain entities from being pulled from DAO catalysts. Default: ""
+- `PENDING_DEPLOYMENT_TTL`: How long a partial (multi-request) deployment may stay pending before it is reclaimed, in milliseconds. Anchors the deployment-timestamp TTL check for staged uploads and the expiry job. Default: "86400000" (24h)
+- `PENDING_DEPLOYMENTS_CLEANUP_INTERVAL`: How often the job that deletes expired pending deployments runs, in milliseconds. Default: "3600000" (1h)

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@dcl/catalyst-api-specs": "^3.8.0",
     "@dcl/catalyst-contracts": "^4.4.2",
     "@dcl/catalyst-storage": "4.6.1",
-    "@dcl/content-validator": "^7.3.3",
+    "@dcl/content-validator": "^7.4.0",
     "@dcl/core-commons": "^0.10.1",
     "@dcl/crypto": "^3.7.0",
     "@dcl/fetch-component": "1.1.1",

--- a/src/Environment.ts
+++ b/src/Environment.ts
@@ -253,6 +253,8 @@ export enum EnvironmentConfig {
   PG_POOL_SIZE,
   GARBAGE_COLLECTION,
   GARBAGE_COLLECTION_INTERVAL,
+  PENDING_DEPLOYMENT_TTL,
+  PENDING_DEPLOYMENTS_CLEANUP_INTERVAL,
   BLOOM_FILTER_EXPECTED_ELEMENTS,
   SEQUENTIAL_TASK_CONCURRENCY,
   ENTITIES_CACHE_CONTROL_MAX_AGE,
@@ -494,6 +496,14 @@ export class EnvironmentBuilder {
     )
     this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.GARBAGE_COLLECTION_INTERVAL, () =>
       parseMsEnv('GARBAGE_COLLECTION_INTERVAL', ms('6h'))
+    )
+    // How long a partial (multi-request) deployment may stay pending before it is reclaimed. Anchors
+    // both the deployment-TTL check for staged uploads and the expiry job that deletes stale rows.
+    this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.PENDING_DEPLOYMENT_TTL, () =>
+      parseMsEnv('PENDING_DEPLOYMENT_TTL', ms('24h'))
+    )
+    this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.PENDING_DEPLOYMENTS_CLEANUP_INTERVAL, () =>
+      parseMsEnv('PENDING_DEPLOYMENTS_CLEANUP_INTERVAL', ms('1h'))
     )
     this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.BLOOM_FILTER_EXPECTED_ELEMENTS, () => {
       const parsed = parseInt(process.env.BLOOM_FILTER_EXPECTED_ELEMENTS ?? '', 10)

--- a/src/Environment.ts
+++ b/src/Environment.ts
@@ -255,6 +255,7 @@ export enum EnvironmentConfig {
   GARBAGE_COLLECTION_INTERVAL,
   PENDING_DEPLOYMENT_TTL,
   PENDING_DEPLOYMENTS_CLEANUP_INTERVAL,
+  MAX_PENDING_DEPLOYMENTS_PER_DEPLOYER,
   BLOOM_FILTER_EXPECTED_ELEMENTS,
   SEQUENTIAL_TASK_CONCURRENCY,
   ENTITIES_CACHE_CONTROL_MAX_AGE,
@@ -505,6 +506,11 @@ export class EnvironmentBuilder {
     this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.PENDING_DEPLOYMENTS_CLEANUP_INTERVAL, () =>
       parseMsEnv('PENDING_DEPLOYMENTS_CLEANUP_INTERVAL', ms('1h'))
     )
+    this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.MAX_PENDING_DEPLOYMENTS_PER_DEPLOYER, () => {
+      const parsed = parseInt(process.env.MAX_PENDING_DEPLOYMENTS_PER_DEPLOYER ?? '', 10)
+      // Max concurrent non-expired pending (partial) uploads one deployer may have in flight. Floor at 1.
+      return Number.isNaN(parsed) ? 10 : Math.max(parsed, 1)
+    })
     this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.BLOOM_FILTER_EXPECTED_ELEMENTS, () => {
       const parsed = parseInt(process.env.BLOOM_FILTER_EXPECTED_ELEMENTS ?? '', 10)
       // Floor at 1: a 0/negative value would make BloomFilter.create() a degenerate 0-size filter.

--- a/src/adapters/content-files-repository/component.ts
+++ b/src/adapters/content-files-repository/component.ts
@@ -57,25 +57,19 @@ async function saveContentFiles(
 async function* streamContentHashesNotBeingUsedAnymore(
   database: DatabaseClient,
   lastGarbageCollectionTimestamp: number,
-  // A content hash referenced by a non-expired pending (partial) deployment must never become a GC
-  // candidate — its content is staged but not yet attached to any deployment. The findReferencedHashes
-  // re-check below is authoritative; this anti-join is defense in depth (both cover the byte-identical
-  // collision where the same hash is also referenced by an already-overwritten deployment).
-  pendingDeploymentTtlMs: number,
   options?: { batchSize?: number }
 ): AsyncIterable<string> {
-  const pendingCutoff = Date.now() - pendingDeploymentTtlMs
+  // This only produces GC *candidates*; pending (partial) deployments are not excluded here. The
+  // per-batch findReferencedHashes re-check (which includes non-expired pending entity ids and content
+  // hashes) runs immediately before deletion and is authoritative, so over-producing candidates is
+  // safe. A correlated pending_deployments anti-join here would run per content_files row across the
+  // whole table for no protection the re-check doesn't already provide.
   const query = SQL`
     SELECT content_files.content_hash
     FROM content_files
     INNER JOIN deployments ON content_files.deployment=id
     LEFT JOIN deployments AS dd ON deployments.deleter_deployment=dd.id
-    WHERE (dd.local_timestamp IS NULL OR dd.local_timestamp > to_timestamp(${lastGarbageCollectionTimestamp} / 1000.0))
-    AND NOT EXISTS (
-      SELECT 1 FROM pending_deployments pd
-      WHERE pd.created_at > to_timestamp(${pendingCutoff} / 1000.0)
-      AND (pd.content_hashes @> ARRAY[content_files.content_hash] OR pd.entity_id = content_files.content_hash)
-    )
+    WHERE dd.local_timestamp IS NULL OR dd.local_timestamp > to_timestamp(${lastGarbageCollectionTimestamp} / 1000.0)
     GROUP BY content_files.content_hash
     HAVING bool_or(deployments.deleter_deployment IS NULL) = FALSE
   `

--- a/src/adapters/content-files-repository/component.ts
+++ b/src/adapters/content-files-repository/component.ts
@@ -57,14 +57,25 @@ async function saveContentFiles(
 async function* streamContentHashesNotBeingUsedAnymore(
   database: DatabaseClient,
   lastGarbageCollectionTimestamp: number,
+  // A content hash referenced by a non-expired pending (partial) deployment must never become a GC
+  // candidate — its content is staged but not yet attached to any deployment. The findReferencedHashes
+  // re-check below is authoritative; this anti-join is defense in depth (both cover the byte-identical
+  // collision where the same hash is also referenced by an already-overwritten deployment).
+  pendingDeploymentTtlMs: number,
   options?: { batchSize?: number }
 ): AsyncIterable<string> {
+  const pendingCutoff = Date.now() - pendingDeploymentTtlMs
   const query = SQL`
     SELECT content_files.content_hash
     FROM content_files
     INNER JOIN deployments ON content_files.deployment=id
     LEFT JOIN deployments AS dd ON deployments.deleter_deployment=dd.id
-    WHERE dd.local_timestamp IS NULL OR dd.local_timestamp > to_timestamp(${lastGarbageCollectionTimestamp} / 1000.0)
+    WHERE (dd.local_timestamp IS NULL OR dd.local_timestamp > to_timestamp(${lastGarbageCollectionTimestamp} / 1000.0))
+    AND NOT EXISTS (
+      SELECT 1 FROM pending_deployments pd
+      WHERE pd.created_at > to_timestamp(${pendingCutoff} / 1000.0)
+      AND (pd.content_hashes @> ARRAY[content_files.content_hash] OR pd.entity_id = content_files.content_hash)
+    )
     GROUP BY content_files.content_hash
     HAVING bool_or(deployments.deleter_deployment IS NULL) = FALSE
   `
@@ -89,10 +100,15 @@ async function* streamContentHashesNotBeingUsedAnymore(
  * The three checks matter because storage is one namespace shared by content files, entity JSONs and
  * snapshot files, and byte-identical files collide on hash.
  */
-async function findReferencedHashes(database: DatabaseClient, hashes: string[]): Promise<Set<string>> {
+async function findReferencedHashes(
+  database: DatabaseClient,
+  hashes: string[],
+  pendingDeploymentTtlMs: number
+): Promise<Set<string>> {
   if (hashes.length === 0) {
     return new Set()
   }
+  const pendingCutoff = Date.now() - pendingDeploymentTtlMs
   const query = SQL`
     SELECT cf.content_hash AS hash
       FROM content_files cf
@@ -102,6 +118,12 @@ async function findReferencedHashes(database: DatabaseClient, hashes: string[]):
     SELECT hash FROM snapshots WHERE hash = ANY(${hashes})
     UNION
     SELECT entity_id AS hash FROM deployments WHERE entity_id = ANY(${hashes})
+    UNION
+    SELECT entity_id AS hash FROM pending_deployments
+      WHERE created_at > to_timestamp(${pendingCutoff} / 1000.0) AND entity_id = ANY(${hashes})
+    UNION
+    SELECT unnest(content_hashes) AS hash FROM pending_deployments
+      WHERE created_at > to_timestamp(${pendingCutoff} / 1000.0) AND content_hashes && ${hashes}
   `
   const result = await database.queryWithValues<{ hash: string }>(query, 'gc_recheck_referenced_hashes')
   return new Set(result.rows.map((row) => row.hash))

--- a/src/adapters/content-files-repository/types.ts
+++ b/src/adapters/content-files-repository/types.ts
@@ -15,12 +15,14 @@ export interface IContentFilesRepository {
   streamContentHashesNotBeingUsedAnymore(
     db: DatabaseClient,
     lastGarbageCollectionTimestamp: number,
+    pendingDeploymentTtlMs: number,
     options?: { batchSize?: number }
   ): AsyncIterable<string>
   /**
    * From a set of candidate hashes, return those still referenced (by an active deployment, a
-   * snapshot, or an entity id) and therefore unsafe to delete from storage.
+   * snapshot, an entity id, or a non-expired pending partial deployment) and therefore unsafe to
+   * delete from storage.
    */
-  findReferencedHashes(db: DatabaseClient, hashes: string[]): Promise<Set<string>>
+  findReferencedHashes(db: DatabaseClient, hashes: string[], pendingDeploymentTtlMs: number): Promise<Set<string>>
   streamAllDistinctContentFileHashes(db: DatabaseClient): AsyncIterable<string>
 }

--- a/src/adapters/content-files-repository/types.ts
+++ b/src/adapters/content-files-repository/types.ts
@@ -15,7 +15,6 @@ export interface IContentFilesRepository {
   streamContentHashesNotBeingUsedAnymore(
     db: DatabaseClient,
     lastGarbageCollectionTimestamp: number,
-    pendingDeploymentTtlMs: number,
     options?: { batchSize?: number }
   ): AsyncIterable<string>
   /**

--- a/src/adapters/content-validator/component.ts
+++ b/src/adapters/content-validator/component.ts
@@ -252,24 +252,29 @@ async function createSubgraphAccessValidateFn(
  * request, before all of its content files are necessarily present. Excludes the size validation
  * (replaced by a cumulative check in the partial-deployments component) and the content-completeness
  * validation (only checkable at finalize). `accessValidateFn` runs last because it is the expensive
- * on-chain / subgraph call.
+ * on-chain / subgraph call; `includeAccessCheck: false` builds the resume variant that omits it (see
+ * IContentValidator.validateStagingScene for when that is safe).
  */
 function createStagingSceneValidateFn(
   components: Pick<AppComponents, 'logs'>,
   externalCalls: ExternalCalls,
-  accessValidateFn: ValidateFn
+  accessValidateFn: ValidateFn,
+  includeAccessCheck: boolean
 ): ValidateFn {
   const { logs } = components
-  return validateAll(
+  const validations = [
     entityStructureValidationFn,
     ipfsHashingValidateFn,
     metadataValidateFn,
     adr45ValidateFn,
     createSignatureValidateFn({ logs, externalCalls, accessValidateFn }),
     sceneValidateFn,
-    allHashesInUploadedFilesAreReportedInTheEntityValidateFn,
-    accessValidateFn
-  )
+    allHashesInUploadedFilesAreReportedInTheEntityValidateFn
+  ]
+  if (includeAccessCheck) {
+    validations.push(accessValidateFn)
+  }
+  return validateAll(...validations)
 }
 
 /**
@@ -307,11 +312,13 @@ export async function createContentValidator(components: ContentValidatorDeps): 
   }
 
   const validate = createValidator({ logs, externalCalls, accessValidateFn })
-  const validateStagingScene = createStagingSceneValidateFn(components, externalCalls, accessValidateFn)
+  const validateStagingWithAccess = createStagingSceneValidateFn(components, externalCalls, accessValidateFn, true)
+  const validateStagingWithoutAccess = createStagingSceneValidateFn(components, externalCalls, accessValidateFn, false)
 
   return {
     validate,
-    validateStagingScene,
+    validateStagingScene: (deployment, options) =>
+      options?.skipAccessCheck ? validateStagingWithoutAccess(deployment) : validateStagingWithAccess(deployment),
     getMaxSizeInBytesPerPointer: (type: EntityType) => entityParameters[type].maxSizeInMB * 1024 * 1024
   }
 }

--- a/src/adapters/content-validator/component.ts
+++ b/src/adapters/content-validator/component.ts
@@ -81,8 +81,8 @@ async function createExternalCallsBag(
 }
 
 // Each of the three strategy helpers below returns the *access* validate fn (LAND/ownership/ACL check)
-// only. The caller composes it into the full validator via `createValidator` and — for staging — into
-// the content-independent subset via `validateAll`, so both paths run the identical access check.
+// only. The caller composes it into the full validator via `createValidator` and — for staging — via
+// `createStagingValidator` (@dcl/content-validator), so both paths run the identical access check.
 async function createIgnoreBlockchainAccessValidateFn(): Promise<ValidateFn> {
   return (_d: DeploymentToValidate) => Promise.resolve(OK)
 }

--- a/src/adapters/content-validator/component.ts
+++ b/src/adapters/content-validator/component.ts
@@ -20,6 +20,20 @@ import { createOnChainAccessCheckValidateFns } from '@dcl/content-validator/dist
 import { createOnChainClient } from '@dcl/content-validator/dist/validations/access/on-chain/client'
 import { createSubgraphAccessCheckValidateFns } from '@dcl/content-validator/dist/validations/access/subgraph'
 import { createTheGraphClient } from '@dcl/content-validator/dist/validations/access/subgraph/the-graph-client'
+// Individual validation fns, composed into the partial-deployment staging subset (validateStagingScene).
+// The library already exposes these via deep imports (see the access/* imports above); we reuse the
+// content-independent ones so a staging request can be fully authenticated and access-checked without
+// requiring every content file to be present yet.
+import { validateAll } from '@dcl/content-validator/dist/validations/validations'
+import { entityStructureValidationFn } from '@dcl/content-validator/dist/validations/entity-structure'
+import { ipfsHashingValidateFn } from '@dcl/content-validator/dist/validations/ipfs-hashing'
+import { metadataValidateFn } from '@dcl/content-validator/dist/validations/metadata-schema'
+import { adr45ValidateFn } from '@dcl/content-validator/dist/validations/ADR45'
+import { createSignatureValidateFn } from '@dcl/content-validator/dist/validations/signature'
+import { sceneValidateFn } from '@dcl/content-validator/dist/validations/scene'
+import { allHashesInUploadedFilesAreReportedInTheEntityValidateFn } from '@dcl/content-validator/dist/validations/content'
+import { entityParameters } from '@dcl/content-validator/dist/validations/ADR51'
+import { EntityType } from '@dcl/schemas'
 import { toCoreFetcher } from '../../logic/to-core-fetcher'
 import { Authenticator } from '@dcl/crypto'
 import { hashV0, hashV1 } from '@dcl/hashing'
@@ -77,19 +91,14 @@ async function createExternalCallsBag(
   }
 }
 
-async function createIgnoreBlockchainAccessValidateFn(
-  components: Pick<AppComponents, 'logs'>,
-  externalCalls: ExternalCalls
-): Promise<ValidateFn> {
-  const { logs } = components
-  return createValidator({
-    logs,
-    externalCalls,
-    accessValidateFn: (_d: DeploymentToValidate) => Promise.resolve(OK)
-  })
+// Each of the three strategy helpers below returns the *access* validate fn (LAND/ownership/ACL check)
+// only. The caller composes it into the full validator via `createValidator` and — for staging — into
+// the content-independent subset via `validateAll`, so both paths run the identical access check.
+async function createIgnoreBlockchainAccessValidateFn(): Promise<ValidateFn> {
+  return (_d: DeploymentToValidate) => Promise.resolve(OK)
 }
 
-async function createOnChainValidateFn(
+async function createOnChainAccessValidateFn(
   components: Pick<AppComponents, 'env' | 'metrics' | 'logs'>,
   externalCalls: ExternalCalls,
   l1Provider: HTTPProvider,
@@ -181,14 +190,10 @@ async function createOnChainValidateFn(
     L2
   })
 
-  return createValidator({
-    logs,
-    externalCalls,
-    accessValidateFn: createAccessValidateFn({ externalCalls }, validateFns)
-  })
+  return createAccessValidateFn({ externalCalls }, validateFns)
 }
 
-async function createSubgraphValidateFn(
+async function createSubgraphAccessValidateFn(
   components: Pick<AppComponents, 'env' | 'metrics' | 'config' | 'logs' | 'fetcher'>,
   externalCalls: ExternalCalls
 ): Promise<ValidateFn> {
@@ -239,11 +244,32 @@ async function createSubgraphValidateFn(
     tokenAddresses
   })
 
-  return createValidator({
-    logs,
-    externalCalls,
-    accessValidateFn: createAccessValidateFn({ externalCalls }, validateFns)
-  })
+  return createAccessValidateFn({ externalCalls }, validateFns)
+}
+
+/**
+ * The content-independent validations that a partial (staging) scene deployment must pass on every
+ * request, before all of its content files are necessarily present. Excludes the size validation
+ * (replaced by a cumulative check in the partial-deployments component) and the content-completeness
+ * validation (only checkable at finalize). `accessValidateFn` runs last because it is the expensive
+ * on-chain / subgraph call.
+ */
+function createStagingSceneValidateFn(
+  components: Pick<AppComponents, 'logs'>,
+  externalCalls: ExternalCalls,
+  accessValidateFn: ValidateFn
+): ValidateFn {
+  const { logs } = components
+  return validateAll(
+    entityStructureValidationFn,
+    ipfsHashingValidateFn,
+    metadataValidateFn,
+    adr45ValidateFn,
+    createSignatureValidateFn({ logs, externalCalls, accessValidateFn }),
+    sceneValidateFn,
+    allHashesInUploadedFilesAreReportedInTheEntityValidateFn,
+    accessValidateFn
+  )
 }
 
 /**
@@ -264,7 +290,7 @@ export async function createContentValidator(components: ContentValidatorDeps): 
   const l2HttpProviderUrl: string | undefined = env.getConfig(EnvironmentConfig.L2_HTTP_PROVIDER_URL)
   const useOnChainValidator = !!(l1HttpProviderUrl && l2HttpProviderUrl)
 
-  let validate: ValidateFn
+  let accessValidateFn: ValidateFn
   if (ignoreBlockchainAccess) {
     // This bypasses all on-chain ownership/access checks, so any signed request can
     // deploy entities for pointers it does not own. It exists for tests/local dev only;
@@ -273,12 +299,19 @@ export async function createContentValidator(components: ContentValidatorDeps): 
       'IGNORE_BLOCKCHAIN_ACCESS_CHECKS is enabled: blockchain ownership/access validation is DISABLED. ' +
         'Deployments will NOT be checked for pointer ownership. This must never be set in production.'
     )
-    validate = await createIgnoreBlockchainAccessValidateFn(components, externalCalls)
+    accessValidateFn = await createIgnoreBlockchainAccessValidateFn()
   } else if (useOnChainValidator) {
-    validate = await createOnChainValidateFn(components, externalCalls, l1Provider, l2Provider)
+    accessValidateFn = await createOnChainAccessValidateFn(components, externalCalls, l1Provider, l2Provider)
   } else {
-    validate = await createSubgraphValidateFn(components, externalCalls)
+    accessValidateFn = await createSubgraphAccessValidateFn(components, externalCalls)
   }
 
-  return { validate }
+  const validate = createValidator({ logs, externalCalls, accessValidateFn })
+  const validateStagingScene = createStagingSceneValidateFn(components, externalCalls, accessValidateFn)
+
+  return {
+    validate,
+    validateStagingScene,
+    getMaxSizeInBytesPerPointer: (type: EntityType) => entityParameters[type].maxSizeInMB * 1024 * 1024
+  }
 }

--- a/src/adapters/content-validator/component.ts
+++ b/src/adapters/content-validator/component.ts
@@ -13,6 +13,7 @@ import {
   OK,
   TokenAddresses,
   ValidateFn,
+  createStagingValidator,
   createValidator
 } from '@dcl/content-validator'
 import { createAccessValidateFn } from '@dcl/content-validator/dist/validations/access'
@@ -20,18 +21,6 @@ import { createOnChainAccessCheckValidateFns } from '@dcl/content-validator/dist
 import { createOnChainClient } from '@dcl/content-validator/dist/validations/access/on-chain/client'
 import { createSubgraphAccessCheckValidateFns } from '@dcl/content-validator/dist/validations/access/subgraph'
 import { createTheGraphClient } from '@dcl/content-validator/dist/validations/access/subgraph/the-graph-client'
-// Individual validation fns, composed into the partial-deployment staging subset (validateStagingScene).
-// The library already exposes these via deep imports (see the access/* imports above); we reuse the
-// content-independent ones so a staging request can be fully authenticated and access-checked without
-// requiring every content file to be present yet.
-import { validateAll } from '@dcl/content-validator/dist/validations/validations'
-import { entityStructureValidationFn } from '@dcl/content-validator/dist/validations/entity-structure'
-import { ipfsHashingValidateFn } from '@dcl/content-validator/dist/validations/ipfs-hashing'
-import { metadataValidateFn } from '@dcl/content-validator/dist/validations/metadata-schema'
-import { adr45ValidateFn } from '@dcl/content-validator/dist/validations/ADR45'
-import { createSignatureValidateFn } from '@dcl/content-validator/dist/validations/signature'
-import { sceneValidateFn } from '@dcl/content-validator/dist/validations/scene'
-import { allHashesInUploadedFilesAreReportedInTheEntityValidateFn } from '@dcl/content-validator/dist/validations/content'
 import { entityParameters } from '@dcl/content-validator/dist/validations/ADR51'
 import { EntityType } from '@dcl/schemas'
 import { toCoreFetcher } from '../../logic/to-core-fetcher'
@@ -248,36 +237,6 @@ async function createSubgraphAccessValidateFn(
 }
 
 /**
- * The content-independent validations that a partial (staging) scene deployment must pass on every
- * request, before all of its content files are necessarily present. Excludes the size validation
- * (replaced by a cumulative check in the partial-deployments component) and the content-completeness
- * validation (only checkable at finalize). `accessValidateFn` runs last because it is the expensive
- * on-chain / subgraph call; `includeAccessCheck: false` builds the resume variant that omits it (see
- * IContentValidator.validateStagingScene for when that is safe).
- */
-function createStagingSceneValidateFn(
-  components: Pick<AppComponents, 'logs'>,
-  externalCalls: ExternalCalls,
-  accessValidateFn: ValidateFn,
-  includeAccessCheck: boolean
-): ValidateFn {
-  const { logs } = components
-  const validations = [
-    entityStructureValidationFn,
-    ipfsHashingValidateFn,
-    metadataValidateFn,
-    adr45ValidateFn,
-    createSignatureValidateFn({ logs, externalCalls, accessValidateFn }),
-    sceneValidateFn,
-    allHashesInUploadedFilesAreReportedInTheEntityValidateFn
-  ]
-  if (includeAccessCheck) {
-    validations.push(accessValidateFn)
-  }
-  return validateAll(...validations)
-}
-
-/**
  * Wraps `@dcl/content-validator` and selects the access-check strategy at construction time
  * based on env config:
  *  - `IGNORE_BLOCKCHAIN_ACCESS_CHECKS=true`     -> skip blockchain access checks
@@ -311,9 +270,15 @@ export async function createContentValidator(components: ContentValidatorDeps): 
     accessValidateFn = await createSubgraphAccessValidateFn(components, externalCalls)
   }
 
-  const validate = createValidator({ logs, externalCalls, accessValidateFn })
-  const validateStagingWithAccess = createStagingSceneValidateFn(components, externalCalls, accessValidateFn, true)
-  const validateStagingWithoutAccess = createStagingSceneValidateFn(components, externalCalls, accessValidateFn, false)
+  // Staging validators come from @dcl/content-validator's public createStagingValidator: the
+  // content-independent subset (structure, hashing, metadata, ADR-45, signature, scene rules,
+  // no-unreferenced-files), excluding size (a cumulative check in the partial-deployments component
+  // replaces it) and content completeness (only checkable at finalize). `includeAccessCheck: false`
+  // builds the resume variant that omits the expensive access check (see validateStagingScene).
+  const validatorComponents = { logs, externalCalls, accessValidateFn }
+  const validate = createValidator(validatorComponents)
+  const validateStagingWithAccess = createStagingValidator(validatorComponents, { includeAccessCheck: true })
+  const validateStagingWithoutAccess = createStagingValidator(validatorComponents, { includeAccessCheck: false })
 
   return {
     validate,

--- a/src/adapters/content-validator/component.ts
+++ b/src/adapters/content-validator/component.ts
@@ -319,6 +319,11 @@ export async function createContentValidator(components: ContentValidatorDeps): 
     validate,
     validateStagingScene: (deployment, options) =>
       options?.skipAccessCheck ? validateStagingWithoutAccess(deployment) : validateStagingWithAccess(deployment),
+    // The access fns anchor their on-chain lookups on entity.timestamp; overriding it with "now" on a
+    // copy validates the deployer's access against the current chain state. Respects the configured
+    // access strategy, including the IGNORE_BLOCKCHAIN_ACCESS_CHECKS no-op.
+    validateCurrentAccess: (deployment) =>
+      accessValidateFn({ ...deployment, entity: { ...deployment.entity, timestamp: Date.now() } }),
     getMaxSizeInBytesPerPointer: (type: EntityType) => entityParameters[type].maxSizeInMB * 1024 * 1024
   }
 }

--- a/src/adapters/content-validator/types.ts
+++ b/src/adapters/content-validator/types.ts
@@ -18,6 +18,15 @@ export interface IContentValidator {
     deployment: DeploymentToValidate,
     options?: { skipAccessCheck?: boolean }
   ): Promise<ValidationResponse>
+  /**
+   * Runs ONLY the access check, validated against the CURRENT chain state instead of the block at
+   * `entity.timestamp`. The protocol's access validation is historical by design (required to sync and
+   * replay old deployments), which is safe for vanilla deploys because REQUEST_TTL_BACKWARDS bounds the
+   * entity's age to ~minutes. A partial upload relaxes that bound to PENDING_DEPLOYMENT_TTL, so the
+   * deploy pipeline additionally requires access *now* before such an entity goes live — otherwise land
+   * traded away mid-upload could still receive the seller's scene at finalize.
+   */
+  validateCurrentAccess(deployment: DeploymentToValidate): Promise<ValidationResponse>
   /** Per-pointer (per-parcel) size budget in bytes for an entity type, from ADR51. */
   getMaxSizeInBytesPerPointer(type: EntityType): number
 }

--- a/src/adapters/content-validator/types.ts
+++ b/src/adapters/content-validator/types.ts
@@ -1,4 +1,4 @@
-import { ValidateFn } from '@dcl/content-validator'
+import { DeploymentToValidate, ValidateFn, ValidationResponse } from '@dcl/content-validator'
 import { EntityType } from '@dcl/schemas'
 
 export interface IContentValidator {
@@ -8,8 +8,16 @@ export interface IContentValidator {
    * The subset of validations a partial (staging) scene deployment must pass before all of its content
    * is present: everything except the size and content-completeness checks. Entities are expected to be
    * of type SCENE (the caller enforces this).
+   *
+   * `skipAccessCheck` skips the (slow, on-chain/subgraph) LAND access check. Safe only when the upload
+   * already has a non-expired pending record: creating that record required passing the access check,
+   * uploaded bytes are hash-verified against the staged manifest, and finalize re-runs the full
+   * validation (including access) before anything goes live.
    */
-  validateStagingScene: ValidateFn
+  validateStagingScene(
+    deployment: DeploymentToValidate,
+    options?: { skipAccessCheck?: boolean }
+  ): Promise<ValidationResponse>
   /** Per-pointer (per-parcel) size budget in bytes for an entity type, from ADR51. */
   getMaxSizeInBytesPerPointer(type: EntityType): number
 }

--- a/src/adapters/content-validator/types.ts
+++ b/src/adapters/content-validator/types.ts
@@ -1,5 +1,15 @@
 import { ValidateFn } from '@dcl/content-validator'
+import { EntityType } from '@dcl/schemas'
 
 export interface IContentValidator {
+  /** Full deployment validation (structure, signature, access, size, content completeness, ...). */
   validate: ValidateFn
+  /**
+   * The subset of validations a partial (staging) scene deployment must pass before all of its content
+   * is present: everything except the size and content-completeness checks. Entities are expected to be
+   * of type SCENE (the caller enforces this).
+   */
+  validateStagingScene: ValidateFn
+  /** Per-pointer (per-parcel) size budget in bytes for an entity type, from ADR51. */
+  getMaxSizeInBytesPerPointer(type: EntityType): number
 }

--- a/src/adapters/pending-deployments-repository/component.ts
+++ b/src/adapters/pending-deployments-repository/component.ts
@@ -12,11 +12,6 @@ import {
 // not to collide with node-pg-migrate's migration lock.
 const PENDING_DEPLOYMENTS_ADVISORY_LOCK = 916352745601
 
-// How long a finalization lease is honored before it is considered stale and reclaimable. Must exceed
-// a real finalization (full validation + deploy) so a slow-but-alive finalizer isn't pre-empted, while
-// a crashed one doesn't wedge the upload for long.
-const FINALIZATION_LEASE_TTL_MS = 2 * 60 * 1000 // 2 minutes
-
 async function acquireStagingLock(database: DatabaseClient): Promise<void> {
   await database.queryWithValues(
     SQL`SELECT pg_advisory_xact_lock(${PENDING_DEPLOYMENTS_ADVISORY_LOCK})`,
@@ -93,44 +88,24 @@ async function deleteByEntityId(database: DatabaseClient, entityId: string): Pro
   )
 }
 
-async function acquireFinalizationLease(database: DatabaseClient, entityId: string): Promise<boolean> {
-  // Atomically flip the row to FINALIZING, but only if it isn't already being finalized by a live
-  // lease. The single UPDATE ... RETURNING is the whole critical section (the row lock serializes
-  // competing acquirers), so exactly one completing request runs the expensive deploy pipeline; others
-  // get `false`. A lease older than the TTL (a crashed finalizer) is reclaimable.
-  const staleCutoff = Date.now() - FINALIZATION_LEASE_TTL_MS
-  const result = await database.queryWithValues<{ entity_id: string }>(
-    SQL`UPDATE pending_deployments
-        SET status = 'FINALIZING', finalizing_at = now()
-        WHERE entity_id = ${entityId}
-          AND (status = 'UPLOADING' OR (status = 'FINALIZING' AND finalizing_at < to_timestamp(${staleCutoff} / 1000.0)))
-        RETURNING entity_id`,
-    'pending_deployment_acquire_lease'
-  )
-  return result.rowCount > 0
-}
-
-async function releaseFinalizationLease(database: DatabaseClient, entityId: string): Promise<void> {
-  // Return a still-present row to UPLOADING so a later request can finalize it (used when a finalize
-  // attempt fails without deploying). A successful deploy deletes the row instead, so this no-ops there.
-  await database.queryWithValues(
-    SQL`UPDATE pending_deployments SET status = 'UPLOADING', finalizing_at = NULL WHERE entity_id = ${entityId}`,
-    'pending_deployment_release_lease'
-  )
-}
-
 async function getOverlappingPointers(
   database: DatabaseClient,
   pointers: string[],
-  excludeEntityId: string
+  excludeEntityId: string,
+  ttlMs: number
 ): Promise<OverlappingPendingDeployment[]> {
   if (pointers.length === 0) {
     return []
   }
+  // Expired rows are dead state (every other read treats them as absent), so they must not surface
+  // here either — an expired overlapping upload must never cause a newer-conflict rejection.
+  const cutoff = Date.now() - ttlMs
   const result = await database.queryWithValues<{ entity_id: string; entity_timestamp: string }>(
     SQL`SELECT entity_id, entity_timestamp
         FROM pending_deployments
-        WHERE pointers && ${pointers} AND entity_id <> ${excludeEntityId}`,
+        WHERE pointers && ${pointers}
+          AND entity_id <> ${excludeEntityId}
+          AND created_at > to_timestamp(${cutoff} / 1000.0)`,
     'pending_deployment_get_overlapping'
   )
   return result.rows.map((r) => ({ entityId: r.entity_id, entityTimestamp: parseInt(r.entity_timestamp, 10) }))
@@ -207,8 +182,6 @@ export function createPendingDeploymentsRepository(): IPendingDeploymentsReposit
     getOverlappingPointers,
     deleteOverlappingPointers,
     countActiveByDeployer,
-    acquireFinalizationLease,
-    releaseFinalizationLease,
     deleteExpired,
     streamAllNonExpiredHashes,
     acquireStagingLock

--- a/src/adapters/pending-deployments-repository/component.ts
+++ b/src/adapters/pending-deployments-repository/component.ts
@@ -2,6 +2,18 @@ import SQL from 'sql-template-strings'
 import { DatabaseClient } from '../../adapters/database'
 import { IPendingDeploymentsRepository, PendingDeploymentRow, UpsertPendingDeployment } from './types'
 
+// Fixed key for the transaction-scoped advisory lock that serializes the "replace overlapping + upsert"
+// critical section across staging requests (and processes). An arbitrary distinctive constant chosen
+// not to collide with node-pg-migrate's migration lock.
+const PENDING_DEPLOYMENTS_ADVISORY_LOCK = 916352745601
+
+async function acquireStagingLock(database: DatabaseClient): Promise<void> {
+  await database.queryWithValues(
+    SQL`SELECT pg_advisory_xact_lock(${PENDING_DEPLOYMENTS_ADVISORY_LOCK})`,
+    'pending_deployment_advisory_lock'
+  )
+}
+
 interface PendingDeploymentDbRow {
   entity_id: string
   entity_type: string
@@ -112,6 +124,7 @@ export function createPendingDeploymentsRepository(): IPendingDeploymentsReposit
     deleteByEntityId,
     deleteOverlappingPointers,
     deleteExpired,
-    streamAllNonExpiredHashes
+    streamAllNonExpiredHashes,
+    acquireStagingLock
   }
 }

--- a/src/adapters/pending-deployments-repository/component.ts
+++ b/src/adapters/pending-deployments-repository/component.ts
@@ -125,13 +125,15 @@ async function deleteOverlappingPointers(
 async function countActiveByDeployer(
   database: DatabaseClient,
   deployerAddress: string,
-  ttlMs: number
+  ttlMs: number,
+  excludeEntityId: string
 ): Promise<number> {
   const cutoff = Date.now() - ttlMs
   const result = await database.queryWithValues<{ count: string }>(
     SQL`SELECT COUNT(*) AS count FROM pending_deployments
         WHERE LOWER(deployer_address) = ${deployerAddress.toLowerCase()}
-          AND created_at > to_timestamp(${cutoff} / 1000.0)`,
+          AND created_at > to_timestamp(${cutoff} / 1000.0)
+          AND entity_id <> ${excludeEntityId}`,
     'pending_deployment_count_by_deployer'
   )
   return parseInt(result.rows[0].count, 10)

--- a/src/adapters/pending-deployments-repository/component.ts
+++ b/src/adapters/pending-deployments-repository/component.ts
@@ -50,16 +50,25 @@ async function getByEntityId(database: DatabaseClient, entityId: string): Promis
   return undefined
 }
 
-async function upsert(database: DatabaseClient, row: UpsertPendingDeployment): Promise<void> {
-  // ON CONFLICT bumps only `updated_at`: `created_at` is the deployment-TTL anchor and must stay
-  // stable so resuming an upload never extends the window. entity_id is content-addressed, so the
-  // other columns are immutable for a given id anyway.
+async function upsert(database: DatabaseClient, row: UpsertPendingDeployment, ttlMs: number): Promise<void> {
+  // ON CONFLICT bumps `updated_at` and keeps `created_at` STABLE while the row is within its TTL:
+  // `created_at` is the deployment-TTL anchor, so resuming an upload must never extend the window.
+  // An EXPIRED row is the exception — it is dead state (its content is GC-eligible and reads treat it
+  // as absent), so re-staging the same entity resets `created_at` to now, starting a fresh window
+  // instead of resurrecting a permanently-expired anchor. entity_id is content-addressed, so the other
+  // columns are immutable for a given id anyway.
+  const cutoff = Date.now() - ttlMs
   await database.queryWithValues(
     SQL`INSERT INTO pending_deployments
           (entity_id, entity_type, pointers, content_hashes, deployer_address, created_at, updated_at)
         VALUES
           (${row.entityId}, ${row.entityType}, ${row.pointers}, ${row.contentHashes}, ${row.deployerAddress}, now(), now())
-        ON CONFLICT (entity_id) DO UPDATE SET updated_at = now()`,
+        ON CONFLICT (entity_id) DO UPDATE SET
+          updated_at = now(),
+          created_at = CASE
+            WHEN pending_deployments.created_at < to_timestamp(${cutoff} / 1000.0) THEN now()
+            ELSE pending_deployments.created_at
+          END`,
     'pending_deployment_upsert'
   )
 }

--- a/src/adapters/pending-deployments-repository/component.ts
+++ b/src/adapters/pending-deployments-repository/component.ts
@@ -1,6 +1,11 @@
 import SQL from 'sql-template-strings'
 import { DatabaseClient } from '../../adapters/database'
-import { IPendingDeploymentsRepository, PendingDeploymentRow, UpsertPendingDeployment } from './types'
+import {
+  IPendingDeploymentsRepository,
+  OverlappingPendingDeployment,
+  PendingDeploymentRow,
+  UpsertPendingDeployment
+} from './types'
 
 // Fixed key for the transaction-scoped advisory lock that serializes the "replace overlapping + upsert"
 // critical section across staging requests (and processes). An arbitrary distinctive constant chosen
@@ -20,6 +25,7 @@ interface PendingDeploymentDbRow {
   pointers: string[]
   content_hashes: string[]
   deployer_address: string
+  entity_timestamp: string
   created_at: Date
   updated_at: Date
 }
@@ -31,6 +37,8 @@ function toRow(row: PendingDeploymentDbRow): PendingDeploymentRow {
     pointers: row.pointers,
     contentHashes: row.content_hashes,
     deployerAddress: row.deployer_address,
+    // bigint columns come back as strings from node-pg.
+    entityTimestamp: parseInt(row.entity_timestamp, 10),
     createdAt: row.created_at,
     updatedAt: row.updated_at
   }
@@ -38,7 +46,7 @@ function toRow(row: PendingDeploymentDbRow): PendingDeploymentRow {
 
 async function getByEntityId(database: DatabaseClient, entityId: string): Promise<PendingDeploymentRow | undefined> {
   const result = await database.queryWithValues<PendingDeploymentDbRow>(
-    SQL`SELECT entity_id, entity_type, pointers, content_hashes, deployer_address, created_at, updated_at
+    SQL`SELECT entity_id, entity_type, pointers, content_hashes, deployer_address, entity_timestamp, created_at, updated_at
         FROM pending_deployments
         WHERE entity_id = ${entityId}
         LIMIT 1`,
@@ -60,9 +68,9 @@ async function upsert(database: DatabaseClient, row: UpsertPendingDeployment, tt
   const cutoff = Date.now() - ttlMs
   await database.queryWithValues(
     SQL`INSERT INTO pending_deployments
-          (entity_id, entity_type, pointers, content_hashes, deployer_address, created_at, updated_at)
+          (entity_id, entity_type, pointers, content_hashes, deployer_address, entity_timestamp, created_at, updated_at)
         VALUES
-          (${row.entityId}, ${row.entityType}, ${row.pointers}, ${row.contentHashes}, ${row.deployerAddress}, now(), now())
+          (${row.entityId}, ${row.entityType}, ${row.pointers}, ${row.contentHashes}, ${row.deployerAddress}, ${row.entityTimestamp}, now(), now())
         ON CONFLICT (entity_id) DO UPDATE SET
           updated_at = now(),
           created_at = CASE
@@ -80,6 +88,23 @@ async function deleteByEntityId(database: DatabaseClient, entityId: string): Pro
   )
 }
 
+async function getOverlappingPointers(
+  database: DatabaseClient,
+  pointers: string[],
+  excludeEntityId: string
+): Promise<OverlappingPendingDeployment[]> {
+  if (pointers.length === 0) {
+    return []
+  }
+  const result = await database.queryWithValues<{ entity_id: string; entity_timestamp: string }>(
+    SQL`SELECT entity_id, entity_timestamp
+        FROM pending_deployments
+        WHERE pointers && ${pointers} AND entity_id <> ${excludeEntityId}`,
+    'pending_deployment_get_overlapping'
+  )
+  return result.rows.map((r) => ({ entityId: r.entity_id, entityTimestamp: parseInt(r.entity_timestamp, 10) }))
+}
+
 async function deleteOverlappingPointers(
   database: DatabaseClient,
   pointers: string[],
@@ -95,6 +120,21 @@ async function deleteOverlappingPointers(
     'pending_deployment_delete_overlapping'
   )
   return result.rows.map((r) => r.entity_id)
+}
+
+async function countActiveByDeployer(
+  database: DatabaseClient,
+  deployerAddress: string,
+  ttlMs: number
+): Promise<number> {
+  const cutoff = Date.now() - ttlMs
+  const result = await database.queryWithValues<{ count: string }>(
+    SQL`SELECT COUNT(*) AS count FROM pending_deployments
+        WHERE LOWER(deployer_address) = ${deployerAddress.toLowerCase()}
+          AND created_at > to_timestamp(${cutoff} / 1000.0)`,
+    'pending_deployment_count_by_deployer'
+  )
+  return parseInt(result.rows[0].count, 10)
 }
 
 async function deleteExpired(database: DatabaseClient, ttlMs: number): Promise<number> {
@@ -131,7 +171,9 @@ export function createPendingDeploymentsRepository(): IPendingDeploymentsReposit
     getByEntityId,
     upsert,
     deleteByEntityId,
+    getOverlappingPointers,
     deleteOverlappingPointers,
+    countActiveByDeployer,
     deleteExpired,
     streamAllNonExpiredHashes,
     acquireStagingLock

--- a/src/adapters/pending-deployments-repository/component.ts
+++ b/src/adapters/pending-deployments-repository/component.ts
@@ -1,0 +1,117 @@
+import SQL from 'sql-template-strings'
+import { DatabaseClient } from '../../adapters/database'
+import { IPendingDeploymentsRepository, PendingDeploymentRow, UpsertPendingDeployment } from './types'
+
+interface PendingDeploymentDbRow {
+  entity_id: string
+  entity_type: string
+  pointers: string[]
+  content_hashes: string[]
+  deployer_address: string
+  created_at: Date
+  updated_at: Date
+}
+
+function toRow(row: PendingDeploymentDbRow): PendingDeploymentRow {
+  return {
+    entityId: row.entity_id,
+    entityType: row.entity_type as PendingDeploymentRow['entityType'],
+    pointers: row.pointers,
+    contentHashes: row.content_hashes,
+    deployerAddress: row.deployer_address,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at
+  }
+}
+
+async function getByEntityId(database: DatabaseClient, entityId: string): Promise<PendingDeploymentRow | undefined> {
+  const result = await database.queryWithValues<PendingDeploymentDbRow>(
+    SQL`SELECT entity_id, entity_type, pointers, content_hashes, deployer_address, created_at, updated_at
+        FROM pending_deployments
+        WHERE entity_id = ${entityId}
+        LIMIT 1`,
+    'pending_deployment_by_id'
+  )
+  if (result.rowCount > 0) {
+    return toRow(result.rows[0])
+  }
+  return undefined
+}
+
+async function upsert(database: DatabaseClient, row: UpsertPendingDeployment): Promise<void> {
+  // ON CONFLICT bumps only `updated_at`: `created_at` is the deployment-TTL anchor and must stay
+  // stable so resuming an upload never extends the window. entity_id is content-addressed, so the
+  // other columns are immutable for a given id anyway.
+  await database.queryWithValues(
+    SQL`INSERT INTO pending_deployments
+          (entity_id, entity_type, pointers, content_hashes, deployer_address, created_at, updated_at)
+        VALUES
+          (${row.entityId}, ${row.entityType}, ${row.pointers}, ${row.contentHashes}, ${row.deployerAddress}, now(), now())
+        ON CONFLICT (entity_id) DO UPDATE SET updated_at = now()`,
+    'pending_deployment_upsert'
+  )
+}
+
+async function deleteByEntityId(database: DatabaseClient, entityId: string): Promise<void> {
+  await database.queryWithValues(
+    SQL`DELETE FROM pending_deployments WHERE entity_id = ${entityId}`,
+    'pending_deployment_delete'
+  )
+}
+
+async function deleteOverlappingPointers(
+  database: DatabaseClient,
+  pointers: string[],
+  excludeEntityId: string
+): Promise<string[]> {
+  if (pointers.length === 0) {
+    return []
+  }
+  const result = await database.queryWithValues<{ entity_id: string }>(
+    SQL`DELETE FROM pending_deployments
+        WHERE pointers && ${pointers} AND entity_id <> ${excludeEntityId}
+        RETURNING entity_id`,
+    'pending_deployment_delete_overlapping'
+  )
+  return result.rows.map((r) => r.entity_id)
+}
+
+async function deleteExpired(database: DatabaseClient, ttlMs: number): Promise<number> {
+  const cutoff = Date.now() - ttlMs
+  const result = await database.queryWithValues(
+    SQL`DELETE FROM pending_deployments WHERE created_at < to_timestamp(${cutoff} / 1000.0)`,
+    'pending_deployment_delete_expired'
+  )
+  return result.rowCount
+}
+
+async function* streamAllNonExpiredHashes(
+  database: DatabaseClient,
+  ttlMs: number,
+  options?: { batchSize?: number }
+): AsyncIterable<string> {
+  const cutoff = Date.now() - ttlMs
+  const query = SQL`
+    SELECT entity_id AS hash FROM pending_deployments WHERE created_at > to_timestamp(${cutoff} / 1000.0)
+    UNION
+    SELECT unnest(content_hashes) AS hash FROM pending_deployments WHERE created_at > to_timestamp(${cutoff} / 1000.0)
+  `
+  for await (const row of database.streamQuery<{ hash: string }>(
+    query,
+    { batchSize: options?.batchSize ?? 1000 },
+    'pending_deployment_stream_hashes'
+  )) {
+    yield row.hash
+  }
+}
+
+export function createPendingDeploymentsRepository(): IPendingDeploymentsRepository {
+  return {
+    getByEntityId,
+    upsert,
+    deleteByEntityId,
+    deleteOverlappingPointers,
+    deleteExpired,
+    streamAllNonExpiredHashes
+  }
+}

--- a/src/adapters/pending-deployments-repository/component.ts
+++ b/src/adapters/pending-deployments-repository/component.ts
@@ -12,6 +12,11 @@ import {
 // not to collide with node-pg-migrate's migration lock.
 const PENDING_DEPLOYMENTS_ADVISORY_LOCK = 916352745601
 
+// How long a finalization lease is honored before it is considered stale and reclaimable. Must exceed
+// a real finalization (full validation + deploy) so a slow-but-alive finalizer isn't pre-empted, while
+// a crashed one doesn't wedge the upload for long.
+const FINALIZATION_LEASE_TTL_MS = 2 * 60 * 1000 // 2 minutes
+
 async function acquireStagingLock(database: DatabaseClient): Promise<void> {
   await database.queryWithValues(
     SQL`SELECT pg_advisory_xact_lock(${PENDING_DEPLOYMENTS_ADVISORY_LOCK})`,
@@ -85,6 +90,32 @@ async function deleteByEntityId(database: DatabaseClient, entityId: string): Pro
   await database.queryWithValues(
     SQL`DELETE FROM pending_deployments WHERE entity_id = ${entityId}`,
     'pending_deployment_delete'
+  )
+}
+
+async function acquireFinalizationLease(database: DatabaseClient, entityId: string): Promise<boolean> {
+  // Atomically flip the row to FINALIZING, but only if it isn't already being finalized by a live
+  // lease. The single UPDATE ... RETURNING is the whole critical section (the row lock serializes
+  // competing acquirers), so exactly one completing request runs the expensive deploy pipeline; others
+  // get `false`. A lease older than the TTL (a crashed finalizer) is reclaimable.
+  const staleCutoff = Date.now() - FINALIZATION_LEASE_TTL_MS
+  const result = await database.queryWithValues<{ entity_id: string }>(
+    SQL`UPDATE pending_deployments
+        SET status = 'FINALIZING', finalizing_at = now()
+        WHERE entity_id = ${entityId}
+          AND (status = 'UPLOADING' OR (status = 'FINALIZING' AND finalizing_at < to_timestamp(${staleCutoff} / 1000.0)))
+        RETURNING entity_id`,
+    'pending_deployment_acquire_lease'
+  )
+  return result.rowCount > 0
+}
+
+async function releaseFinalizationLease(database: DatabaseClient, entityId: string): Promise<void> {
+  // Return a still-present row to UPLOADING so a later request can finalize it (used when a finalize
+  // attempt fails without deploying). A successful deploy deletes the row instead, so this no-ops there.
+  await database.queryWithValues(
+    SQL`UPDATE pending_deployments SET status = 'UPLOADING', finalizing_at = NULL WHERE entity_id = ${entityId}`,
+    'pending_deployment_release_lease'
   )
 }
 
@@ -176,6 +207,8 @@ export function createPendingDeploymentsRepository(): IPendingDeploymentsReposit
     getOverlappingPointers,
     deleteOverlappingPointers,
     countActiveByDeployer,
+    acquireFinalizationLease,
+    releaseFinalizationLease,
     deleteExpired,
     streamAllNonExpiredHashes,
     acquireStagingLock

--- a/src/adapters/pending-deployments-repository/component.ts
+++ b/src/adapters/pending-deployments-repository/component.ts
@@ -7,16 +7,32 @@ import {
   UpsertPendingDeployment
 } from './types'
 
-// Fixed key for the transaction-scoped advisory lock that serializes the "replace overlapping + upsert"
-// critical section across staging requests (and processes). An arbitrary distinctive constant chosen
-// not to collide with node-pg-migrate's migration lock.
-const PENDING_DEPLOYMENTS_ADVISORY_LOCK = 916352745601
-
-async function acquireStagingLock(database: DatabaseClient): Promise<void> {
+async function acquireStagingLocks(
+  database: DatabaseClient,
+  pointers: string[],
+  deployerAddress: string
+): Promise<void> {
+  // Serialize only the staging requests that actually contend, instead of all of them on one global
+  // lock. Two transaction-scoped advisory locks, always in this order (a consistent global acquisition
+  // order → deadlock-free):
+  // 1. Per-deployer: serializes a single deployer's concurrent staging so the per-deployer cap can't be
+  //    raced. Different deployers never contend here.
   await database.queryWithValues(
-    SQL`SELECT pg_advisory_xact_lock(${PENDING_DEPLOYMENTS_ADVISORY_LOCK})`,
-    'pending_deployment_advisory_lock'
+    SQL`SELECT pg_advisory_xact_lock(hashtextextended(${'pending_deployer:' + deployerAddress.toLowerCase()}, 0))`,
+    'pending_deployment_deployer_lock'
   )
+  // 2. Per-pointer, taken in sorted order: serializes exactly the uploads whose pointer sets overlap
+  //    (protecting the "reject-newer / replace-overlapping" critical section) while letting uploads on
+  //    disjoint pointers run concurrently. Sorting guarantees any two requests acquire shared pointer
+  //    locks in the same order, so they can't deadlock.
+  if (pointers.length > 0) {
+    await database.queryWithValues(
+      SQL`SELECT pg_advisory_xact_lock(hashtextextended('pending_pointer:' || p, 0))
+          FROM unnest(${pointers}::text[]) AS p
+          ORDER BY p`,
+      'pending_deployment_pointer_locks'
+    )
+  }
 }
 
 interface PendingDeploymentDbRow {
@@ -114,17 +130,22 @@ async function getOverlappingPointers(
 async function deleteOverlappingPointers(
   database: DatabaseClient,
   pointers: string[],
-  excludeEntityId: string
+  excludeEntityId: string,
+  onlyDeployer?: string
 ): Promise<string[]> {
   if (pointers.length === 0) {
     return []
   }
-  const result = await database.queryWithValues<{ entity_id: string }>(
-    SQL`DELETE FROM pending_deployments
-        WHERE pointers && ${pointers} AND entity_id <> ${excludeEntityId}
-        RETURNING entity_id`,
-    'pending_deployment_delete_overlapping'
-  )
+  // `onlyDeployer` restricts the destructive replace to the caller's OWN pending rows. Used on the
+  // resume fast path, which skips the (slow) access check: without the restriction, a deployer who has
+  // since lost access to these pointers could still evict a DIFFERENT deployer's freshly-staged upload.
+  // A cross-deployer newest-wins replacement only happens on a request that ran the full access check.
+  const query = SQL`DELETE FROM pending_deployments WHERE pointers && ${pointers} AND entity_id <> ${excludeEntityId}`
+  if (onlyDeployer !== undefined) {
+    query.append(SQL` AND LOWER(deployer_address) = ${onlyDeployer.toLowerCase()}`)
+  }
+  query.append(SQL` RETURNING entity_id`)
+  const result = await database.queryWithValues<{ entity_id: string }>(query, 'pending_deployment_delete_overlapping')
   return result.rows.map((r) => r.entity_id)
 }
 
@@ -184,6 +205,6 @@ export function createPendingDeploymentsRepository(): IPendingDeploymentsReposit
     countActiveByDeployer,
     deleteExpired,
     streamAllNonExpiredHashes,
-    acquireStagingLock
+    acquireStagingLocks
   }
 }

--- a/src/adapters/pending-deployments-repository/index.ts
+++ b/src/adapters/pending-deployments-repository/index.ts
@@ -1,0 +1,2 @@
+export { createPendingDeploymentsRepository } from './component'
+export type { IPendingDeploymentsRepository, PendingDeploymentRow, UpsertPendingDeployment } from './types'

--- a/src/adapters/pending-deployments-repository/types.ts
+++ b/src/adapters/pending-deployments-repository/types.ts
@@ -23,10 +23,11 @@ export interface IPendingDeploymentsRepository {
   /** Returns the pending deployment for an entity id, or undefined if none exists. */
   getByEntityId(db: DatabaseClient, entityId: string): Promise<PendingDeploymentRow | undefined>
   /**
-   * Inserts or refreshes a pending deployment. On conflict only `updated_at` is bumped so `created_at`
-   * (the deployment-TTL anchor) stays stable across resume requests.
+   * Inserts or refreshes a pending deployment. On conflict `created_at` (the deployment-TTL anchor)
+   * stays stable across resume requests while the row is within `ttlMs`; an expired row is dead state,
+   * so its `created_at` is reset to now, starting a fresh window.
    */
-  upsert(db: DatabaseClient, row: UpsertPendingDeployment): Promise<void>
+  upsert(db: DatabaseClient, row: UpsertPendingDeployment, ttlMs: number): Promise<void>
   deleteByEntityId(db: DatabaseClient, entityId: string): Promise<void>
   /**
    * Deletes every pending deployment whose pointers overlap the given ones, except `excludeEntityId`.

--- a/src/adapters/pending-deployments-repository/types.ts
+++ b/src/adapters/pending-deployments-repository/types.ts
@@ -63,6 +63,15 @@ export interface IPendingDeploymentsRepository {
     ttlMs: number,
     excludeEntityId: string
   ): Promise<number>
+  /**
+   * Atomically claims the finalization lease for a pending deployment (UPLOADING → FINALIZING, or takes
+   * over a stale FINALIZING lease). Returns true if this caller holds the lease and should run the
+   * finalization; false if another request is already finalizing. Ensures only one completing request
+   * runs the expensive validation + deploy.
+   */
+  acquireFinalizationLease(db: DatabaseClient, entityId: string): Promise<boolean>
+  /** Releases the finalization lease (FINALIZING → UPLOADING) when a finalize attempt fails without deploying. */
+  releaseFinalizationLease(db: DatabaseClient, entityId: string): Promise<void>
   /** Deletes pending deployments older than `ttlMs`. Returns the number of rows removed. */
   deleteExpired(db: DatabaseClient, ttlMs: number): Promise<number>
   /**

--- a/src/adapters/pending-deployments-repository/types.ts
+++ b/src/adapters/pending-deployments-repository/types.ts
@@ -1,0 +1,44 @@
+import { EntityType } from '@dcl/schemas'
+import { DatabaseClient } from '../../adapters/database'
+
+export interface PendingDeploymentRow {
+  entityId: string
+  entityType: EntityType
+  pointers: string[]
+  contentHashes: string[]
+  deployerAddress: string
+  createdAt: Date
+  updatedAt: Date
+}
+
+export interface UpsertPendingDeployment {
+  entityId: string
+  entityType: EntityType
+  pointers: string[]
+  contentHashes: string[]
+  deployerAddress: string
+}
+
+export interface IPendingDeploymentsRepository {
+  /** Returns the pending deployment for an entity id, or undefined if none exists. */
+  getByEntityId(db: DatabaseClient, entityId: string): Promise<PendingDeploymentRow | undefined>
+  /**
+   * Inserts or refreshes a pending deployment. On conflict only `updated_at` is bumped so `created_at`
+   * (the deployment-TTL anchor) stays stable across resume requests.
+   */
+  upsert(db: DatabaseClient, row: UpsertPendingDeployment): Promise<void>
+  deleteByEntityId(db: DatabaseClient, entityId: string): Promise<void>
+  /**
+   * Deletes every pending deployment whose pointers overlap the given ones, except `excludeEntityId`.
+   * Returns the entity ids that were removed (for logging/metrics). Enforces the "one pending
+   * deployment per parcel set" rule.
+   */
+  deleteOverlappingPointers(db: DatabaseClient, pointers: string[], excludeEntityId: string): Promise<string[]>
+  /** Deletes pending deployments older than `ttlMs`. Returns the number of rows removed. */
+  deleteExpired(db: DatabaseClient, ttlMs: number): Promise<number>
+  /**
+   * Streams the entity ids and content hashes of every non-expired pending deployment. Used by the
+   * garbage-collection bloom sweep so staged content is never reclaimed while its upload is in flight.
+   */
+  streamAllNonExpiredHashes(db: DatabaseClient, ttlMs: number, options?: { batchSize?: number }): AsyncIterable<string>
+}

--- a/src/adapters/pending-deployments-repository/types.ts
+++ b/src/adapters/pending-deployments-repository/types.ts
@@ -49,15 +49,21 @@ export interface IPendingDeploymentsRepository {
     ttlMs: number
   ): Promise<OverlappingPendingDeployment[]>
   /**
-   * Deletes every pending deployment whose pointers overlap the given ones, except `excludeEntityId`.
-   * Returns the entity ids that were removed (for logging/metrics). Enforces the "one pending
-   * deployment per parcel set" rule.
+   * Deletes every pending deployment whose pointers overlap the given ones, except `excludeEntityId`,
+   * enforcing the "one pending deployment per parcel set" rule. Returns the removed entity ids (for
+   * logging/metrics). When `onlyDeployer` is set the delete is restricted to that deployer's own rows —
+   * used on the access-check-skipping resume fast path so it can't evict another deployer's upload.
    */
-  deleteOverlappingPointers(db: DatabaseClient, pointers: string[], excludeEntityId: string): Promise<string[]>
+  deleteOverlappingPointers(
+    db: DatabaseClient,
+    pointers: string[],
+    excludeEntityId: string,
+    onlyDeployer?: string
+  ): Promise<string[]>
   /**
-   * Counts a deployer's non-expired pending deployments, excluding `excludeEntityId` (the row this
-   * request is about to insert/update). `count + 1` is the deployer's post-upsert row total, used to
-   * enforce the concurrent-pending cap on the net change rather than a stale "is this new?" flag.
+   * Counts a deployer's non-expired pending deployments (excluding `excludeEntityId`). `count + 1` is the
+   * deployer's post-upsert row total; the caller enforces the concurrent-pending cap with it, but only
+   * for a NEW upload (a resume is exempt, so lowering the cap can't wedge in-flight uploads).
    */
   countActiveByDeployer(
     db: DatabaseClient,
@@ -73,8 +79,11 @@ export interface IPendingDeploymentsRepository {
    */
   streamAllNonExpiredHashes(db: DatabaseClient, ttlMs: number, options?: { batchSize?: number }): AsyncIterable<string>
   /**
-   * Takes a transaction-scoped advisory lock serializing the pending-deployment "replace overlapping +
-   * upsert" critical section. Must be called inside a transaction; released automatically on commit.
+   * Takes the transaction-scoped advisory locks that serialize the pending-deployment "reject-newer /
+   * replace-overlapping + upsert" critical section: a per-deployer lock (guards the cap) plus one lock
+   * per pointer in sorted order (guards overlap, deadlock-free). Only contending requests serialize;
+   * uploads on disjoint pointers by different deployers proceed concurrently. Must be called inside a
+   * transaction; released automatically on commit.
    */
-  acquireStagingLock(db: DatabaseClient): Promise<void>
+  acquireStagingLocks(db: DatabaseClient, pointers: string[], deployerAddress: string): Promise<void>
 }

--- a/src/adapters/pending-deployments-repository/types.ts
+++ b/src/adapters/pending-deployments-repository/types.ts
@@ -38,13 +38,15 @@ export interface IPendingDeploymentsRepository {
   upsert(db: DatabaseClient, row: UpsertPendingDeployment, ttlMs: number): Promise<void>
   deleteByEntityId(db: DatabaseClient, entityId: string): Promise<void>
   /**
-   * Returns the pending deployments whose pointers overlap the given ones, except `excludeEntityId`,
-   * with their entity timestamps — so the caller can decide whether the incoming upload is newer.
+   * Returns the non-expired pending deployments whose pointers overlap the given ones, except
+   * `excludeEntityId`, with their entity timestamps — so the caller can decide whether the incoming
+   * upload is newer. Rows past `ttlMs` are dead state and never surface here.
    */
   getOverlappingPointers(
     db: DatabaseClient,
     pointers: string[],
-    excludeEntityId: string
+    excludeEntityId: string,
+    ttlMs: number
   ): Promise<OverlappingPendingDeployment[]>
   /**
    * Deletes every pending deployment whose pointers overlap the given ones, except `excludeEntityId`.
@@ -63,15 +65,6 @@ export interface IPendingDeploymentsRepository {
     ttlMs: number,
     excludeEntityId: string
   ): Promise<number>
-  /**
-   * Atomically claims the finalization lease for a pending deployment (UPLOADING → FINALIZING, or takes
-   * over a stale FINALIZING lease). Returns true if this caller holds the lease and should run the
-   * finalization; false if another request is already finalizing. Ensures only one completing request
-   * runs the expensive validation + deploy.
-   */
-  acquireFinalizationLease(db: DatabaseClient, entityId: string): Promise<boolean>
-  /** Releases the finalization lease (FINALIZING → UPLOADING) when a finalize attempt fails without deploying. */
-  releaseFinalizationLease(db: DatabaseClient, entityId: string): Promise<void>
   /** Deletes pending deployments older than `ttlMs`. Returns the number of rows removed. */
   deleteExpired(db: DatabaseClient, ttlMs: number): Promise<number>
   /**

--- a/src/adapters/pending-deployments-repository/types.ts
+++ b/src/adapters/pending-deployments-repository/types.ts
@@ -41,4 +41,9 @@ export interface IPendingDeploymentsRepository {
    * garbage-collection bloom sweep so staged content is never reclaimed while its upload is in flight.
    */
   streamAllNonExpiredHashes(db: DatabaseClient, ttlMs: number, options?: { batchSize?: number }): AsyncIterable<string>
+  /**
+   * Takes a transaction-scoped advisory lock serializing the pending-deployment "replace overlapping +
+   * upsert" critical section. Must be called inside a transaction; released automatically on commit.
+   */
+  acquireStagingLock(db: DatabaseClient): Promise<void>
 }

--- a/src/adapters/pending-deployments-repository/types.ts
+++ b/src/adapters/pending-deployments-repository/types.ts
@@ -52,8 +52,17 @@ export interface IPendingDeploymentsRepository {
    * deployment per parcel set" rule.
    */
   deleteOverlappingPointers(db: DatabaseClient, pointers: string[], excludeEntityId: string): Promise<string[]>
-  /** Counts a deployer's non-expired pending deployments. Used to cap concurrent staged uploads. */
-  countActiveByDeployer(db: DatabaseClient, deployerAddress: string, ttlMs: number): Promise<number>
+  /**
+   * Counts a deployer's non-expired pending deployments, excluding `excludeEntityId` (the row this
+   * request is about to insert/update). `count + 1` is the deployer's post-upsert row total, used to
+   * enforce the concurrent-pending cap on the net change rather than a stale "is this new?" flag.
+   */
+  countActiveByDeployer(
+    db: DatabaseClient,
+    deployerAddress: string,
+    ttlMs: number,
+    excludeEntityId: string
+  ): Promise<number>
   /** Deletes pending deployments older than `ttlMs`. Returns the number of rows removed. */
   deleteExpired(db: DatabaseClient, ttlMs: number): Promise<number>
   /**

--- a/src/adapters/pending-deployments-repository/types.ts
+++ b/src/adapters/pending-deployments-repository/types.ts
@@ -7,6 +7,7 @@ export interface PendingDeploymentRow {
   pointers: string[]
   contentHashes: string[]
   deployerAddress: string
+  entityTimestamp: number
   createdAt: Date
   updatedAt: Date
 }
@@ -17,6 +18,13 @@ export interface UpsertPendingDeployment {
   pointers: string[]
   contentHashes: string[]
   deployerAddress: string
+  entityTimestamp: number
+}
+
+/** An overlapping pending deployment, used to resolve which of two uploads keeps the parcel-set slot. */
+export interface OverlappingPendingDeployment {
+  entityId: string
+  entityTimestamp: number
 }
 
 export interface IPendingDeploymentsRepository {
@@ -30,11 +38,22 @@ export interface IPendingDeploymentsRepository {
   upsert(db: DatabaseClient, row: UpsertPendingDeployment, ttlMs: number): Promise<void>
   deleteByEntityId(db: DatabaseClient, entityId: string): Promise<void>
   /**
+   * Returns the pending deployments whose pointers overlap the given ones, except `excludeEntityId`,
+   * with their entity timestamps — so the caller can decide whether the incoming upload is newer.
+   */
+  getOverlappingPointers(
+    db: DatabaseClient,
+    pointers: string[],
+    excludeEntityId: string
+  ): Promise<OverlappingPendingDeployment[]>
+  /**
    * Deletes every pending deployment whose pointers overlap the given ones, except `excludeEntityId`.
    * Returns the entity ids that were removed (for logging/metrics). Enforces the "one pending
    * deployment per parcel set" rule.
    */
   deleteOverlappingPointers(db: DatabaseClient, pointers: string[], excludeEntityId: string): Promise<string[]>
+  /** Counts a deployer's non-expired pending deployments. Used to cap concurrent staged uploads. */
+  countActiveByDeployer(db: DatabaseClient, deployerAddress: string, ttlMs: number): Promise<number>
   /** Deletes pending deployments older than `ttlMs`. Returns the number of rows removed. */
   deleteExpired(db: DatabaseClient, ttlMs: number): Promise<number>
   /**

--- a/src/components.ts
+++ b/src/components.ts
@@ -57,6 +57,8 @@ import { createCrypto } from './logic/crypto'
 import { createContentCluster, createCustomDAOSource, createDAOSource } from './logic/peer-cluster'
 import { createDeploymentsComponent, retryFailedDeploymentExecution } from './logic/deployments'
 import { createDeploymentService } from './logic/deployment-service'
+import { createPartialDeployments } from './logic/partial-deployments'
+import { createPendingDeploymentsRepository } from './adapters/pending-deployments-repository'
 import { createEntities } from './logic/entities'
 import { createGarbageCollectionComponent } from './logic/garbage-collection'
 import { createQueryParams } from './logic/query-params'
@@ -158,6 +160,7 @@ export async function initComponentsWithEnv(env: Environment): Promise<AppCompon
   const activeEntitiesRepository = createActiveEntitiesRepository()
   const contentFilesRepository = createContentFilesRepository()
   const deploymentsRepository = createDeploymentsRepository()
+  const pendingDeploymentsRepository = createPendingDeploymentsRepository()
   const pointersRepository = createPointersRepository()
   const snapshotsRepository = createSnapshotsRepository()
 
@@ -253,7 +256,22 @@ export async function initComponentsWithEnv(env: Environment): Promise<AppCompon
     denylist,
     deploymentsRepository,
     contentFilesRepository,
+    pendingDeploymentsRepository,
     entities
+  })
+
+  const partialDeployments = createPartialDeployments({
+    logs,
+    metrics,
+    env,
+    storage,
+    database,
+    crypto,
+    validator,
+    deployer,
+    entities,
+    deploymentsRepository,
+    pendingDeploymentsRepository
   })
 
   // ---------------------------------------------------------------------------
@@ -269,10 +287,12 @@ export async function initComponentsWithEnv(env: Environment): Promise<AppCompon
       activeEntities,
       contentFilesRepository,
       deploymentsRepository,
+      pendingDeploymentsRepository,
       snapshotsRepository
     },
     env.getConfig(EnvironmentConfig.GARBAGE_COLLECTION),
-    env.getConfig(EnvironmentConfig.PROFILE_DURATION)
+    env.getConfig(EnvironmentConfig.PROFILE_DURATION),
+    env.getConfig(EnvironmentConfig.PENDING_DEPLOYMENT_TTL)
   )
 
   const garbageCollectionJob = createJobComponent(
@@ -281,6 +301,17 @@ export async function initComponentsWithEnv(env: Environment): Promise<AppCompon
     env.getConfig(EnvironmentConfig.GARBAGE_COLLECTION_INTERVAL),
     {
       onError: (err) => logs.getLogger('GarbageCollectionJob').error(err as Error)
+    }
+  )
+
+  // Expiry of stale partial (pending) deployments. Kept separate from the GC sweep, which short-circuits
+  // when GARBAGE_COLLECTION is disabled — expiry must run on every node so staged uploads can't linger.
+  const pendingDeploymentsCleanupJob = createJobComponent(
+    { logs },
+    partialDeployments.cleanupExpired,
+    env.getConfig(EnvironmentConfig.PENDING_DEPLOYMENTS_CLEANUP_INTERVAL),
+    {
+      onError: (err) => logs.getLogger('PendingDeploymentsCleanupJob').error(err as Error)
     }
   )
 
@@ -501,8 +532,11 @@ export async function initComponentsWithEnv(env: Environment): Promise<AppCompon
     denylistReloadJob,
     deployedEntitiesBloomFilter,
     deployer,
+    partialDeployments,
     deployments,
     deploymentsRepository,
+    pendingDeploymentsRepository,
+    pendingDeploymentsCleanupJob,
     downloadQueue,
     env,
     failedDeployments,

--- a/src/controllers/handlers/create-entity-handler.ts
+++ b/src/controllers/handlers/create-entity-handler.ts
@@ -2,8 +2,12 @@ import { PostEntity200, PostEntity400 } from '@dcl/catalyst-api-specs/lib/client
 import { Field } from '@well-known-components/multipart-wrapper'
 import { AuthChain, AuthLink, EthAddress } from '@dcl/crypto'
 import { DeploymentContext, isInvalidDeployment, isSuccessfulDeployment } from '../../deployment-types'
+import { InvalidPartialDeploymentError } from '../../logic/partial-deployments'
 import { FormHandlerContextWithPath } from '../../types'
 import { InvalidRequestError } from '../errors'
+
+/** Body of a 202 response to a partial deployment request: the content hashes not yet on the server. */
+type PostEntity202 = { missing: string[] }
 
 // A real auth chain has 2-3 links; cap generously. This bounds the index-parsing loop below so a
 // crafted `authChain[<huge>][...]` field name can't drive a large iteration count on the public,
@@ -15,13 +19,16 @@ type ContentFile = {
   content: Buffer
 }
 
-type Response = { status: 200; body: PostEntity200 } | { status: 400; body: PostEntity400 }
+type Response =
+  | { status: 200; body: PostEntity200 }
+  | { status: 202; body: PostEntity202 }
+  | { status: 400; body: PostEntity400 }
 
 // Method: POST
 export async function createEntity(
-  context: FormHandlerContextWithPath<'logs' | 'fs' | 'metrics' | 'deployer', '/entities'>
+  context: FormHandlerContextWithPath<'logs' | 'fs' | 'metrics' | 'deployer' | 'partialDeployments', '/entities'>
 ): Promise<Response> {
-  const { metrics, deployer, logs } = context.components
+  const { metrics, deployer, partialDeployments, logs } = context.components
 
   const logger = logs.getLogger('create-entity')
   // Guard the required field explicitly: without it a missing `entityId` throws a TypeError and the
@@ -48,6 +55,53 @@ export async function createEntity(
   }
   if (!AuthChain.validate(authChain)) {
     throw new InvalidRequestError('Invalid auth chain')
+  }
+
+  // A `partial=true` field marks a staging request of a multi-request (partial) deployment: the
+  // content may be uploaded across several requests and the entity only becomes live once all of it is
+  // present. Requests without the flag behave exactly as before.
+  if (context.formData.fields.partial?.value === 'true') {
+    // Preserve the field-name keys (content hashes): unlike the vanilla path, they are load-bearing.
+    const files = new Map<string, Uint8Array>()
+    for (const filename of Object.keys(context.formData.files)) {
+      files.set(filename, context.formData.files[filename].value)
+    }
+
+    try {
+      const result = await partialDeployments.stageDeployment({ entityId, authChain, files })
+      if (result.kind === 'deployed') {
+        metrics.increment('dcl_partial_deployments_staging_total', { kind: 'finalized' })
+        logger.info(`POST /entities - Partial deployment finalized`, { entityId, ethAddress, userAgent })
+        return { status: 200, body: { creationTimestamp: result.creationTimestamp } }
+      }
+      metrics.increment('dcl_partial_deployments_staging_total', { kind: 'accepted' })
+      logger.info(`POST /entities - Partial deployment staged`, {
+        entityId,
+        ethAddress,
+        userAgent,
+        missing: result.missing.length
+      })
+      return { status: 202, body: { missing: result.missing } }
+    } catch (error) {
+      if (error instanceof InvalidPartialDeploymentError) {
+        metrics.increment('dcl_partial_deployments_staging_total', { kind: 'validation_error' })
+        logger.error(`POST /entities - Partial deployment failed (${error.errors.join(',')})`, {
+          entityId,
+          ethAddress,
+          userAgent
+        })
+        return { status: 400, body: { errors: error.errors } }
+      }
+      metrics.increment('dcl_partial_deployments_staging_total', { kind: 'error' })
+      // Never log `authChain` or `signature`: they are cryptographic credentials.
+      logger.error(`POST /entities - Partial deployment internal server error '${error}'`, {
+        entityId,
+        ethAddress,
+        userAgent
+      })
+      logger.error(error)
+      throw error
+    }
   }
 
   const deployFiles: ContentFile[] = []

--- a/src/controllers/handlers/create-entity-handler.ts
+++ b/src/controllers/handlers/create-entity-handler.ts
@@ -22,7 +22,7 @@ type ContentFile = {
 type Response =
   | { status: 200; body: PostEntity200 }
   | { status: 202; body: PostEntity202 }
-  | { status: 400; body: PostEntity400 }
+  | { status: 400 | 429; body: PostEntity400 }
 
 // Method: POST
 export async function createEntity(
@@ -90,7 +90,8 @@ export async function createEntity(
           ethAddress,
           userAgent
         })
-        return { status: 400, body: { errors: error.errors } }
+        // statusCode is 429 for transient conditions (rate limiting), 400 for validation errors.
+        return { status: error.statusCode, body: { errors: error.errors } }
       }
       metrics.increment('dcl_partial_deployments_staging_total', { kind: 'error' })
       // Never log `authChain` or `signature`: they are cryptographic credentials.

--- a/src/controllers/handlers/create-entity-handler.ts
+++ b/src/controllers/handlers/create-entity-handler.ts
@@ -22,7 +22,7 @@ type ContentFile = {
 type Response =
   | { status: 200; body: PostEntity200 }
   | { status: 202; body: PostEntity202 }
-  | { status: 400 | 429; body: PostEntity400 }
+  | { status: 400 | 429; body: PostEntity400; headers?: Record<string, string> }
 
 // Method: POST
 export async function createEntity(
@@ -90,8 +90,14 @@ export async function createEntity(
           ethAddress,
           userAgent
         })
-        // statusCode is 429 for transient conditions (rate limiting), 400 for validation errors.
-        return { status: error.statusCode, body: { errors: error.errors } }
+        // statusCode is 429 for transient conditions (rate limiting), 400 for validation errors. On a
+        // 429 with a known window, send Retry-After so the client waits it out instead of exhausting its
+        // resume budget inside the window.
+        const headers =
+          error.statusCode === 429 && error.retryAfterSeconds !== undefined
+            ? { 'Retry-After': String(error.retryAfterSeconds) }
+            : undefined
+        return { status: error.statusCode, body: { errors: error.errors }, headers }
       }
       metrics.increment('dcl_partial_deployments_staging_total', { kind: 'error' })
       // Never log `authChain` or `signature`: they are cryptographic credentials.

--- a/src/deployment-types.ts
+++ b/src/deployment-types.ts
@@ -86,7 +86,13 @@ export type PartialDeploymentHistory<T extends DeploymentBase> = {
 
 export type LocalDeploymentAuditInfo = Pick<AuditInfo, 'authChain'>
 
-export type InvalidResult = { errors: string[] }
+export type InvalidResult = {
+  errors: string[]
+  // Distinguishes a transient, retryable pointer-lock conflict (another deploy is holding the pointers
+  // right now) from a terminal validation failure, so callers can branch on structure instead of
+  // string-matching the error message.
+  kind?: 'pointer-conflict'
+}
 export function InvalidResult(val: InvalidResult): InvalidResult {
   return val
 }

--- a/src/entrypoints/run-maintenance.ts
+++ b/src/entrypoints/run-maintenance.ts
@@ -12,6 +12,7 @@ import { createMigrationExecutor } from '../migrations/migration-executor'
 import { createDatabaseComponent } from '../adapters/database'
 import { createContentFilesRepository } from '../adapters/content-files-repository'
 import { createDeploymentsRepository } from '../adapters/deployments-repository'
+import { createPendingDeploymentsRepository } from '../adapters/pending-deployments-repository'
 import { createSnapshotsRepository } from '../adapters/snapshots-repository'
 import { createSystemProperties } from '../adapters/system-properties'
 import { ActiveEntities } from '../logic/active-entities'
@@ -48,6 +49,7 @@ void Lifecycle.run({
     const migrationManager = createMigrationExecutor({ logs, env })
     const contentFilesRepository = createContentFilesRepository()
     const deploymentsRepository = createDeploymentsRepository()
+    const pendingDeploymentsRepository = createPendingDeploymentsRepository()
     const snapshotsRepository = createSnapshotsRepository()
     const systemProperties = createSystemProperties({ database })
     // `deleteUnreferencedFiles` is the only GC method this entrypoint invokes; the
@@ -63,12 +65,14 @@ void Lifecycle.run({
         storage,
         contentFilesRepository,
         deploymentsRepository,
+        pendingDeploymentsRepository,
         snapshotsRepository,
         systemProperties,
         activeEntities
       },
       false,
-      0
+      0,
+      env.getConfig(EnvironmentConfig.PENDING_DEPLOYMENT_TTL)
     )
     env.logConfigValues(logs.getLogger('Environment'))
     return {
@@ -81,6 +85,7 @@ void Lifecycle.run({
       storage,
       contentFilesRepository,
       deploymentsRepository,
+      pendingDeploymentsRepository,
       snapshotsRepository,
       garbageCollectionManager
     }

--- a/src/logic/deployment-service/component.ts
+++ b/src/logic/deployment-service/component.ts
@@ -1,8 +1,8 @@
-import { bufferToStream } from '@dcl/catalyst-storage/dist/content-item'
 import { AuthChain, Authenticator } from '@dcl/crypto'
 import { Entity, EntityType, IPFSv2 } from '@dcl/schemas'
 import { isDeepStrictEqual } from 'util'
 import { EnvironmentConfig } from '../../Environment'
+import { storeStreamsInBatches } from '../store-content'
 import {
   AuditInfo,
   DeploymentContext,
@@ -21,11 +21,6 @@ import { createDeployRateLimiter, IDeployRateLimiterComponent } from './rate-lim
 import * as serverValidator from './server-validator'
 import ms from 'ms'
 import { TestableDeploymentService } from './types'
-
-// Upper bound on concurrent content-file writes within a single deployment. Content files are
-// content-addressed and independent, so they can be written in parallel; the cap keeps a single
-// many-file entity from fanning out into an unbounded number of simultaneous storage writes.
-const CONTENT_STORE_CONCURRENCY = 10
 
 // Stable fragment of the error returned when a concurrent deploy already holds one of the pointers.
 // Exported so callers (e.g. the partial-deployment finalize retry) can detect this transient condition
@@ -99,13 +94,22 @@ export function createDeploymentService(
   // already too old by wall clock (the common fresh deploy short-circuits with a pure comparison) and
   // only for scenes (the only entity type that can be partially uploaded). So profiles and other
   // high-volume deploys never touch pending_deployments here.
+  // True when the entity is older, by wall clock, than the vanilla REQUEST_TTL_BACKWARDS bound — i.e.
+  // only a pending-upload anchor could have let it through the freshness check. The TTL-anchoring logic
+  // and the finalize current-access gate both key off this exact condition, so it is defined once here
+  // to keep them from drifting. (Comparison, not `<=`, so an unset TTL — `x > undefined` is false —
+  // behaves as before.)
+  function isOlderThanRequestTtlBackwards(entity: Entity): boolean {
+    const backwards = components.env.getConfig<number>(EnvironmentConfig.REQUEST_TTL_BACKWARDS)
+    return Date.now() - entity.timestamp > backwards
+  }
+
   async function isRequestTtlBackwards(entity: Entity): Promise<boolean> {
     const backwards = components.env.getConfig<number>(EnvironmentConfig.REQUEST_TTL_BACKWARDS)
     // Anchoring on an earlier pending.created_at can only make this smaller, so if the entity is not
     // already too old measured against now, no anchor changes the answer. This branch also covers the
     // hot path (fresh deploys) and non-scene types, keeping the pending lookup off them entirely.
-    // (Comparison, not `<=`, so an unset TTL — `x > undefined` is false — behaves as before.)
-    if (!(Date.now() - entity.timestamp > backwards)) {
+    if (!isOlderThanRequestTtlBackwards(entity)) {
       return false
     }
     // Too old by wall clock. Only scenes can be partial uploads, so only they can have a pending anchor.
@@ -320,16 +324,9 @@ export function createDeploymentService(
     // Check for if content is already stored
     const alreadyStoredHashes: Map<string, boolean> = await components.storage.existMultiple(Array.from(hashes.keys()))
 
-    // Store all the entity's not-already-stored content. The files are independent
-    // (content-addressed) and this runs before/outside the deployment transaction, so write
-    // them in bounded-parallel batches instead of one at a time to speed up multi-file deploys.
+    // Store all the entity's not-already-stored content, in bounded-parallel batches (see helper).
     const filesToStore = Array.from(hashes).filter(([fileHash]) => !alreadyStoredHashes.get(fileHash))
-    for (let i = 0; i < filesToStore.length; i += CONTENT_STORE_CONCURRENCY) {
-      const batch = filesToStore.slice(i, i + CONTENT_STORE_CONCURRENCY)
-      await Promise.all(
-        batch.map(([fileHash, content]) => components.storage.storeStream(fileHash, bufferToStream(content)))
-      )
-    }
+    await storeStreamsInBatches(components.storage, filesToStore)
   }
 
   async function validateDeployment(
@@ -387,8 +384,7 @@ export function createDeploymentService(
     // unaffected; it covers both completion paths (auto-finalize and a vanilla POST of a pending
     // entity) because both go through this pipeline.
     if (context === DeploymentContext.LOCAL && entity.type === EntityType.SCENE) {
-      const requestTtlBackwards = components.env.getConfig<number>(EnvironmentConfig.REQUEST_TTL_BACKWARDS)
-      if (Date.now() - entity.timestamp > requestTtlBackwards) {
+      if (isOlderThanRequestTtlBackwards(entity)) {
         const currentAccessResult = await components.validator.validateCurrentAccess({
           entity: entity as any,
           auditInfo,
@@ -467,6 +463,7 @@ export function createDeploymentService(
       const overlappingPointers = tryAcquirePointerLocks(entity.type, entity.pointers)
       if (overlappingPointers.length > 0) {
         return InvalidResult({
+          kind: 'pointer-conflict',
           errors: [
             `The following pointers are ${POINTERS_BEING_DEPLOYED_ERROR}: '${overlappingPointers.join()}'. Please try again in a few seconds.`
           ]

--- a/src/logic/deployment-service/component.ts
+++ b/src/logic/deployment-service/component.ts
@@ -367,12 +367,45 @@ export function createDeploymentService(
       }
     }
 
-    return await components.validator.validate({
+    const protocolResult = await components.validator.validate({
       // TODO: remove as any after fixing content validator
       entity: entity as any,
       auditInfo,
       files: hashes
     })
+    if (!protocolResult.ok) {
+      return protocolResult
+    }
+
+    // The protocol access validation above is historical: it proves ownership at entity.timestamp's
+    // block (required for sync/replay). Vanilla deploys bound that staleness to REQUEST_TTL_BACKWARDS
+    // (~minutes), but a scene completing a partial upload may be up to PENDING_DEPLOYMENT_TTL (~24h)
+    // old — long enough for the LAND to have been sold mid-upload. When the entity is older than the
+    // vanilla bound (i.e. only a pending-upload anchor let it through the TTL check above), require
+    // access against the CURRENT chain state too, so a seller can't finalize onto land they no longer
+    // own. Fresh deploys never reach this (the wall-clock condition fails), so the hot path is
+    // unaffected; it covers both completion paths (auto-finalize and a vanilla POST of a pending
+    // entity) because both go through this pipeline.
+    if (context === DeploymentContext.LOCAL && entity.type === EntityType.SCENE) {
+      const requestTtlBackwards = components.env.getConfig<number>(EnvironmentConfig.REQUEST_TTL_BACKWARDS)
+      if (Date.now() - entity.timestamp > requestTtlBackwards) {
+        const currentAccessResult = await components.validator.validateCurrentAccess({
+          entity: entity as any,
+          auditInfo,
+          files: hashes
+        })
+        if (!currentAccessResult.ok) {
+          return {
+            ok: false,
+            errors: currentAccessResult.errors ?? [
+              'The deployer no longer has access to the entity pointers (access is required both when a partial upload starts and when it is finalized).'
+            ]
+          }
+        }
+      }
+    }
+
+    return protocolResult
   }
 
   return {

--- a/src/logic/deployment-service/component.ts
+++ b/src/logic/deployment-service/component.ts
@@ -78,11 +78,25 @@ export function createDeploymentService(
     | 'denylist'
     | 'deploymentsRepository'
     | 'contentFilesRepository'
+    | 'pendingDeploymentsRepository'
     | 'entities'
   >
 ): TestableDeploymentService {
   const logger = components.logs.getLogger('deployer')
   const LEGACY_CONTENT_MIGRATION_TIMESTAMP: Date = new Date(1582167600000) // DCL Launch Day
+  const pendingDeploymentTtlMs = components.env.getConfig<number>(EnvironmentConfig.PENDING_DEPLOYMENT_TTL)
+
+  // Anchor for the "request is not recent enough" (REQUEST_TTL_BACKWARDS) check. A partial (multi-request)
+  // upload can legitimately span longer than that TTL, so when the entity has a non-expired pending
+  // deployment we measure the entity timestamp against when the upload *started* (pending.created_at)
+  // rather than now. Normal deploys have no pending row and fall back to Date.now() — today's behavior.
+  async function getRequestTtlAnchor(entityId: string): Promise<number> {
+    const pending = await components.pendingDeploymentsRepository.getByEntityId(components.database, entityId)
+    if (pending && Date.now() - pending.createdAt.getTime() <= pendingDeploymentTtlMs) {
+      return pending.createdAt.getTime()
+    }
+    return Date.now()
+  }
 
   // In-process deploy rate limiter. Defaults to a real instance built from env config;
   // tests swap it via `setRateLimiter` (see TestableDeploymentService).
@@ -239,6 +253,11 @@ export function createDeploymentService(
 
         // Set who overwrote who
         await components.deploymentsRepository.setEntitiesAsOverwritten(database, overwrote, deploymentId)
+
+        // If this entity had a pending (partial) deployment, it is now fully deployed — drop its
+        // staging row atomically with the deployment. Covers both auto-finalize of a partial upload
+        // and a vanilla deploy of a previously-staged entity. No-op (single PK delete) otherwise.
+        await components.pendingDeploymentsRepository.deleteByEntityId(database, entity.id)
       }, 'tx_deploy_entity')
 
       // Now that the transaction has committed, reflect the new active pointers in the in-memory cache.
@@ -315,8 +334,10 @@ export function createDeploymentService(
           (entity.type === EntityType.PROFILE &&
             isContentUnchanged &&
             rateLimiter.isUnchangedDeploymentRateLimited(entity.type, entity.pointers)),
-        isRequestTtlBackwards: (entity) =>
-          Date.now() - entity.timestamp > components.env.getConfig<number>(EnvironmentConfig.REQUEST_TTL_BACKWARDS)
+        isRequestTtlBackwards: async (entity) => {
+          const anchor = await getRequestTtlAnchor(entity.id)
+          return anchor - entity.timestamp > components.env.getConfig<number>(EnvironmentConfig.REQUEST_TTL_BACKWARDS)
+        }
       }
     )
 
@@ -339,6 +360,11 @@ export function createDeploymentService(
   return {
     setRateLimiter(rl: IDeployRateLimiterComponent) {
       rateLimiter = rl
+    },
+    // Exposes the in-process rate-limiter to the partial-deployment staging path so a staging request
+    // is subject to the same limit as a full deploy, without duplicating limiter state.
+    isRateLimited(entityType: EntityType, pointers: string[]): boolean {
+      return rateLimiter.isRateLimited(entityType, pointers)
     },
     async deployEntity(
       files: DeploymentFiles,

--- a/src/logic/deployment-service/component.ts
+++ b/src/logic/deployment-service/component.ts
@@ -27,6 +27,11 @@ import { TestableDeploymentService } from './types'
 // many-file entity from fanning out into an unbounded number of simultaneous storage writes.
 const CONTENT_STORE_CONCURRENCY = 10
 
+// Stable fragment of the error returned when a concurrent deploy already holds one of the pointers.
+// Exported so callers (e.g. the partial-deployment finalize retry) can detect this transient condition
+// without coupling to the full, human-readable message text.
+export const POINTERS_BEING_DEPLOYED_ERROR = 'currently being deployed'
+
 export function isIPFSHash(hash: string): boolean {
   return IPFSv2.validate(hash)
 }
@@ -86,16 +91,32 @@ export function createDeploymentService(
   const LEGACY_CONTENT_MIGRATION_TIMESTAMP: Date = new Date(1582167600000) // DCL Launch Day
   const pendingDeploymentTtlMs = components.env.getConfig<number>(EnvironmentConfig.PENDING_DEPLOYMENT_TTL)
 
-  // Anchor for the "request is not recent enough" (REQUEST_TTL_BACKWARDS) check. A partial (multi-request)
-  // upload can legitimately span longer than that TTL, so when the entity has a non-expired pending
-  // deployment we measure the entity timestamp against when the upload *started* (pending.created_at)
-  // rather than now. Normal deploys have no pending row and fall back to Date.now() — today's behavior.
-  async function getRequestTtlAnchor(entityId: string): Promise<number> {
-    const pending = await components.pendingDeploymentsRepository.getByEntityId(components.database, entityId)
-    if (pending && Date.now() - pending.createdAt.getTime() <= pendingDeploymentTtlMs) {
-      return pending.createdAt.getTime()
+  // The "request is not recent enough" (REQUEST_TTL_BACKWARDS) check. A partial (multi-request) upload
+  // can legitimately span longer than that TTL, so a scene with a non-expired pending deployment is
+  // measured against when the upload *started* (pending.created_at) rather than now.
+  //
+  // The pending-deployment lookup is gated to keep it off the hot path: it runs only when the entity is
+  // already too old by wall clock (the common fresh deploy short-circuits with a pure comparison) and
+  // only for scenes (the only entity type that can be partially uploaded). So profiles and other
+  // high-volume deploys never touch pending_deployments here.
+  async function isRequestTtlBackwards(entity: Entity): Promise<boolean> {
+    const backwards = components.env.getConfig<number>(EnvironmentConfig.REQUEST_TTL_BACKWARDS)
+    // Anchoring on an earlier pending.created_at can only make this smaller, so if the entity is not
+    // already too old measured against now, no anchor changes the answer. This branch also covers the
+    // hot path (fresh deploys) and non-scene types, keeping the pending lookup off them entirely.
+    // (Comparison, not `<=`, so an unset TTL — `x > undefined` is false — behaves as before.)
+    if (!(Date.now() - entity.timestamp > backwards)) {
+      return false
     }
-    return Date.now()
+    // Too old by wall clock. Only scenes can be partial uploads, so only they can have a pending anchor.
+    if (entity.type !== EntityType.SCENE) {
+      return true
+    }
+    const pending = await components.pendingDeploymentsRepository.getByEntityId(components.database, entity.id)
+    if (pending && Date.now() - pending.createdAt.getTime() <= pendingDeploymentTtlMs) {
+      return pending.createdAt.getTime() - entity.timestamp > backwards
+    }
+    return true
   }
 
   // In-process deploy rate limiter. Defaults to a real instance built from env config;
@@ -334,10 +355,7 @@ export function createDeploymentService(
           (entity.type === EntityType.PROFILE &&
             isContentUnchanged &&
             rateLimiter.isUnchangedDeploymentRateLimited(entity.type, entity.pointers)),
-        isRequestTtlBackwards: async (entity) => {
-          const anchor = await getRequestTtlAnchor(entity.id)
-          return anchor - entity.timestamp > components.env.getConfig<number>(EnvironmentConfig.REQUEST_TTL_BACKWARDS)
-        }
+        isRequestTtlBackwards: (entity) => isRequestTtlBackwards(entity)
       }
     )
 
@@ -417,7 +435,7 @@ export function createDeploymentService(
       if (overlappingPointers.length > 0) {
         return InvalidResult({
           errors: [
-            `The following pointers are currently being deployed: '${overlappingPointers.join()}'. Please try again in a few seconds.`
+            `The following pointers are ${POINTERS_BEING_DEPLOYED_ERROR}: '${overlappingPointers.join()}'. Please try again in a few seconds.`
           ]
         })
       }

--- a/src/logic/deployment-service/component.ts
+++ b/src/logic/deployment-service/component.ts
@@ -413,6 +413,9 @@ export function createDeploymentService(
     isRateLimited(entityType: EntityType, pointers: string[]): boolean {
       return rateLimiter.isRateLimited(entityType, pointers)
     },
+    getRateLimitTtlSeconds(entityType: EntityType): number {
+      return rateLimiter.getRateLimitTtlSeconds(entityType)
+    },
     async deployEntity(
       files: DeploymentFiles,
       entityId: string,

--- a/src/logic/deployment-service/index.ts
+++ b/src/logic/deployment-service/index.ts
@@ -1,4 +1,10 @@
-export { createDeploymentService, isIPFSHash, isEntityContentUnchanged, hashFiles } from './component'
+export {
+  createDeploymentService,
+  isIPFSHash,
+  isEntityContentUnchanged,
+  hashFiles,
+  POINTERS_BEING_DEPLOYED_ERROR
+} from './component'
 export { DELTA_POINTER_RESULT, referenceEntityFromPointers } from './pointer-bookkeeping'
 export type { PointerDeltaMap } from './pointer-bookkeeping'
 export { createDeployRateLimiter } from './rate-limiter'

--- a/src/logic/deployment-service/rate-limiter.ts
+++ b/src/logic/deployment-service/rate-limiter.ts
@@ -9,6 +9,8 @@ export type IDeployRateLimiterComponent = {
   isRateLimited(entityType: EntityType, pointers: string[]): boolean
   newUnchangedDeployment(entityType: EntityType, pointers: string[], localTimestamp: number): void
   isUnchangedDeploymentRateLimited(entityType: EntityType, pointers: string[]): boolean
+  /** The rate-limit window (seconds) for an entity type — the TTL after which a pointer clears. */
+  getRateLimitTtlSeconds(entityType: EntityType): number
 }
 
 export type DeploymentRateLimitConfig = {
@@ -108,6 +110,11 @@ export function createDeployRateLimiter(
         })
       }
       return limited
+    },
+
+    getRateLimitTtlSeconds(entityType: EntityType): number {
+      // stdTTL is the per-type window in seconds (see generateDeploymentCacheMap).
+      return getCacheFromEntityType(entityType).cache.options.stdTTL ?? 0
     }
   }
 }

--- a/src/logic/deployment-service/server-validator.ts
+++ b/src/logic/deployment-service/server-validator.ts
@@ -3,7 +3,9 @@ import ms from 'ms'
 import { IFailedDeploymentsComponent } from '../../adapters/failed-deployments'
 import { DeploymentContext } from '../../deployment-types'
 
-const REQUEST_TTL_FORWARDS: number = ms('15m')
+// Exported so the partial-deployment staging path can apply the identical "too far in the future" bound
+// without duplicating the constant.
+export const REQUEST_TTL_FORWARDS: number = ms('15m')
 
 export interface ServiceCalls {
   areThereNewerEntities(entity: Entity): boolean | Promise<boolean>

--- a/src/logic/deployment-service/types.ts
+++ b/src/logic/deployment-service/types.ts
@@ -1,3 +1,4 @@
+import { EntityType } from '@dcl/schemas'
 import { DeploymentContext, DeploymentFiles, DeploymentResult, LocalDeploymentAuditInfo } from '../../deployment-types'
 import { IDeployRateLimiterComponent } from './rate-limiter'
 
@@ -8,6 +9,8 @@ export interface IDeploymentService {
     auditInfo: LocalDeploymentAuditInfo,
     context: DeploymentContext
   ): Promise<DeploymentResult>
+  /** Whether a deployment of this entity type on these pointers is currently rate limited. */
+  isRateLimited(entityType: EntityType, pointers: string[]): boolean
 }
 
 /**

--- a/src/logic/deployment-service/types.ts
+++ b/src/logic/deployment-service/types.ts
@@ -11,6 +11,8 @@ export interface IDeploymentService {
   ): Promise<DeploymentResult>
   /** Whether a deployment of this entity type on these pointers is currently rate limited. */
   isRateLimited(entityType: EntityType, pointers: string[]): boolean
+  /** The rate-limit window (seconds) for an entity type, used as a Retry-After hint on a 429. */
+  getRateLimitTtlSeconds(entityType: EntityType): number
 }
 
 /**

--- a/src/logic/garbage-collection/component.ts
+++ b/src/logic/garbage-collection/component.ts
@@ -1,5 +1,4 @@
 import * as bf from 'bloom-filters'
-import PQueue from 'p-queue'
 import SQL from 'sql-template-strings'
 import { SYSTEM_PROPERTIES } from '../../adapters/system-properties'
 import { runLoggingPerformance } from '../../instrument'
@@ -326,30 +325,47 @@ export function createGarbageCollectionComponent(
       )
     })
 
-    const queue = new PQueue({ concurrency: 1000 })
     let numberOfDeletedFiles = 0
+    let batch: string[] = []
+
+    // Delete in batches, re-verifying each batch against the database right before deletion. The bloom
+    // filter was built once at the start of a potentially hours-long sweep, so anything referenced
+    // AFTER that — most notably a partial (pending) upload that starts mid-sweep and stages files for
+    // hours — is invisible to it. findReferencedHashes covers active deployments, snapshots, entity ids
+    // and non-expired pending deployments at delete time.
+    const flushBatch = async (): Promise<void> => {
+      if (batch.length === 0) {
+        return
+      }
+      const candidates = batch
+      batch = []
+      try {
+        const stillReferenced = await components.contentFilesRepository.findReferencedHashes(
+          components.database,
+          candidates,
+          pendingDeploymentTtlMs
+        )
+        const toDelete = candidates.filter((hash) => !stillReferenced.has(hash))
+        if (toDelete.length === 0) {
+          return
+        }
+        await components.storage.delete(toDelete)
+        numberOfDeletedFiles += toDelete.length
+      } catch (error) {
+        unreferencedLogger.error(error as Error, { batchSize: String(candidates.length) })
+      }
+    }
+
     unreferencedLogger.info(`Deleting files...`)
     for await (const storageFileId of components.storage.allFileIds()) {
       if (!referencedHashesBloom.has(storageFileId)) {
-        // Enqueue without awaiting each task so up to `concurrency` deletes run in parallel; awaiting
-        // `queue.add` here would serialize them and make the concurrency setting meaningless.
-        // Backpressure keeps the queue from growing unbounded ahead of the workers.
-        void queue.add(async () => {
-          try {
-            await components.storage.delete([storageFileId])
-            numberOfDeletedFiles++
-          } catch (error) {
-            unreferencedLogger.error(error as Error, { storageFileId })
-          }
-        })
-        // Backpressure: if the queued (not-yet-started) work grows too large, wait for it to drain
-        // before enqueuing more, so a multi-million-file sweep can't buffer every task in memory.
-        if (queue.size >= GC_DELETE_BATCH_SIZE * 2) {
-          await queue.onEmpty()
+        batch.push(storageFileId)
+        if (batch.length >= GC_DELETE_BATCH_SIZE) {
+          await flushBatch()
         }
       }
     }
-    await queue.onIdle()
+    await flushBatch()
     unreferencedLogger.info(`Deleted ${numberOfDeletedFiles} files`)
   }
 

--- a/src/logic/garbage-collection/component.ts
+++ b/src/logic/garbage-collection/component.ts
@@ -83,7 +83,6 @@ export function createGarbageCollectionComponent(
     for await (const hash of components.contentFilesRepository.streamContentHashesNotBeingUsedAnymore(
       components.database,
       lastTimeOfCollection,
-      pendingDeploymentTtlMs,
       { batchSize: GC_DELETE_BATCH_SIZE }
     )) {
       batch.push(hash)

--- a/src/logic/garbage-collection/component.ts
+++ b/src/logic/garbage-collection/component.ts
@@ -11,6 +11,12 @@ const PROFILE_CLEANUP_LIMIT = 10000
 // and the size of each storage.delete operation during a sweep.
 const GC_DELETE_BATCH_SIZE = 1000
 
+// How many delete batches deleteUnreferencedFiles keeps in flight at once. Each batch is one
+// findReferencedHashes query + one storage.delete; a small window keeps folder-based storage (which
+// unlinks serially inside delete()) from making the sweep fully sequential, without the unbounded
+// fan-out of per-file parallel deletes.
+const GC_DELETE_CONCURRENCY = 4
+
 // Safety margin subtracted from the stored garbage-collection watermark. The next sweep only
 // reconsiders hashes whose overwrite committed after the watermark; a deploy that assigned an older
 // local_timestamp but committed just after the sweep started would otherwise slip below a
@@ -327,18 +333,14 @@ export function createGarbageCollectionComponent(
 
     let numberOfDeletedFiles = 0
     let batch: string[] = []
+    const inFlight = new Set<Promise<void>>()
 
     // Delete in batches, re-verifying each batch against the database right before deletion. The bloom
     // filter was built once at the start of a potentially hours-long sweep, so anything referenced
     // AFTER that — most notably a partial (pending) upload that starts mid-sweep and stages files for
     // hours — is invisible to it. findReferencedHashes covers active deployments, snapshots, entity ids
     // and non-expired pending deployments at delete time.
-    const flushBatch = async (): Promise<void> => {
-      if (batch.length === 0) {
-        return
-      }
-      const candidates = batch
-      batch = []
+    const deleteBatch = async (candidates: string[]): Promise<void> => {
       try {
         const stillReferenced = await components.contentFilesRepository.findReferencedHashes(
           components.database,
@@ -356,6 +358,23 @@ export function createGarbageCollectionComponent(
       }
     }
 
+    // Batches run through a small window of concurrent workers so the next batch's reference re-check
+    // and deletes overlap the previous batch's I/O. On S3 each batch is a bulk DeleteObjects; on
+    // folder-based storage delete() unlinks serially, so without this overlap the whole sweep would
+    // degrade to fully serial unlinks interleaved with blocking DB queries.
+    const flushBatch = async (): Promise<void> => {
+      if (batch.length === 0) {
+        return
+      }
+      const candidates = batch
+      batch = []
+      const task: Promise<void> = deleteBatch(candidates).finally(() => inFlight.delete(task))
+      inFlight.add(task)
+      if (inFlight.size >= GC_DELETE_CONCURRENCY) {
+        await Promise.race(inFlight)
+      }
+    }
+
     unreferencedLogger.info(`Deleting files...`)
     for await (const storageFileId of components.storage.allFileIds()) {
       if (!referencedHashesBloom.has(storageFileId)) {
@@ -366,6 +385,7 @@ export function createGarbageCollectionComponent(
       }
     }
     await flushBatch()
+    await Promise.all(inFlight)
     unreferencedLogger.info(`Deleted ${numberOfDeletedFiles} files`)
   }
 

--- a/src/logic/garbage-collection/component.ts
+++ b/src/logic/garbage-collection/component.ts
@@ -30,10 +30,14 @@ export function createGarbageCollectionComponent(
     | 'activeEntities'
     | 'contentFilesRepository'
     | 'deploymentsRepository'
+    | 'pendingDeploymentsRepository'
     | 'snapshotsRepository'
   >,
   performGarbageCollection: boolean,
-  profileDuration: number
+  profileDuration: number,
+  // How long a partial (pending) deployment survives. Its entity id + content hashes are treated as
+  // referenced until it expires, so in-flight staged uploads are never reclaimed.
+  pendingDeploymentTtlMs: number
 ): IGarbageCollectionComponent {
   const logger = components.logs.getLogger('GarbageCollectionManager')
   let lastSweepResult: SweepResult | undefined = undefined
@@ -55,7 +59,11 @@ export function createGarbageCollectionComponent(
       // a concurrent deploy may have re-referenced a hash since; and because storage is a single
       // content-addressed namespace, a candidate hash may also be a snapshot file or an entity JSON
       // (byte-identical files collide on hash). Never delete anything that is still referenced.
-      const stillReferenced = await components.contentFilesRepository.findReferencedHashes(components.database, batch)
+      const stillReferenced = await components.contentFilesRepository.findReferencedHashes(
+        components.database,
+        batch,
+        pendingDeploymentTtlMs
+      )
       const toDelete = batch.filter((hash) => !stillReferenced.has(hash))
       batch = []
       if (toDelete.length === 0) {
@@ -75,6 +83,7 @@ export function createGarbageCollectionComponent(
     for await (const hash of components.contentFilesRepository.streamContentHashesNotBeingUsedAnymore(
       components.database,
       lastTimeOfCollection,
+      pendingDeploymentTtlMs,
       { batchSize: GC_DELETE_BATCH_SIZE }
     )) {
       batch.push(hash)
@@ -189,7 +198,8 @@ export function createGarbageCollectionComponent(
     if (hashesToDelete.length > 0) {
       const stillReferenced = await components.contentFilesRepository.findReferencedHashes(
         components.database,
-        hashesToDelete
+        hashesToDelete,
+        pendingDeploymentTtlMs
       )
       hashesToDelete = hashesToDelete.filter((hash) => !stillReferenced.has(hash))
     }
@@ -296,8 +306,24 @@ export function createGarbageCollectionComponent(
         'add of stream snapshot hashes to bloom filter',
         async () => await addAllToBloomFilter(components.snapshotsRepository.getAllSnapshotHashes(components.database))
       )
+
+      // Entity ids and content hashes of non-expired pending (partial) deployments are still referenced:
+      // their content is staged but not yet attached to any deployment, so it would otherwise look
+      // unreferenced and be swept. Expired pending rows are intentionally excluded so their staged
+      // content becomes reclaimable.
+      const totalPendingHashes = await runLoggingPerformance(
+        unreferencedLogger,
+        'add of stream pending deployment hashes to bloom filter',
+        async () =>
+          await addAllToBloomFilter(
+            components.pendingDeploymentsRepository.streamAllNonExpiredHashes(
+              components.database,
+              pendingDeploymentTtlMs
+            )
+          )
+      )
       unreferencedLogger.info(
-        `Created bloom filter with ${totalEntityIds} entity ids, ${totalContentFileHashes} content hashes and ${totalSnapshotHashes} snapshot hashes.`
+        `Created bloom filter with ${totalEntityIds} entity ids, ${totalContentFileHashes} content hashes, ${totalSnapshotHashes} snapshot hashes and ${totalPendingHashes} pending deployment hashes.`
       )
     })
 

--- a/src/logic/partial-deployments/component.ts
+++ b/src/logic/partial-deployments/component.ts
@@ -320,8 +320,31 @@ export function createPartialDeployments(
       return { kind: 'incomplete', missing }
     }
 
-    const creationTimestamp = await finalize(entityId, entityFile, authChain)
-    return { kind: 'deployed', creationTimestamp }
+    // Claim the finalization lease so only ONE completing request runs the expensive deploy pipeline
+    // (validation + on-chain access + deploy). The client's parallel worker pool and retries mean
+    // several completing requests can arrive at once.
+    const gotLease = await pendingDeploymentsRepository.acquireFinalizationLease(database, entityId)
+    if (!gotLease) {
+      // Another request is finalizing (or already did). If the entity is live now, report the
+      // idempotent success; otherwise report not-yet-complete so the client backs off and retries —
+      // it converges once the winner finishes (or its lease goes stale and this request takes over).
+      const alreadyDeployed = await deploymentsRepository.getEntityById(database, entityId)
+      if (alreadyDeployed) {
+        return { kind: 'deployed', creationTimestamp: alreadyDeployed.localTimestamp }
+      }
+      return { kind: 'incomplete', missing: [] }
+    }
+
+    try {
+      const creationTimestamp = await finalize(entityId, entityFile, authChain)
+      return { kind: 'deployed', creationTimestamp }
+    } catch (error) {
+      // Finalize failed without deploying: release the lease so a later request can retry. A successful
+      // deploy deletes the pending row inside its transaction, so this only runs on failure. Terminal
+      // errors (validation) still propagate; the row then expires via the TTL.
+      await pendingDeploymentsRepository.releaseFinalizationLease(database, entityId).catch(() => undefined)
+      throw error
+    }
   }
 
   async function cleanupExpired(): Promise<number> {

--- a/src/logic/partial-deployments/component.ts
+++ b/src/logic/partial-deployments/component.ts
@@ -146,7 +146,7 @@ export function createPartialDeployments(
       // (c) Rate limited between staging and now (e.g. a vanilla deploy on these pointers marked the
       // limiter): transient, so 429 (resumable) — matching how the staging path already treats it.
       if (deployer.isRateLimited(entity.type, entity.pointers)) {
-        throw new InvalidPartialDeploymentError(result.errors, 429)
+        throw new InvalidPartialDeploymentError(result.errors, 429, deployer.getRateLimitTtlSeconds(entity.type))
       }
 
       // Otherwise: a genuine validation failure, or exhausted pointer-conflict retries (429, someone else
@@ -270,9 +270,11 @@ export function createPartialDeployments(
     if (deployer.isRateLimited(entity.type, entity.pointers)) {
       // 429: rate limiting is transient, so a client can resume once the window clears (the staged
       // content is preserved server-side), rather than treating it as a terminal validation failure.
+      // Hand back the rate-limit window as Retry-After so the client waits it out.
       throw new InvalidPartialDeploymentError(
         [`Entity rate limited (entityId=${entity.id} pointers=${entity.pointers.join(',')}).`],
-        429
+        429,
+        deployer.getRateLimitTtlSeconds(entity.type)
       )
     }
     // (The per-deployer concurrent-pending cap is enforced inside the staging transaction below, under

--- a/src/logic/partial-deployments/component.ts
+++ b/src/logic/partial-deployments/component.ts
@@ -75,9 +75,11 @@ export function createPartialDeployments(
     }
   }
 
-  async function storeMissing(uploadedFiles: Map<string, Uint8Array>): Promise<void> {
-    const alreadyStored = await storage.existMultiple(Array.from(uploadedFiles.keys()))
-    const toStore = Array.from(uploadedFiles).filter(([hash]) => !alreadyStored.get(hash))
+  async function storeMissing(
+    uploadedFiles: Map<string, Uint8Array>,
+    alreadyStored: (hash: string) => boolean
+  ): Promise<void> {
+    const toStore = Array.from(uploadedFiles).filter(([hash]) => !alreadyStored(hash))
     for (let i = 0; i < toStore.length; i += CONTENT_STORE_CONCURRENCY) {
       await Promise.all(
         toStore
@@ -252,7 +254,6 @@ export function createPartialDeployments(
     // resurrected row never carries a stale created_at.
     await database.transaction(async (tx) => {
       await pendingDeploymentsRepository.acquireStagingLock(tx)
-      await pendingDeploymentsRepository.deleteExpired(tx, pendingDeploymentTtlMs)
       const replaced = await pendingDeploymentsRepository.deleteOverlappingPointers(tx, entity.pointers, entityId)
       if (replaced.length > 0) {
         metrics.increment('dcl_pending_deployments_replaced_total', {}, replaced.length)
@@ -261,18 +262,26 @@ export function createPartialDeployments(
           replaced: replaced.join(',')
         })
       }
-      await pendingDeploymentsRepository.upsert(tx, {
-        entityId,
-        entityType: entity.type,
-        pointers: entity.pointers,
-        contentHashes,
-        deployerAddress: Authenticator.ownerAddress(authChain)
-      })
+      // The upsert resets an expired row's created_at itself (fresh TTL window), so no global expired
+      // sweep is needed here — that is the cleanup job's duty, not this per-request critical section's.
+      await pendingDeploymentsRepository.upsert(
+        tx,
+        {
+          entityId,
+          entityType: entity.type,
+          pointers: entity.pointers,
+          contentHashes,
+          deployerAddress: Authenticator.ownerAddress(authChain)
+        },
+        pendingDeploymentTtlMs
+      )
     }, 'tx_stage_pending_deployment')
 
     // Store the batch's files (content-addressed, so concurrent identical writes are idempotent), in
-    // bounded-parallel batches, skipping anything already stored.
-    await storeMissing(uploadedFiles)
+    // bounded-parallel batches. Presence is derived from the fileInfoMultiple lookup already performed
+    // for the size check — no extra storage round trip. The entity file (not part of contentHashes) is
+    // always (re)stored; it is small and this covers the first request.
+    await storeMissing(uploadedFiles, (hash) => hash !== entityId && storedInfo.get(hash) !== undefined)
 
     // Completeness must be a fresh read (not derived from storedInfo): a concurrent partial request for
     // the same entity may have stored the remaining content while this one ran, and whichever request

--- a/src/logic/partial-deployments/component.ts
+++ b/src/logic/partial-deployments/component.ts
@@ -1,19 +1,14 @@
-import { bufferToStream, streamToBuffer } from '@dcl/catalyst-storage/dist/content-item'
+import { streamToBuffer } from '@dcl/catalyst-storage/dist/content-item'
 import { Authenticator } from '@dcl/crypto'
 import { Entity, EntityType, IPFSv2 } from '@dcl/schemas'
 import { sleep } from '@dcl/snapshots-fetcher/dist/utils'
 import { EnvironmentConfig } from '../../Environment'
 import { DeploymentContext, isInvalidDeployment } from '../../deployment-types'
 import { AppComponents } from '../../types'
-import { POINTERS_BEING_DEPLOYED_ERROR } from '../deployment-service'
 import { REQUEST_TTL_FORWARDS } from '../deployment-service/server-validator'
+import { storeStreamsInBatches } from '../store-content'
 import { InvalidPartialDeploymentError } from './errors'
 import { IPartialDeployments, StageDeploymentInput, StageDeploymentResult } from './types'
-
-// Upper bound on concurrent content-file writes for a staging batch — matches the vanilla deploy path's
-// CONTENT_STORE_CONCURRENCY. Content files are content-addressed and independent, so they store in
-// bounded-parallel batches instead of one awaited write at a time.
-const CONTENT_STORE_CONCURRENCY = 10
 
 // Bounded retry for the rare case where two requests complete a partial upload at the same instant:
 // the loser of the in-memory pointer lock retries and hits deployEntity's idempotency fast path.
@@ -52,6 +47,7 @@ export function createPartialDeployments(
   const logger = logs.getLogger('partial-deployments')
   const pendingDeploymentTtlMs = env.getConfig<number>(EnvironmentConfig.PENDING_DEPLOYMENT_TTL)
   const requestTtlBackwards = env.getConfig<number>(EnvironmentConfig.REQUEST_TTL_BACKWARDS)
+  const maxPendingPerDeployer = env.getConfig<number>(EnvironmentConfig.MAX_PENDING_DEPLOYMENTS_PER_DEPLOYER)
 
   async function finalize(entityId: string, entityFile: Uint8Array, authChain: StageDeploymentInput['authChain']) {
     // The deploy pipeline re-reads content from storage (all of it is present now), so only the entity
@@ -63,7 +59,7 @@ export function createPartialDeployments(
         // number === creation timestamp; the pending row was deleted inside the deploy transaction.
         return result
       }
-      const isPointerConflict = result.errors.some((e) => e.includes(POINTERS_BEING_DEPLOYED_ERROR))
+      const isPointerConflict = result.kind === 'pointer-conflict'
       if (isPointerConflict && attempt < FINALIZE_POINTER_CONFLICT_RETRIES) {
         await sleep(FINALIZE_POINTER_CONFLICT_DELAY_MS)
         continue
@@ -76,20 +72,13 @@ export function createPartialDeployments(
   }
 
   async function storeUploaded(uploadedFiles: Map<string, Uint8Array>): Promise<void> {
-    // Store every file the client sent this batch, in bounded-parallel batches. We do NOT skip files a
-    // pre-request snapshot said were already stored: that snapshot is taken before the pending row (and
-    // its GC protection) is committed, so a file present then could be swept before we get here — and
-    // skipping it would discard bytes the client uploaded in this very batch. Storage is content-
-    // addressed so re-storing an already-present file is an idempotent no-op, and the client already
-    // omits files reported by /available-content, so this rarely re-sends present content anyway.
-    const toStore = Array.from(uploadedFiles)
-    for (let i = 0; i < toStore.length; i += CONTENT_STORE_CONCURRENCY) {
-      await Promise.all(
-        toStore
-          .slice(i, i + CONTENT_STORE_CONCURRENCY)
-          .map(([hash, content]) => storage.storeStream(hash, bufferToStream(content)))
-      )
-    }
+    // Store every file the client sent this batch, in bounded-parallel batches (shared helper). We do
+    // NOT skip files a pre-request snapshot said were already stored: that snapshot is taken before the
+    // pending row (and its GC protection) is committed, so a file present then could be swept before we
+    // get here — and skipping it would discard bytes the client uploaded in this very batch. Storage is
+    // content-addressed so re-storing an already-present file is an idempotent no-op, and the client
+    // already omits files reported by /available-content, so this rarely re-sends present content.
+    await storeStreamsInBatches(storage, Array.from(uploadedFiles))
   }
 
   async function stageDeployment({ entityId, authChain, files }: StageDeploymentInput): Promise<StageDeploymentResult> {
@@ -193,6 +182,21 @@ export function createPartialDeployments(
         429
       )
     }
+    // Cap concurrent staged uploads per deployer so one account can't pin storage across many
+    // pointer-sets for the full TTL. Only NEW uploads count against the cap — a resume (activePending)
+    // reuses its existing slot.
+    if (!activePending) {
+      const activeCount = await pendingDeploymentsRepository.countActiveByDeployer(
+        database,
+        Authenticator.ownerAddress(authChain),
+        pendingDeploymentTtlMs
+      )
+      if (activeCount >= maxPendingPerDeployer) {
+        throw new InvalidPartialDeploymentError([
+          `Too many partial uploads in progress for this account (max ${maxPendingPerDeployer}). Finalize or abandon an existing upload before starting another.`
+        ])
+      }
+    }
     // A partial upload can span longer than REQUEST_TTL_BACKWARDS, so anchor the freshness check on
     // when the upload started (the pending row's created_at) rather than now.
     const ttlAnchor = activePending ? activePending.createdAt.getTime() : Date.now()
@@ -258,6 +262,23 @@ export function createPartialDeployments(
     // expired rows is the cleanup job's responsibility, not this per-request critical section's.
     await database.transaction(async (tx) => {
       await pendingDeploymentsRepository.acquireStagingLock(tx)
+
+      // The single pending slot per pointer set goes to the NEWEST scene (deployment ordering: greater
+      // entity.timestamp, tie broken by greater entity id). Reject rather than replace when a
+      // strictly-newer overlapping upload is already in flight, so a stale/older upload can't evict a
+      // newer competitor's staged content (and two clients can't ping-pong evicting each other). A
+      // resume (same entity id) is excluded from the overlap set and never conflicts with itself.
+      const overlapping = await pendingDeploymentsRepository.getOverlappingPointers(tx, entity.pointers, entityId)
+      const newer = overlapping.find(
+        (o) => o.entityTimestamp > entity.timestamp || (o.entityTimestamp === entity.timestamp && o.entityId > entityId)
+      )
+      if (newer) {
+        throw new InvalidPartialDeploymentError([
+          `A newer partial upload (${newer.entityId}) is already in progress for one or more of these pointers.`
+        ])
+      }
+
+      // Having rejected the newer-conflict above, every overlapping row is strictly older — replace them.
       const replaced = await pendingDeploymentsRepository.deleteOverlappingPointers(tx, entity.pointers, entityId)
       if (replaced.length > 0) {
         metrics.increment('dcl_pending_deployments_replaced_total', {}, replaced.length)
@@ -275,7 +296,8 @@ export function createPartialDeployments(
           entityType: entity.type,
           pointers: entity.pointers,
           contentHashes,
-          deployerAddress: Authenticator.ownerAddress(authChain)
+          deployerAddress: Authenticator.ownerAddress(authChain),
+          entityTimestamp: entity.timestamp
         },
         pendingDeploymentTtlMs
       )

--- a/src/logic/partial-deployments/component.ts
+++ b/src/logic/partial-deployments/component.ts
@@ -68,7 +68,10 @@ export function createPartialDeployments(
         await sleep(FINALIZE_POINTER_CONFLICT_DELAY_MS)
         continue
       }
-      throw new InvalidPartialDeploymentError(result.errors)
+      // Exhausting the pointer-conflict retries is a transient condition (someone else is deploying on
+      // these pointers right now), not a validation failure: 429 tells the client to resume later —
+      // the staged content is intact.
+      throw new InvalidPartialDeploymentError(result.errors, isPointerConflict ? 429 : 400)
     }
   }
 
@@ -150,11 +153,23 @@ export function createPartialDeployments(
 
     // Content-independent validations: entity structure, IPFS hashing, metadata schema, ADR45,
     // signature, scene rules, "reject extra files", and the LAND access/ownership check.
-    const validationResult = await validator.validateStagingScene({
-      entity,
-      files: uploadedFiles,
-      auditInfo: { authChain }
-    })
+    //
+    // Resume batches skip the slow on-chain/subgraph access check, but only when the signer is the
+    // deployer who created the pending record: that creation required passing the access check, every
+    // uploaded byte is hash-verified against the staged manifest, and finalize re-runs the full
+    // validation (including access) before going live. Any other signer — authorized or not — goes
+    // through the full staging validation, so a third party can't ride an existing upload's fast path.
+    const isResumeBySameDeployer =
+      !!activePending &&
+      activePending.deployerAddress.toLowerCase() === Authenticator.ownerAddress(authChain).toLowerCase()
+    const validationResult = await validator.validateStagingScene(
+      {
+        entity,
+        files: uploadedFiles,
+        auditInfo: { authChain }
+      },
+      { skipAccessCheck: isResumeBySameDeployer }
+    )
     if (!validationResult.ok) {
       throw new InvalidPartialDeploymentError(validationResult.errors ?? ['The staging validation was not successful.'])
     }
@@ -229,10 +244,15 @@ export function createPartialDeployments(
     }
 
     // Record/refresh the pending deployment, replacing any pending upload on overlapping pointers, in a
-    // short transaction serialized by an advisory lock. Done BEFORE storing the batch so the staged
-    // content is protected from the garbage collector as soon as it lands.
+    // short transaction serialized by an advisory lock. This runs on EVERY batch (not only the first)
+    // and always BEFORE storing the batch's files: it is what protects the staged content from the
+    // garbage collector, and re-asserting it per batch resurrects the row if a competing overlapping
+    // upload replaced it between requests — otherwise this batch's files would be written with no GC
+    // protection for the remainder of the upload. Expired rows are purged in the same transaction so a
+    // resurrected row never carries a stale created_at.
     await database.transaction(async (tx) => {
       await pendingDeploymentsRepository.acquireStagingLock(tx)
+      await pendingDeploymentsRepository.deleteExpired(tx, pendingDeploymentTtlMs)
       const replaced = await pendingDeploymentsRepository.deleteOverlappingPointers(tx, entity.pointers, entityId)
       if (replaced.length > 0) {
         metrics.increment('dcl_pending_deployments_replaced_total', {}, replaced.length)

--- a/src/logic/partial-deployments/component.ts
+++ b/src/logic/partial-deployments/component.ts
@@ -182,21 +182,8 @@ export function createPartialDeployments(
         429
       )
     }
-    // Cap concurrent staged uploads per deployer so one account can't pin storage across many
-    // pointer-sets for the full TTL. Only NEW uploads count against the cap — a resume (activePending)
-    // reuses its existing slot.
-    if (!activePending) {
-      const activeCount = await pendingDeploymentsRepository.countActiveByDeployer(
-        database,
-        Authenticator.ownerAddress(authChain),
-        pendingDeploymentTtlMs
-      )
-      if (activeCount >= maxPendingPerDeployer) {
-        throw new InvalidPartialDeploymentError([
-          `Too many partial uploads in progress for this account (max ${maxPendingPerDeployer}). Finalize or abandon an existing upload before starting another.`
-        ])
-      }
-    }
+    // (The per-deployer concurrent-pending cap is enforced inside the staging transaction below, under
+    // the advisory lock, so concurrent new uploads can't race past it.)
     // A partial upload can span longer than REQUEST_TTL_BACKWARDS, so anchor the freshness check on
     // when the upload started (the pending row's created_at) rather than now.
     const ttlAnchor = activePending ? activePending.createdAt.getTime() : Date.now()
@@ -262,6 +249,23 @@ export function createPartialDeployments(
     // expired rows is the cleanup job's responsibility, not this per-request critical section's.
     await database.transaction(async (tx) => {
       await pendingDeploymentsRepository.acquireStagingLock(tx)
+
+      // Cap concurrent staged uploads per deployer so one account can't pin storage across many
+      // pointer-sets for the full TTL. Enforced HERE, under the advisory lock (which serializes all
+      // staging), so concurrent new uploads can't each read a count below the cap and then all insert.
+      // Only NEW uploads count — a resume (activePending) reuses its existing slot.
+      if (!activePending) {
+        const activeCount = await pendingDeploymentsRepository.countActiveByDeployer(
+          tx,
+          Authenticator.ownerAddress(authChain),
+          pendingDeploymentTtlMs
+        )
+        if (activeCount >= maxPendingPerDeployer) {
+          throw new InvalidPartialDeploymentError([
+            `Too many partial uploads in progress for this account (max ${maxPendingPerDeployer}). Finalize or abandon an existing upload before starting another.`
+          ])
+        }
+      }
 
       // The single pending slot per pointer set goes to the NEWEST scene (deployment ordering: greater
       // entity.timestamp, tie broken by greater entity id). Reject rather than replace when a

--- a/src/logic/partial-deployments/component.ts
+++ b/src/logic/partial-deployments/component.ts
@@ -250,23 +250,6 @@ export function createPartialDeployments(
     await database.transaction(async (tx) => {
       await pendingDeploymentsRepository.acquireStagingLock(tx)
 
-      // Cap concurrent staged uploads per deployer so one account can't pin storage across many
-      // pointer-sets for the full TTL. Enforced HERE, under the advisory lock (which serializes all
-      // staging), so concurrent new uploads can't each read a count below the cap and then all insert.
-      // Only NEW uploads count — a resume (activePending) reuses its existing slot.
-      if (!activePending) {
-        const activeCount = await pendingDeploymentsRepository.countActiveByDeployer(
-          tx,
-          Authenticator.ownerAddress(authChain),
-          pendingDeploymentTtlMs
-        )
-        if (activeCount >= maxPendingPerDeployer) {
-          throw new InvalidPartialDeploymentError([
-            `Too many partial uploads in progress for this account (max ${maxPendingPerDeployer}). Finalize or abandon an existing upload before starting another.`
-          ])
-        }
-      }
-
       // The single pending slot per pointer set goes to the NEWEST scene (deployment ordering: greater
       // entity.timestamp, tie broken by greater entity id). Reject rather than replace when a
       // strictly-newer overlapping upload is already in flight, so a stale/older upload can't evict a
@@ -290,6 +273,24 @@ export function createPartialDeployments(
           entityId,
           replaced: replaced.join(',')
         })
+      }
+
+      // Cap concurrent staged uploads per deployer so one account can't pin storage across many
+      // pointer-sets for the full TTL. Decided HERE — under the advisory lock (which serializes all
+      // staging) and AFTER the overlap-replace — on the NET row-count change: `others` excludes this
+      // entity id, so `others + 1` is the deployer's post-upsert total whether this is a fresh insert, a
+      // resume, or a newer scene that just replaced one of the deployer's own overlapping rows. That
+      // avoids both racing the cap and wrongly rejecting a resume/replacement that doesn't grow the count.
+      const others = await pendingDeploymentsRepository.countActiveByDeployer(
+        tx,
+        Authenticator.ownerAddress(authChain),
+        pendingDeploymentTtlMs,
+        entityId
+      )
+      if (others + 1 > maxPendingPerDeployer) {
+        throw new InvalidPartialDeploymentError([
+          `Too many partial uploads in progress for this account (max ${maxPendingPerDeployer}). Finalize or abandon an existing upload before starting another.`
+        ])
       }
       // The upsert resets an expired row's created_at itself (fresh TTL window), so no global expired
       // sweep is needed here — that is the cleanup job's duty, not this per-request critical section's.

--- a/src/logic/partial-deployments/component.ts
+++ b/src/logic/partial-deployments/component.ts
@@ -5,6 +5,7 @@ import { EnvironmentConfig } from '../../Environment'
 import { DeploymentContext, isInvalidDeployment } from '../../deployment-types'
 import { AppComponents } from '../../types'
 import { REQUEST_TTL_FORWARDS } from '../deployment-service/server-validator'
+import { happenedBefore } from '../deployment-service/time-sorting'
 import { storeStreamsInBatches } from '../store-content'
 import { InvalidPartialDeploymentError } from './errors'
 import { IPartialDeployments, StageDeploymentInput, StageDeploymentResult } from './types'
@@ -69,12 +70,30 @@ export function createPartialDeployments(
   const requestTtlBackwards = env.getConfig<number>(EnvironmentConfig.REQUEST_TTL_BACKWARDS)
   const maxPendingPerDeployer = env.getConfig<number>(EnvironmentConfig.MAX_PENDING_DEPLOYMENTS_PER_DEPLOYER)
 
+  async function deletePendingBestEffort(entityId: string): Promise<void> {
+    // deployEntity deletes the pending row inside tx_deploy_entity on the real-deploy path, but its
+    // already-deployed idempotency fast path returns WITHOUT running that delete — so a row re-created by
+    // a straggling resume (after a concurrent winner already committed) would linger and pin a cap slot
+    // for the full TTL. Deleting here on every successful finalize is idempotent (a no-op when the deploy
+    // tx already removed it) and closes that leak. Best-effort: the deploy has committed, so a failed
+    // cleanup must not fail the request — the row would otherwise expire via the TTL.
+    try {
+      await pendingDeploymentsRepository.deleteByEntityId(database, entityId)
+    } catch (error: any) {
+      logger.warn('Failed to delete pending deployment after finalize; it will expire via TTL', {
+        entityId,
+        error: error?.message ?? `${error}`
+      })
+    }
+  }
+
   async function finalize(
-    entityId: string,
+    entity: Entity,
     entityFile: Uint8Array,
     authChain: StageDeploymentInput['authChain'],
     contentHashes: string[]
   ): Promise<StageDeploymentResult> {
+    const entityId = entity.id
     // Re-verify content presence immediately before deploying. The completeness check ran before this
     // (slow) deploy pipeline, and a garbage-collection sweep whose snapshot predates the pending row
     // could have reclaimed a reused, already-stored file in that window. Committing a scene that
@@ -93,7 +112,7 @@ export function createPartialDeployments(
     for (let attempt = 0; ; attempt++) {
       const result = await deployer.deployEntity(finalizeFiles, entityId, { authChain }, DeploymentContext.LOCAL)
       if (!isInvalidDeployment(result)) {
-        // number === creation timestamp; the pending row was deleted inside the deploy transaction.
+        await deletePendingBestEffort(entityId)
         return { kind: 'deployed', creationTimestamp: result }
       }
       const isPointerConflict = result.kind === 'pointer-conflict'
@@ -101,9 +120,37 @@ export function createPartialDeployments(
         await sleep(FINALIZE_POINTER_CONFLICT_DELAY_MS)
         continue
       }
-      // Exhausting the pointer-conflict retries is a transient condition (someone else is deploying on
-      // these pointers right now), not a validation failure: 429 tells the client to resume later —
-      // the staged content is intact.
+
+      // The deploy returned an invalid result. deployEntity mints `kind: 'pointer-conflict'` at exactly
+      // one site (the in-memory pointer lock); every other failure is a kind-less InvalidResult that
+      // would otherwise become a terminal 400 the client cannot resume. Distinguish the transient/racy
+      // causes so a fully-staged upload isn't abandoned for a recoverable condition:
+
+      // (a) Already deployed: a concurrent finalize won — including on ANOTHER process, whose duplicate
+      // INSERT hit the deployments unique entity-id constraint and surfaced as a generic error here.
+      // The entity is live, so this is an idempotent success (and we clean up any pending row we own).
+      const alreadyDeployed = await deploymentsRepository.getEntityById(database, entityId)
+      if (alreadyDeployed) {
+        await deletePendingBestEffort(entityId)
+        return { kind: 'deployed', creationTimestamp: alreadyDeployed.localTimestamp }
+      }
+
+      // (b) A GC sweep reclaimed a reused, already-stored file DURING the deploy validation (the
+      // pre-check above passed, but the pipeline re-reads content). Resumable — the client re-uploads it.
+      const present = await storage.existMultiple(contentHashes)
+      const missingNow = contentHashes.filter((hash) => !present.get(hash))
+      if (missingNow.length > 0) {
+        return { kind: 'incomplete', missing: missingNow }
+      }
+
+      // (c) Rate limited between staging and now (e.g. a vanilla deploy on these pointers marked the
+      // limiter): transient, so 429 (resumable) — matching how the staging path already treats it.
+      if (deployer.isRateLimited(entity.type, entity.pointers)) {
+        throw new InvalidPartialDeploymentError(result.errors, 429)
+      }
+
+      // Otherwise: a genuine validation failure, or exhausted pointer-conflict retries (429, someone else
+      // is deploying on these pointers right now — the staged content is intact).
       throw new InvalidPartialDeploymentError(result.errors, isPointerConflict ? 429 : 400)
     }
   }
@@ -150,9 +197,18 @@ export function createPartialDeployments(
     }
 
     // The entity JSON must be present in the first request; later (resume) requests re-read it from
-    // storage, where it was stored under its own id on the first request.
+    // storage, where it was stored under its own id on the first request. Cap it on BOTH paths: the
+    // resume read-back caps while streaming, so the first request must reject an oversized manifest too
+    // — otherwise a >cap manifest would stage successfully on request 1 and then wedge on every resume
+    // (which can never read it back within the cap).
     let entityFile = uploadedFiles.get(entityId)
-    if (!entityFile) {
+    if (entityFile) {
+      if (entityFile.byteLength > MAX_ENTITY_FILE_SIZE_BYTES) {
+        throw new InvalidPartialDeploymentError([
+          `The entity file '${entityId}' is too large (${entityFile.byteLength} bytes, max ${MAX_ENTITY_FILE_SIZE_BYTES}).`
+        ])
+      }
+    } else {
       const stored = await storage.retrieve(entityId)
       if (!stored) {
         throw new InvalidPartialDeploymentError([
@@ -285,36 +341,42 @@ export function createPartialDeployments(
     // the repository), so a resurrected row never carries a stale TTL anchor; purging other entities'
     // expired rows is the cleanup job's responsibility, not this per-request critical section's.
     await database.transaction(async (tx) => {
-      await pendingDeploymentsRepository.acquireStagingLock(tx)
+      await pendingDeploymentsRepository.acquireStagingLocks(tx, entity.pointers, Authenticator.ownerAddress(authChain))
 
-      // The single pending slot per pointer set goes to the NEWEST scene (deployment ordering: greater
-      // entity.timestamp, tie broken by greater entity id). Reject rather than replace when a
-      // strictly-newer overlapping upload is already in flight, so a stale/older upload can't evict a
-      // newer competitor's staged content (and two clients can't ping-pong evicting each other). A
-      // resume (same entity id) is excluded from the overlap set and never conflicts with itself.
+      // The single pending slot per pointer set goes to the NEWEST scene. Reject rather than replace
+      // when a strictly-newer overlapping upload is already in flight, so a stale/older upload can't
+      // evict a newer competitor's staged content (and two clients can't ping-pong evicting each other).
+      // A resume (same entity id) is excluded from the overlap set and never conflicts with itself.
       const overlapping = await pendingDeploymentsRepository.getOverlappingPointers(
         tx,
         entity.pointers,
         entityId,
         pendingDeploymentTtlMs
       )
-      // Newest-wins, matching the deployments `happenedBefore` ordering: greater entity timestamp, ties
-      // broken by the LEXICOGRAPHICALLY-greater LOWERCASED entity id. Lowercasing keeps this consistent
-      // with the deployments comparator (which compares LOWER(entity_id)); a raw comparison could order
-      // two uploads differently here than at finalize.
-      const newer = overlapping.find(
-        (o) =>
-          o.entityTimestamp > entity.timestamp ||
-          (o.entityTimestamp === entity.timestamp && o.entityId.toLowerCase() > entityId.toLowerCase())
+      // Use the canonical `happenedBefore` ordering (greater timestamp, ties broken by LOWER(entity_id))
+      // so pending-slot arbitration can never diverge from how the deployments table orders the same two
+      // entities at finalize. `happenedBefore(entity, o)` is true when `entity` is OLDER than `o`.
+      const newer = overlapping.find((o) =>
+        happenedBefore(entity, { entityId: o.entityId, timestamp: o.entityTimestamp })
       )
       if (newer) {
+        // Deliberately generic: do NOT disclose the other upload's entity id. It is the content hash of
+        // an unreleased scene not yet in any public listing, and leaking it lets a caller confirm/ target
+        // a specific in-flight deployment (worlds returns the same generic message).
         throw new InvalidPartialDeploymentError([
-          `A newer partial upload (${newer.entityId}) is already in progress for one or more of these pointers.`
+          'A newer partial upload is already in progress for one or more of these pointers.'
         ])
       }
 
       // Having rejected the newer-conflict above, every overlapping row is strictly older — replace them.
-      const replaced = await pendingDeploymentsRepository.deleteOverlappingPointers(tx, entity.pointers, entityId)
+      // On the resume fast path (which skipped the access check) restrict the replace to this deployer's
+      // own rows, so a deployer who lost access mid-upload can't evict another deployer's staged upload.
+      const replaced = await pendingDeploymentsRepository.deleteOverlappingPointers(
+        tx,
+        entity.pointers,
+        entityId,
+        isResumeBySameDeployer ? Authenticator.ownerAddress(authChain) : undefined
+      )
       if (replaced.length > 0) {
         metrics.increment('dcl_pending_deployments_replaced_total', {}, replaced.length)
         logger.info(`Replaced ${replaced.length} pending deployment(s) overlapping the new one's pointers`, {
@@ -375,10 +437,10 @@ export function createPartialDeployments(
 
     // Everything is present — run the full deploy pipeline in this request. Concurrent completing
     // requests (the client's parallel worker pool, retries) may race here; the deployments unique
-    // entity-id constraint serializes them, and finalize's bounded pointer-conflict retry lets the
-    // loser fall through to deployEntity's idempotency fast path. The duplicated validation in that rare
-    // race is accepted — a lease to avoid it costs more in failure modes than the work it would save.
-    return await finalize(entityId, entityFile, authChain, contentHashes)
+    // entity-id constraint serializes them, and finalize maps the loser to an idempotent success. The
+    // duplicated validation in that rare race is accepted — a lease to avoid it costs more in failure
+    // modes than the work it would save.
+    return await finalize(entity, entityFile, authChain, contentHashes)
   }
 
   async function cleanupExpired(): Promise<number> {

--- a/src/logic/partial-deployments/component.ts
+++ b/src/logic/partial-deployments/component.ts
@@ -1,0 +1,256 @@
+import { bufferToStream, streamToBuffer } from '@dcl/catalyst-storage/dist/content-item'
+import { Authenticator } from '@dcl/crypto'
+import { Entity, EntityType, IPFSv2 } from '@dcl/schemas'
+import SQL from 'sql-template-strings'
+import { EnvironmentConfig } from '../../Environment'
+import { DeploymentContext, isInvalidDeployment } from '../../deployment-types'
+import { AppComponents } from '../../types'
+import { REQUEST_TTL_FORWARDS } from '../deployment-service/server-validator'
+import { InvalidPartialDeploymentError } from './errors'
+import { IPartialDeployments, StageDeploymentInput, StageDeploymentResult } from './types'
+
+// Fixed key for the transaction-scoped advisory lock that serializes the tiny "replace overlapping +
+// upsert" critical section across concurrent staging requests (and across processes). An arbitrary
+// distinctive constant, chosen not to collide with node-pg-migrate's migration lock.
+const PENDING_DEPLOYMENTS_ADVISORY_LOCK = 916352745601
+
+// Bounded retry for the rare case where two requests complete a partial upload at the same instant:
+// the loser of the in-memory pointer lock retries and hits deployEntity's idempotency fast path.
+const FINALIZE_POINTER_CONFLICT_RETRIES = 3
+const FINALIZE_POINTER_CONFLICT_DELAY_MS = 300
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+export function createPartialDeployments(
+  components: Pick<
+    AppComponents,
+    | 'logs'
+    | 'metrics'
+    | 'env'
+    | 'storage'
+    | 'database'
+    | 'crypto'
+    | 'validator'
+    | 'deployer'
+    | 'entities'
+    | 'deploymentsRepository'
+    | 'pendingDeploymentsRepository'
+  >
+): IPartialDeployments {
+  const {
+    logs,
+    metrics,
+    env,
+    storage,
+    database,
+    crypto,
+    validator,
+    deployer,
+    entities,
+    deploymentsRepository,
+    pendingDeploymentsRepository
+  } = components
+  const logger = logs.getLogger('partial-deployments')
+  const pendingDeploymentTtlMs = env.getConfig<number>(EnvironmentConfig.PENDING_DEPLOYMENT_TTL)
+  const requestTtlBackwards = env.getConfig<number>(EnvironmentConfig.REQUEST_TTL_BACKWARDS)
+
+  async function finalize(entityId: string, entityFile: Uint8Array, authChain: StageDeploymentInput['authChain']) {
+    // The deploy pipeline re-reads content from storage (all of it is present now), so only the entity
+    // file needs to be in the map. Passing a Map hits deployEntity's hashFiles fast path (no re-hash).
+    const finalizeFiles = new Map<string, Uint8Array>([[entityId, entityFile]])
+    for (let attempt = 0; ; attempt++) {
+      const result = await deployer.deployEntity(finalizeFiles, entityId, { authChain }, DeploymentContext.LOCAL)
+      if (!isInvalidDeployment(result)) {
+        // number === creation timestamp; the pending row was deleted inside the deploy transaction.
+        return result
+      }
+      const isPointerConflict = result.errors.some((e) => e.includes('currently being deployed'))
+      if (isPointerConflict && attempt < FINALIZE_POINTER_CONFLICT_RETRIES) {
+        await delay(FINALIZE_POINTER_CONFLICT_DELAY_MS)
+        continue
+      }
+      throw new InvalidPartialDeploymentError(result.errors)
+    }
+  }
+
+  async function stageDeployment({ entityId, authChain, files }: StageDeploymentInput): Promise<StageDeploymentResult> {
+    // Entity deployments are idempotent: if it's already deployed, report it as such (this also covers
+    // a staging request that arrives after a concurrent finalize won).
+    const alreadyDeployed = await deploymentsRepository.getEntityById(database, entityId)
+    if (alreadyDeployed) {
+      return { kind: 'deployed', creationTimestamp: alreadyDeployed.localTimestamp }
+    }
+
+    // Partial deployments are v3/IPFSv2 only (the legacy Qm hash path is not supported).
+    if (!IPFSv2.validate(entityId)) {
+      throw new InvalidPartialDeploymentError([
+        `The entity id '${entityId}' is not a valid IPFS v2 hash. Partial deployments require IPFS v2 entities.`
+      ])
+    }
+
+    // Verify every uploaded file hashes to its multipart field-name key. In partial mode the keys are
+    // load-bearing (unlike a full deploy, where files are re-keyed by their computed hash).
+    const entries = Array.from(files.entries())
+    const hashed = await crypto.calculateIPFSHashes(entries.map(([, buf]) => buf))
+    const uploadedFiles = new Map<string, Uint8Array>()
+    for (let i = 0; i < entries.length; i++) {
+      const declaredKey = entries[i][0]
+      const computedHash = hashed[i].hash
+      if (declaredKey !== computedHash) {
+        throw new InvalidPartialDeploymentError([
+          `The uploaded file '${declaredKey}' does not match its content hash (computed ${computedHash}).`
+        ])
+      }
+      uploadedFiles.set(computedHash, hashed[i].file)
+    }
+
+    // The entity JSON must be present in the first request; later (resume) requests re-read it from
+    // storage, where it was stored under its own id on the first request.
+    let entityFile = uploadedFiles.get(entityId)
+    if (!entityFile) {
+      const stored = await storage.retrieve(entityId)
+      if (!stored) {
+        throw new InvalidPartialDeploymentError([
+          `The first partial request for an entity must include the entity file '${entityId}'.`
+        ])
+      }
+      entityFile = await streamToBuffer(await stored.asStream())
+    }
+
+    let entity: Entity
+    try {
+      entity = entities.parse(entityFile, entityId)
+    } catch (error) {
+      throw new InvalidPartialDeploymentError([`There was a problem parsing the entity: ${error}`])
+    }
+    if (entity.type !== EntityType.SCENE) {
+      throw new InvalidPartialDeploymentError([
+        `Partial deployments are only supported for scenes, but the entity type is '${entity.type}'.`
+      ])
+    }
+    if (!entity.pointers || entity.pointers.length === 0) {
+      throw new InvalidPartialDeploymentError(['The entity does not have any pointer.'])
+    }
+
+    // Existing pending row (drives TTL anchoring; a row past its TTL is treated as absent).
+    const pending = await pendingDeploymentsRepository.getByEntityId(database, entityId)
+    const activePending =
+      pending && Date.now() - pending.createdAt.getTime() <= pendingDeploymentTtlMs ? pending : undefined
+
+    // Content-independent validations: entity structure, IPFS hashing, metadata schema, ADR45,
+    // signature, scene rules, "reject extra files", and the LAND access/ownership check.
+    const validationResult = await validator.validateStagingScene({
+      entity,
+      files: uploadedFiles,
+      auditInfo: { authChain }
+    })
+    if (!validationResult.ok) {
+      throw new InvalidPartialDeploymentError(validationResult.errors ?? ['The staging validation was not successful.'])
+    }
+
+    // Server-side checks that mirror the LOCAL-context localChecks, minus content completeness.
+    if (await deploymentsRepository.hasNewerDeploymentOnPointers(database, entity)) {
+      throw new InvalidPartialDeploymentError([
+        `There is a newer entity pointed by one or more of the pointers you provided (entityId=${entity.id}).`
+      ])
+    }
+    if (deployer.isRateLimited(entity.type, entity.pointers)) {
+      throw new InvalidPartialDeploymentError([
+        `Entity rate limited (entityId=${entity.id} pointers=${entity.pointers.join(',')}).`
+      ])
+    }
+    // A partial upload can span longer than REQUEST_TTL_BACKWARDS, so anchor the freshness check on
+    // when the upload started (the pending row's created_at) rather than now.
+    const ttlAnchor = activePending ? activePending.createdAt.getTime() : Date.now()
+    if (ttlAnchor - entity.timestamp > requestTtlBackwards) {
+      throw new InvalidPartialDeploymentError([
+        `The request is not recent enough, please submit it again with a new timestamp (entityId=${entity.id}).`
+      ])
+    }
+    if (Date.now() - entity.timestamp < -REQUEST_TTL_FORWARDS) {
+      throw new InvalidPartialDeploymentError([
+        `The request is too far in the future, please submit it again with a new timestamp (entityId=${entity.id}).`
+      ])
+    }
+
+    // Cumulative size budget. Mirrors calculateDeploymentSize (the finalize-time check): sum uploaded
+    // bytes for files in this batch and stored sizes for files staged earlier; not-yet-uploaded files
+    // contribute 0. Checked before storing this batch so an over-budget upload is never persisted.
+    const contentHashes = Array.from(new Set((entity.content ?? []).map((c) => c.hash)))
+    const storedInfo = await storage.fileInfoMultiple(contentHashes)
+    let totalSize = 0
+    for (const hash of contentHashes) {
+      const uploaded = uploadedFiles.get(hash)
+      totalSize += uploaded ? uploaded.byteLength : storedInfo.get(hash)?.contentSize ?? 0
+    }
+    const maxSizePerPointer = validator.getMaxSizeInBytesPerPointer(EntityType.SCENE)
+    if (totalSize / entity.pointers.length > maxSizePerPointer) {
+      // Drop the pending row (and let its content become GC-eligible) so an over-budget upload can't
+      // hold staged storage until expiry.
+      await pendingDeploymentsRepository.deleteByEntityId(database, entityId)
+      throw new InvalidPartialDeploymentError([
+        `The deployment is too big. The maximum allowed size per pointer is ${
+          maxSizePerPointer / (1024 * 1024)
+        } MB for ${entity.type}. You can upload up to ${
+          entity.pointers.length * maxSizePerPointer
+        } bytes but you tried to upload ${totalSize}.`
+      ])
+    }
+
+    // Record/refresh the pending deployment, replacing any pending upload on overlapping pointers, in a
+    // short transaction serialized by an advisory lock. Done BEFORE storing the batch so the staged
+    // content is protected from the garbage collector as soon as it lands.
+    await database.transaction(async (tx) => {
+      await tx.queryWithValues(
+        SQL`SELECT pg_advisory_xact_lock(${PENDING_DEPLOYMENTS_ADVISORY_LOCK})`,
+        'pending_deployment_advisory_lock'
+      )
+      const replaced = await pendingDeploymentsRepository.deleteOverlappingPointers(tx, entity.pointers, entityId)
+      if (replaced.length > 0) {
+        metrics.increment('dcl_pending_deployments_replaced_total', {}, replaced.length)
+        logger.info(`Replaced ${replaced.length} pending deployment(s) overlapping the new one's pointers`, {
+          entityId,
+          replaced: replaced.join(',')
+        })
+      }
+      await pendingDeploymentsRepository.upsert(tx, {
+        entityId,
+        entityType: entity.type,
+        pointers: entity.pointers,
+        contentHashes,
+        deployerAddress: Authenticator.ownerAddress(authChain)
+      })
+    }, 'tx_stage_pending_deployment')
+
+    // Store the batch's files (content-addressed, so concurrent identical writes are idempotent).
+    const toStore = await storage.existMultiple(Array.from(uploadedFiles.keys()))
+    for (const [hash, content] of uploadedFiles) {
+      if (!toStore.get(hash)) {
+        await storage.storeStream(hash, bufferToStream(content))
+      }
+    }
+
+    // Completeness check. If everything referenced by the entity is now present, auto-finalize.
+    const present = await storage.existMultiple(contentHashes)
+    const missing = contentHashes.filter((hash) => !present.get(hash))
+    if (missing.length > 0) {
+      return { kind: 'incomplete', missing }
+    }
+
+    const creationTimestamp = await finalize(entityId, entityFile, authChain)
+    return { kind: 'deployed', creationTimestamp }
+  }
+
+  async function cleanupExpired(): Promise<number> {
+    const removed = await pendingDeploymentsRepository.deleteExpired(database, pendingDeploymentTtlMs)
+    if (removed > 0) {
+      metrics.increment('dcl_pending_deployments_expired_total', {}, removed)
+      logger.info(`Removed ${removed} expired pending deployment(s)`)
+    }
+    return removed
+  }
+
+  return { stageDeployment, cleanupExpired }
+}

--- a/src/logic/partial-deployments/component.ts
+++ b/src/logic/partial-deployments/component.ts
@@ -166,9 +166,12 @@ export function createPartialDeployments(
       ])
     }
     if (deployer.isRateLimited(entity.type, entity.pointers)) {
-      throw new InvalidPartialDeploymentError([
-        `Entity rate limited (entityId=${entity.id} pointers=${entity.pointers.join(',')}).`
-      ])
+      // 429: rate limiting is transient, so a client can resume once the window clears (the staged
+      // content is preserved server-side), rather than treating it as a terminal validation failure.
+      throw new InvalidPartialDeploymentError(
+        [`Entity rate limited (entityId=${entity.id} pointers=${entity.pointers.join(',')}).`],
+        429
+      )
     }
     // A partial upload can span longer than REQUEST_TTL_BACKWARDS, so anchor the freshness check on
     // when the upload started (the pending row's created_at) rather than now.

--- a/src/logic/partial-deployments/component.ts
+++ b/src/logic/partial-deployments/component.ts
@@ -1,27 +1,24 @@
 import { bufferToStream, streamToBuffer } from '@dcl/catalyst-storage/dist/content-item'
 import { Authenticator } from '@dcl/crypto'
 import { Entity, EntityType, IPFSv2 } from '@dcl/schemas'
-import SQL from 'sql-template-strings'
+import { sleep } from '@dcl/snapshots-fetcher/dist/utils'
 import { EnvironmentConfig } from '../../Environment'
 import { DeploymentContext, isInvalidDeployment } from '../../deployment-types'
 import { AppComponents } from '../../types'
+import { POINTERS_BEING_DEPLOYED_ERROR } from '../deployment-service'
 import { REQUEST_TTL_FORWARDS } from '../deployment-service/server-validator'
 import { InvalidPartialDeploymentError } from './errors'
 import { IPartialDeployments, StageDeploymentInput, StageDeploymentResult } from './types'
 
-// Fixed key for the transaction-scoped advisory lock that serializes the tiny "replace overlapping +
-// upsert" critical section across concurrent staging requests (and across processes). An arbitrary
-// distinctive constant, chosen not to collide with node-pg-migrate's migration lock.
-const PENDING_DEPLOYMENTS_ADVISORY_LOCK = 916352745601
+// Upper bound on concurrent content-file writes for a staging batch — matches the vanilla deploy path's
+// CONTENT_STORE_CONCURRENCY. Content files are content-addressed and independent, so they store in
+// bounded-parallel batches instead of one awaited write at a time.
+const CONTENT_STORE_CONCURRENCY = 10
 
 // Bounded retry for the rare case where two requests complete a partial upload at the same instant:
 // the loser of the in-memory pointer lock retries and hits deployEntity's idempotency fast path.
 const FINALIZE_POINTER_CONFLICT_RETRIES = 3
 const FINALIZE_POINTER_CONFLICT_DELAY_MS = 300
-
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms))
-}
 
 export function createPartialDeployments(
   components: Pick<
@@ -66,12 +63,24 @@ export function createPartialDeployments(
         // number === creation timestamp; the pending row was deleted inside the deploy transaction.
         return result
       }
-      const isPointerConflict = result.errors.some((e) => e.includes('currently being deployed'))
+      const isPointerConflict = result.errors.some((e) => e.includes(POINTERS_BEING_DEPLOYED_ERROR))
       if (isPointerConflict && attempt < FINALIZE_POINTER_CONFLICT_RETRIES) {
-        await delay(FINALIZE_POINTER_CONFLICT_DELAY_MS)
+        await sleep(FINALIZE_POINTER_CONFLICT_DELAY_MS)
         continue
       }
       throw new InvalidPartialDeploymentError(result.errors)
+    }
+  }
+
+  async function storeMissing(uploadedFiles: Map<string, Uint8Array>): Promise<void> {
+    const alreadyStored = await storage.existMultiple(Array.from(uploadedFiles.keys()))
+    const toStore = Array.from(uploadedFiles).filter(([hash]) => !alreadyStored.get(hash))
+    for (let i = 0; i < toStore.length; i += CONTENT_STORE_CONCURRENCY) {
+      await Promise.all(
+        toStore
+          .slice(i, i + CONTENT_STORE_CONCURRENCY)
+          .map(([hash, content]) => storage.storeStream(hash, bufferToStream(content)))
+      )
     }
   }
 
@@ -176,14 +185,31 @@ export function createPartialDeployments(
     }
 
     // Cumulative size budget. Mirrors calculateDeploymentSize (the finalize-time check): sum uploaded
-    // bytes for files in this batch and stored sizes for files staged earlier; not-yet-uploaded files
-    // contribute 0. Checked before storing this batch so an over-budget upload is never persisted.
+    // bytes for files in this batch and stored sizes for files staged earlier. Checked before storing
+    // this batch so an over-budget upload is never persisted.
     const contentHashes = Array.from(new Set((entity.content ?? []).map((c) => c.hash)))
     const storedInfo = await storage.fileInfoMultiple(contentHashes)
     let totalSize = 0
     for (const hash of contentHashes) {
       const uploaded = uploadedFiles.get(hash)
-      totalSize += uploaded ? uploaded.byteLength : storedInfo.get(hash)?.contentSize ?? 0
+      if (uploaded) {
+        totalSize += uploaded.byteLength
+        continue
+      }
+      const info = storedInfo.get(hash)
+      if (info === undefined) {
+        // Not uploaded in this batch and not yet stored — it will arrive in a later request.
+        continue
+      }
+      if (info.contentSize == null) {
+        // Stored, but its size can't be determined. The finalize-time size validation fetches the same
+        // contentSize and fails with "Couldn't fetch content file"; fail fast now (on the first request
+        // that references it) instead of after the whole scene has been uploaded.
+        throw new InvalidPartialDeploymentError([
+          `Couldn't determine the size of the already-stored content file: ${hash}`
+        ])
+      }
+      totalSize += info.contentSize
     }
     const maxSizePerPointer = validator.getMaxSizeInBytesPerPointer(EntityType.SCENE)
     if (totalSize / entity.pointers.length > maxSizePerPointer) {
@@ -203,10 +229,7 @@ export function createPartialDeployments(
     // short transaction serialized by an advisory lock. Done BEFORE storing the batch so the staged
     // content is protected from the garbage collector as soon as it lands.
     await database.transaction(async (tx) => {
-      await tx.queryWithValues(
-        SQL`SELECT pg_advisory_xact_lock(${PENDING_DEPLOYMENTS_ADVISORY_LOCK})`,
-        'pending_deployment_advisory_lock'
-      )
+      await pendingDeploymentsRepository.acquireStagingLock(tx)
       const replaced = await pendingDeploymentsRepository.deleteOverlappingPointers(tx, entity.pointers, entityId)
       if (replaced.length > 0) {
         metrics.increment('dcl_pending_deployments_replaced_total', {}, replaced.length)
@@ -224,15 +247,13 @@ export function createPartialDeployments(
       })
     }, 'tx_stage_pending_deployment')
 
-    // Store the batch's files (content-addressed, so concurrent identical writes are idempotent).
-    const toStore = await storage.existMultiple(Array.from(uploadedFiles.keys()))
-    for (const [hash, content] of uploadedFiles) {
-      if (!toStore.get(hash)) {
-        await storage.storeStream(hash, bufferToStream(content))
-      }
-    }
+    // Store the batch's files (content-addressed, so concurrent identical writes are idempotent), in
+    // bounded-parallel batches, skipping anything already stored.
+    await storeMissing(uploadedFiles)
 
-    // Completeness check. If everything referenced by the entity is now present, auto-finalize.
+    // Completeness must be a fresh read (not derived from storedInfo): a concurrent partial request for
+    // the same entity may have stored the remaining content while this one ran, and whichever request
+    // observes the full set is the one that finalizes.
     const present = await storage.existMultiple(contentHashes)
     const missing = contentHashes.filter((hash) => !present.get(hash))
     if (missing.length > 0) {

--- a/src/logic/partial-deployments/component.ts
+++ b/src/logic/partial-deployments/component.ts
@@ -75,11 +75,14 @@ export function createPartialDeployments(
     }
   }
 
-  async function storeMissing(
-    uploadedFiles: Map<string, Uint8Array>,
-    alreadyStored: (hash: string) => boolean
-  ): Promise<void> {
-    const toStore = Array.from(uploadedFiles).filter(([hash]) => !alreadyStored(hash))
+  async function storeUploaded(uploadedFiles: Map<string, Uint8Array>): Promise<void> {
+    // Store every file the client sent this batch, in bounded-parallel batches. We do NOT skip files a
+    // pre-request snapshot said were already stored: that snapshot is taken before the pending row (and
+    // its GC protection) is committed, so a file present then could be swept before we get here — and
+    // skipping it would discard bytes the client uploaded in this very batch. Storage is content-
+    // addressed so re-storing an already-present file is an idempotent no-op, and the client already
+    // omits files reported by /available-content, so this rarely re-sends present content anyway.
+    const toStore = Array.from(uploadedFiles)
     for (let i = 0; i < toStore.length; i += CONTENT_STORE_CONCURRENCY) {
       await Promise.all(
         toStore
@@ -250,8 +253,9 @@ export function createPartialDeployments(
     // and always BEFORE storing the batch's files: it is what protects the staged content from the
     // garbage collector, and re-asserting it per batch resurrects the row if a competing overlapping
     // upload replaced it between requests — otherwise this batch's files would be written with no GC
-    // protection for the remainder of the upload. Expired rows are purged in the same transaction so a
-    // resurrected row never carries a stale created_at.
+    // protection for the remainder of the upload. The upsert resets an expired row's created_at (see
+    // the repository), so a resurrected row never carries a stale TTL anchor; purging other entities'
+    // expired rows is the cleanup job's responsibility, not this per-request critical section's.
     await database.transaction(async (tx) => {
       await pendingDeploymentsRepository.acquireStagingLock(tx)
       const replaced = await pendingDeploymentsRepository.deleteOverlappingPointers(tx, entity.pointers, entityId)
@@ -277,11 +281,8 @@ export function createPartialDeployments(
       )
     }, 'tx_stage_pending_deployment')
 
-    // Store the batch's files (content-addressed, so concurrent identical writes are idempotent), in
-    // bounded-parallel batches. Presence is derived from the fileInfoMultiple lookup already performed
-    // for the size check — no extra storage round trip. The entity file (not part of contentHashes) is
-    // always (re)stored; it is small and this covers the first request.
-    await storeMissing(uploadedFiles, (hash) => hash !== entityId && storedInfo.get(hash) !== undefined)
+    // Store the batch's files (content-addressed, so concurrent identical writes are idempotent).
+    await storeUploaded(uploadedFiles)
 
     // Completeness must be a fresh read (not derived from storedInfo): a concurrent partial request for
     // the same entity may have stored the remaining content while this one ran, and whichever request

--- a/src/logic/partial-deployments/component.ts
+++ b/src/logic/partial-deployments/component.ts
@@ -1,4 +1,3 @@
-import { streamToBuffer } from '@dcl/catalyst-storage/dist/content-item'
 import { Authenticator } from '@dcl/crypto'
 import { Entity, EntityType, IPFSv2 } from '@dcl/schemas'
 import { sleep } from '@dcl/snapshots-fetcher/dist/utils'
@@ -14,6 +13,27 @@ import { IPartialDeployments, StageDeploymentInput, StageDeploymentResult } from
 // the loser of the in-memory pointer lock retries and hits deployEntity's idempotency fast path.
 const FINALIZE_POINTER_CONFLICT_RETRIES = 3
 const FINALIZE_POINTER_CONFLICT_DELAY_MS = 300
+
+// The entity file is the scene manifest (JSON): pointers, the content-hash list, and metadata — always
+// small, independent of how large the content is. On a resume request it is read back from storage and
+// is NOT covered by the multipart in-flight-bytes budget (the resume body is tiny), so cap it: without a
+// cap, many concurrent resumes could each buffer a large stored blob and exhaust memory.
+const MAX_ENTITY_FILE_SIZE_BYTES = 10 * 1024 * 1024 // 10 MB
+
+// Buffers a stream but aborts as soon as it exceeds maxBytes, so an oversized stored blob is never held
+// whole in memory (the storage size metadata can be unknown, so the cap must hold while reading).
+async function streamToBufferCapped(stream: AsyncIterable<Buffer>, maxBytes: number): Promise<Uint8Array> {
+  const chunks: Buffer[] = []
+  let total = 0
+  for await (const chunk of stream) {
+    total += chunk.byteLength
+    if (total > maxBytes) {
+      throw new InvalidPartialDeploymentError([`The stored entity file is too large (over ${maxBytes} bytes).`])
+    }
+    chunks.push(chunk)
+  }
+  return Buffer.concat(chunks)
+}
 
 export function createPartialDeployments(
   components: Pick<
@@ -49,7 +69,24 @@ export function createPartialDeployments(
   const requestTtlBackwards = env.getConfig<number>(EnvironmentConfig.REQUEST_TTL_BACKWARDS)
   const maxPendingPerDeployer = env.getConfig<number>(EnvironmentConfig.MAX_PENDING_DEPLOYMENTS_PER_DEPLOYER)
 
-  async function finalize(entityId: string, entityFile: Uint8Array, authChain: StageDeploymentInput['authChain']) {
+  async function finalize(
+    entityId: string,
+    entityFile: Uint8Array,
+    authChain: StageDeploymentInput['authChain'],
+    contentHashes: string[]
+  ): Promise<StageDeploymentResult> {
+    // Re-verify content presence immediately before deploying. The completeness check ran before this
+    // (slow) deploy pipeline, and a garbage-collection sweep whose snapshot predates the pending row
+    // could have reclaimed a reused, already-stored file in that window. Committing a scene that
+    // references deleted content would corrupt it, so if anything is missing now, report it as
+    // resumable (202 { missing }) — the client re-uploads that one file — rather than letting the deploy
+    // fail with a terminal "Couldn't fetch content file" 400 that aborts the whole upload.
+    const stillPresent = await storage.existMultiple(contentHashes)
+    const nowMissing = contentHashes.filter((hash) => !stillPresent.get(hash))
+    if (nowMissing.length > 0) {
+      return { kind: 'incomplete', missing: nowMissing }
+    }
+
     // The deploy pipeline re-reads content from storage (all of it is present now), so only the entity
     // file needs to be in the map. Passing a Map hits deployEntity's hashFiles fast path (no re-hash).
     const finalizeFiles = new Map<string, Uint8Array>([[entityId, entityFile]])
@@ -57,7 +94,7 @@ export function createPartialDeployments(
       const result = await deployer.deployEntity(finalizeFiles, entityId, { authChain }, DeploymentContext.LOCAL)
       if (!isInvalidDeployment(result)) {
         // number === creation timestamp; the pending row was deleted inside the deploy transaction.
-        return result
+        return { kind: 'deployed', creationTimestamp: result }
       }
       const isPointerConflict = result.kind === 'pointer-conflict'
       if (isPointerConflict && attempt < FINALIZE_POINTER_CONFLICT_RETRIES) {
@@ -122,7 +159,7 @@ export function createPartialDeployments(
           `The first partial request for an entity must include the entity file '${entityId}'.`
         ])
       }
-      entityFile = await streamToBuffer(await stored.asStream())
+      entityFile = await streamToBufferCapped(await stored.asStream(), MAX_ENTITY_FILE_SIZE_BYTES)
     }
 
     let entity: Entity
@@ -255,9 +292,20 @@ export function createPartialDeployments(
       // strictly-newer overlapping upload is already in flight, so a stale/older upload can't evict a
       // newer competitor's staged content (and two clients can't ping-pong evicting each other). A
       // resume (same entity id) is excluded from the overlap set and never conflicts with itself.
-      const overlapping = await pendingDeploymentsRepository.getOverlappingPointers(tx, entity.pointers, entityId)
+      const overlapping = await pendingDeploymentsRepository.getOverlappingPointers(
+        tx,
+        entity.pointers,
+        entityId,
+        pendingDeploymentTtlMs
+      )
+      // Newest-wins, matching the deployments `happenedBefore` ordering: greater entity timestamp, ties
+      // broken by the LEXICOGRAPHICALLY-greater LOWERCASED entity id. Lowercasing keeps this consistent
+      // with the deployments comparator (which compares LOWER(entity_id)); a raw comparison could order
+      // two uploads differently here than at finalize.
       const newer = overlapping.find(
-        (o) => o.entityTimestamp > entity.timestamp || (o.entityTimestamp === entity.timestamp && o.entityId > entityId)
+        (o) =>
+          o.entityTimestamp > entity.timestamp ||
+          (o.entityTimestamp === entity.timestamp && o.entityId.toLowerCase() > entityId.toLowerCase())
       )
       if (newer) {
         throw new InvalidPartialDeploymentError([
@@ -276,21 +324,26 @@ export function createPartialDeployments(
       }
 
       // Cap concurrent staged uploads per deployer so one account can't pin storage across many
-      // pointer-sets for the full TTL. Decided HERE — under the advisory lock (which serializes all
-      // staging) and AFTER the overlap-replace — on the NET row-count change: `others` excludes this
-      // entity id, so `others + 1` is the deployer's post-upsert total whether this is a fresh insert, a
-      // resume, or a newer scene that just replaced one of the deployer's own overlapping rows. That
-      // avoids both racing the cap and wrongly rejecting a resume/replacement that doesn't grow the count.
-      const others = await pendingDeploymentsRepository.countActiveByDeployer(
-        tx,
-        Authenticator.ownerAddress(authChain),
-        pendingDeploymentTtlMs,
-        entityId
-      )
-      if (others + 1 > maxPendingPerDeployer) {
-        throw new InvalidPartialDeploymentError([
-          `Too many partial uploads in progress for this account (max ${maxPendingPerDeployer}). Finalize or abandon an existing upload before starting another.`
-        ])
+      // pointer-sets for the full TTL. Enforced HERE — under the advisory lock (which serializes all
+      // staging) and AFTER the overlap-replace — but ONLY when this upsert would CREATE a row. A resume
+      // (the entity already has a live row) or a newer scene that just replaced one of the deployer's own
+      // overlapping rows does not grow the count, so it is exempt; otherwise lowering the cap below a
+      // deployer's current in-flight count would reject every resume batch and wedge those uploads until
+      // they expire, instead of only preventing new ones.
+      const existing = await pendingDeploymentsRepository.getByEntityId(tx, entityId)
+      const isResume = !!existing && Date.now() - existing.createdAt.getTime() <= pendingDeploymentTtlMs
+      if (!isResume) {
+        const others = await pendingDeploymentsRepository.countActiveByDeployer(
+          tx,
+          Authenticator.ownerAddress(authChain),
+          pendingDeploymentTtlMs,
+          entityId
+        )
+        if (others + 1 > maxPendingPerDeployer) {
+          throw new InvalidPartialDeploymentError([
+            `Too many partial uploads in progress for this account (max ${maxPendingPerDeployer}). Finalize or abandon an existing upload before starting another.`
+          ])
+        }
       }
       // The upsert resets an expired row's created_at itself (fresh TTL window), so no global expired
       // sweep is needed here — that is the cleanup job's duty, not this per-request critical section's.
@@ -320,31 +373,12 @@ export function createPartialDeployments(
       return { kind: 'incomplete', missing }
     }
 
-    // Claim the finalization lease so only ONE completing request runs the expensive deploy pipeline
-    // (validation + on-chain access + deploy). The client's parallel worker pool and retries mean
-    // several completing requests can arrive at once.
-    const gotLease = await pendingDeploymentsRepository.acquireFinalizationLease(database, entityId)
-    if (!gotLease) {
-      // Another request is finalizing (or already did). If the entity is live now, report the
-      // idempotent success; otherwise report not-yet-complete so the client backs off and retries —
-      // it converges once the winner finishes (or its lease goes stale and this request takes over).
-      const alreadyDeployed = await deploymentsRepository.getEntityById(database, entityId)
-      if (alreadyDeployed) {
-        return { kind: 'deployed', creationTimestamp: alreadyDeployed.localTimestamp }
-      }
-      return { kind: 'incomplete', missing: [] }
-    }
-
-    try {
-      const creationTimestamp = await finalize(entityId, entityFile, authChain)
-      return { kind: 'deployed', creationTimestamp }
-    } catch (error) {
-      // Finalize failed without deploying: release the lease so a later request can retry. A successful
-      // deploy deletes the pending row inside its transaction, so this only runs on failure. Terminal
-      // errors (validation) still propagate; the row then expires via the TTL.
-      await pendingDeploymentsRepository.releaseFinalizationLease(database, entityId).catch(() => undefined)
-      throw error
-    }
+    // Everything is present — run the full deploy pipeline in this request. Concurrent completing
+    // requests (the client's parallel worker pool, retries) may race here; the deployments unique
+    // entity-id constraint serializes them, and finalize's bounded pointer-conflict retry lets the
+    // loser fall through to deployEntity's idempotency fast path. The duplicated validation in that rare
+    // race is accepted — a lease to avoid it costs more in failure modes than the work it would save.
+    return await finalize(entityId, entityFile, authChain, contentHashes)
   }
 
   async function cleanupExpired(): Promise<number> {

--- a/src/logic/partial-deployments/errors.ts
+++ b/src/logic/partial-deployments/errors.ts
@@ -1,10 +1,13 @@
 /**
  * Thrown by the partial-deployments component when a staging request is invalid (bad hash, unsupported
- * entity type, over budget, failed validation, ...). The controller maps it to a 400 response carrying
- * the `errors` array, mirroring the shape of a failed full deployment.
+ * entity type, over budget, failed validation, ...). The controller maps it to a response carrying the
+ * `errors` array with `statusCode` (default 400, mirroring a failed full deployment).
+ *
+ * `statusCode` is 429 for transient conditions (rate limiting) so a client can tell a retryable
+ * rejection from a terminal validation error.
  */
 export class InvalidPartialDeploymentError extends Error {
-  constructor(public readonly errors: string[]) {
+  constructor(public readonly errors: string[], public readonly statusCode: 400 | 429 = 400) {
     super(errors.join(', '))
     this.name = 'InvalidPartialDeploymentError'
   }

--- a/src/logic/partial-deployments/errors.ts
+++ b/src/logic/partial-deployments/errors.ts
@@ -1,0 +1,11 @@
+/**
+ * Thrown by the partial-deployments component when a staging request is invalid (bad hash, unsupported
+ * entity type, over budget, failed validation, ...). The controller maps it to a 400 response carrying
+ * the `errors` array, mirroring the shape of a failed full deployment.
+ */
+export class InvalidPartialDeploymentError extends Error {
+  constructor(public readonly errors: string[]) {
+    super(errors.join(', '))
+    this.name = 'InvalidPartialDeploymentError'
+  }
+}

--- a/src/logic/partial-deployments/errors.ts
+++ b/src/logic/partial-deployments/errors.ts
@@ -7,7 +7,13 @@
  * rejection from a terminal validation error.
  */
 export class InvalidPartialDeploymentError extends Error {
-  constructor(public readonly errors: string[], public readonly statusCode: 400 | 429 = 400) {
+  constructor(
+    public readonly errors: string[],
+    public readonly statusCode: 400 | 429 = 400,
+    // For a 429, the window (seconds) after which the client should retry — surfaced as a Retry-After
+    // header so the client can wait the rate-limit window out instead of exhausting its resume budget.
+    public readonly retryAfterSeconds?: number
+  ) {
     super(errors.join(', '))
     this.name = 'InvalidPartialDeploymentError'
   }

--- a/src/logic/partial-deployments/index.ts
+++ b/src/logic/partial-deployments/index.ts
@@ -1,0 +1,3 @@
+export { createPartialDeployments } from './component'
+export { InvalidPartialDeploymentError } from './errors'
+export type { IPartialDeployments, StageDeploymentInput, StageDeploymentResult } from './types'

--- a/src/logic/partial-deployments/types.ts
+++ b/src/logic/partial-deployments/types.ts
@@ -1,0 +1,27 @@
+import { AuthChain } from '@dcl/crypto'
+
+export type StageDeploymentInput = {
+  entityId: string
+  authChain: AuthChain
+  /** Uploaded files keyed by their multipart field name (the content hash, or the entity id). */
+  files: Map<string, Uint8Array>
+}
+
+export type StageDeploymentResult =
+  | { kind: 'deployed'; creationTimestamp: number }
+  | { kind: 'incomplete'; missing: string[] }
+
+export interface IPartialDeployments {
+  /**
+   * Stage one request's worth of a partial (multi-request) scene deployment. Authenticates and
+   * validates everything that doesn't require the full content set, stores the uploaded files, and
+   * records/refreshes the pending deployment. When the request completes the content set, it runs the
+   * full validation + deploy pipeline and returns `{ kind: 'deployed' }`; otherwise it returns
+   * `{ kind: 'incomplete' }` with the hashes still missing.
+   *
+   * Throws {@link InvalidPartialDeploymentError} for client errors (mapped to HTTP 400).
+   */
+  stageDeployment(input: StageDeploymentInput): Promise<StageDeploymentResult>
+  /** Deletes pending deployments older than PENDING_DEPLOYMENT_TTL. Returns the number removed. */
+  cleanupExpired(): Promise<number>
+}

--- a/src/logic/store-content.ts
+++ b/src/logic/store-content.ts
@@ -1,0 +1,24 @@
+import { IContentStorageComponent } from '@dcl/catalyst-storage'
+import { bufferToStream } from '@dcl/catalyst-storage/dist/content-item'
+
+// How many content files to write to storage at once. They are independent content-addressed objects,
+// so storing them in bounded-parallel batches (rather than one awaited PUT at a time) speeds up
+// multi-file deploys without an unbounded fan-out.
+export const CONTENT_STORE_CONCURRENCY = 10
+
+/**
+ * Writes `entries` (hash → bytes) to storage in bounded-parallel batches. Shared by the vanilla deploy
+ * path and the partial-upload staging path so the batched-store logic and its concurrency live in one
+ * place.
+ */
+export async function storeStreamsInBatches(
+  storage: Pick<IContentStorageComponent, 'storeStream'>,
+  entries: Array<[string, Uint8Array]>,
+  concurrency: number = CONTENT_STORE_CONCURRENCY
+): Promise<void> {
+  for (let i = 0; i < entries.length; i += concurrency) {
+    await Promise.all(
+      entries.slice(i, i + concurrency).map(([hash, content]) => storage.storeStream(hash, bufferToStream(content)))
+    )
+  }
+}

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -72,6 +72,22 @@ export const metricsDeclaration = validateMetricsDeclaration({
     type: 'gauge',
     labelNames: ['entity_type']
   },
+  dcl_partial_deployments_staging_total: {
+    help: 'Partial (multi-request) deployment staging requests through HTTP',
+    type: 'counter',
+    // kind=(accepted|finalized|already_deployed|validation_error|error)
+    labelNames: ['kind']
+  },
+  dcl_pending_deployments_replaced_total: {
+    help: 'Pending deployments removed because a newer partial deployment overlapped their pointers',
+    type: 'counter',
+    labelNames: []
+  },
+  dcl_pending_deployments_expired_total: {
+    help: 'Pending deployments removed by the expiry cleanup job',
+    type: 'counter',
+    labelNames: []
+  },
   dcl_ignored_sync_deployments: {
     help: 'Entities ignored during the synchronization and bootstrapping',
     type: 'counter',

--- a/src/migrations/scripts/1783372800000_create-pending-deployments.ts
+++ b/src/migrations/scripts/1783372800000_create-pending-deployments.ts
@@ -32,6 +32,12 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
     name: 'pending_deployments_created_at_idx',
     ifNotExists: true
   })
+  // Backs the per-deployer concurrent-pending cap check, whose predicate is
+  // `LOWER(deployer_address) = $ AND created_at > $` — a functional index so the cap query doesn't
+  // scan all pending rows.
+  pgm.sql(
+    'CREATE INDEX pending_deployments_deployer_created_at_idx ON pending_deployments (LOWER(deployer_address), created_at)'
+  )
 }
 
 export async function down(pgm: MigrationBuilder): Promise<void> {

--- a/src/migrations/scripts/1783372800000_create-pending-deployments.ts
+++ b/src/migrations/scripts/1783372800000_create-pending-deployments.ts
@@ -1,0 +1,36 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate'
+
+export const shorthands: ColumnDefinitions | undefined = undefined
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  // Staging area for partial (multi-request) deployments: an entity's content is uploaded across
+  // several POST /entities requests and lives here until every referenced file is present, at which
+  // point the row is deleted and the entity is deployed for real into `deployments`/`active_pointers`.
+  // This table is intentionally invisible to every sync/replication read path (snapshots,
+  // /pointer-changes, batchDeployer) — those only read `deployments`.
+  pgm.createTable('pending_deployments', {
+    entity_id: { type: 'text', primaryKey: true },
+    entity_type: { type: 'text', notNull: true },
+    pointers: { type: 'text[]', notNull: true },
+    content_hashes: { type: 'text[]', notNull: true },
+    deployer_address: { type: 'text', notNull: true },
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') }
+  })
+
+  // GIN on pointers backs the `pointers && $1` overlap query used to enforce "at most one pending
+  // deployment per parcel set" (a new partial deploy replaces overlapping ones).
+  pgm.sql('CREATE INDEX pending_deployments_pointers_gin_idx ON pending_deployments USING GIN (pointers)')
+  // GIN on content_hashes backs the garbage-collection referenced-hash check (`content_hashes && $1`).
+  pgm.sql('CREATE INDEX pending_deployments_content_hashes_gin_idx ON pending_deployments USING GIN (content_hashes)')
+  // B-tree on created_at backs expiry filters/deletes.
+  pgm.createIndex('pending_deployments', 'created_at', {
+    name: 'pending_deployments_created_at_idx',
+    ifNotExists: true
+  })
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropTable('pending_deployments')
+}

--- a/src/migrations/scripts/1783372800000_create-pending-deployments.ts
+++ b/src/migrations/scripts/1783372800000_create-pending-deployments.ts
@@ -18,6 +18,11 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
     // The entity's own timestamp (deployment ordering). Overlapping pending uploads resolve by this so
     // the single per-parcel-set slot goes to the newest scene, not merely the last writer.
     entity_timestamp: { type: 'bigint', notNull: true },
+    // Finalization lease: 'UPLOADING' while content is staged; a completing request flips it to
+    // 'FINALIZING' (recording finalizing_at) so only one request runs the expensive validation + deploy.
+    // A stale lease (finalizing_at older than the lease TTL) can be taken over after a crash.
+    status: { type: 'text', notNull: true, default: 'UPLOADING' },
+    finalizing_at: { type: 'timestamptz', notNull: false },
     created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
     updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') }
   })

--- a/src/migrations/scripts/1783372800000_create-pending-deployments.ts
+++ b/src/migrations/scripts/1783372800000_create-pending-deployments.ts
@@ -18,11 +18,6 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
     // The entity's own timestamp (deployment ordering). Overlapping pending uploads resolve by this so
     // the single per-parcel-set slot goes to the newest scene, not merely the last writer.
     entity_timestamp: { type: 'bigint', notNull: true },
-    // Finalization lease: 'UPLOADING' while content is staged; a completing request flips it to
-    // 'FINALIZING' (recording finalizing_at) so only one request runs the expensive validation + deploy.
-    // A stale lease (finalizing_at older than the lease TTL) can be taken over after a crash.
-    status: { type: 'text', notNull: true, default: 'UPLOADING' },
-    finalizing_at: { type: 'timestamptz', notNull: false },
     created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
     updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') }
   })

--- a/src/migrations/scripts/1783372800000_create-pending-deployments.ts
+++ b/src/migrations/scripts/1783372800000_create-pending-deployments.ts
@@ -15,6 +15,9 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
     pointers: { type: 'text[]', notNull: true },
     content_hashes: { type: 'text[]', notNull: true },
     deployer_address: { type: 'text', notNull: true },
+    // The entity's own timestamp (deployment ordering). Overlapping pending uploads resolve by this so
+    // the single per-parcel-set slot goes to the newest scene, not merely the last writer.
+    entity_timestamp: { type: 'bigint', notNull: true },
     created_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
     updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') }
   })

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,7 @@ import { ActiveEntities } from './logic/active-entities'
 import { IContentFilesRepository } from './adapters/content-files-repository'
 import { Denylist } from './adapters/denylist'
 import { IDeploymentsRepository } from './adapters/deployments-repository'
+import { IPendingDeploymentsRepository } from './adapters/pending-deployments-repository'
 import { IPointersRepository } from './adapters/pointers-repository'
 import { ISnapshotsRepository } from './adapters/snapshots-repository'
 import { DeployedEntitiesBloomFilter } from './adapters/deployed-entities-bloom-filter'
@@ -37,6 +38,7 @@ import { IGarbageCollectionComponent } from './logic/garbage-collection'
 import { IContentClusterComponent } from './logic/peer-cluster'
 import { SnapshotStorage } from './adapters/snapshot-storage'
 import { IDeploymentsComponent } from './logic/deployments'
+import { IPartialDeployments } from './logic/partial-deployments'
 import { IQueryParams } from './logic/query-params'
 import { IEntities } from './logic/entities'
 import { ISnapshots } from './logic/snapshots'
@@ -87,10 +89,13 @@ export type AppComponents = {
   activeEntitiesRepository: IActiveEntitiesRepository
   contentFilesRepository: IContentFilesRepository
   deploymentsRepository: IDeploymentsRepository
+  pendingDeploymentsRepository: IPendingDeploymentsRepository
   pointersRepository: IPointersRepository
   snapshotsRepository: ISnapshotsRepository
   config: IConfigComponent
   deployer: Deployer
+  partialDeployments: IPartialDeployments
+  pendingDeploymentsCleanupJob: IJobComponent
   staticConfigs: {
     contentStorageFolder: string
     tmpDownloadFolder: string
@@ -139,6 +144,7 @@ export type MaintenanceComponents = {
   migrationManager: MigrationExecutor
   contentFilesRepository: IContentFilesRepository
   deploymentsRepository: IDeploymentsRepository
+  pendingDeploymentsRepository: IPendingDeploymentsRepository
   snapshotsRepository: ISnapshotsRepository
   garbageCollectionManager: IGarbageCollectionComponent
 }

--- a/test/helpers/logic/server-validator/NoOpValidator.ts
+++ b/test/helpers/logic/server-validator/NoOpValidator.ts
@@ -11,6 +11,9 @@ export class NoOpValidator {
   async validateStagingScene(_d: DeploymentToValidate): Promise<ValidationResponse> {
     return { ok: true }
   }
+  async validateCurrentAccess(_d: DeploymentToValidate): Promise<ValidationResponse> {
+    return { ok: true }
+  }
   getMaxSizeInBytesPerPointer(_type: EntityType): number {
     return 15 * 1024 * 1024
   }
@@ -19,6 +22,7 @@ export class NoOpValidator {
 export function makeNoopValidator(components: Pick<AppComponents, 'validator'>) {
   jest.spyOn(components.validator, 'validate').mockResolvedValue({ ok: true })
   jest.spyOn(components.validator, 'validateStagingScene').mockResolvedValue({ ok: true })
+  jest.spyOn(components.validator, 'validateCurrentAccess').mockResolvedValue({ ok: true })
 }
 
 export function makeNoopDeploymentValidator(components: Pick<AppComponents, 'syncOrchestrator'>) {

--- a/test/helpers/logic/server-validator/NoOpValidator.ts
+++ b/test/helpers/logic/server-validator/NoOpValidator.ts
@@ -1,4 +1,5 @@
 import { DeploymentToValidate, ValidationResponse } from '@dcl/content-validator'
+import { EntityType } from '@dcl/schemas'
 import * as deploymentServiceServerValidator from '../../../../src/logic/deployment-service/server-validator'
 import { State } from '../../../../src/logic/sync-orchestrator'
 import { AppComponents } from '../../../../src/types'
@@ -7,10 +8,17 @@ export class NoOpValidator {
   async validate(_d: DeploymentToValidate): Promise<ValidationResponse> {
     return { ok: true }
   }
+  async validateStagingScene(_d: DeploymentToValidate): Promise<ValidationResponse> {
+    return { ok: true }
+  }
+  getMaxSizeInBytesPerPointer(_type: EntityType): number {
+    return 15 * 1024 * 1024
+  }
 }
 
 export function makeNoopValidator(components: Pick<AppComponents, 'validator'>) {
   jest.spyOn(components.validator, 'validate').mockResolvedValue({ ok: true })
+  jest.spyOn(components.validator, 'validateStagingScene').mockResolvedValue({ ok: true })
 }
 
 export function makeNoopDeploymentValidator(components: Pick<AppComponents, 'syncOrchestrator'>) {

--- a/test/integration/controller/partial-deployments.spec.ts
+++ b/test/integration/controller/partial-deployments.spec.ts
@@ -63,6 +63,11 @@ async function countPendingDeployments(server: TestProgram): Promise<number> {
   return parseInt(result.rows[0].count)
 }
 
+async function countDeployments(server: TestProgram, entityId: string): Promise<number> {
+  const result = await server.components.deploymentsRepository.getEntityById(server.components.database, entityId)
+  return result ? 1 : 0
+}
+
 describe('Integration - Partial deployments', () => {
   let server: TestProgram
   let identity: IdentityType
@@ -222,6 +227,56 @@ describe('Integration - Partial deployments', () => {
         buildPartialForm(deployment, [deployment.entityId, ...deployment.contentHashes], false)
       )
       expect(res.status).toBe(200)
+      expect(await countPendingDeployments(server)).toBe(0)
+    })
+  })
+
+  describe('when staging requests for the same entity run in parallel', () => {
+    it('should accept two distinct content batches uploaded concurrently and deploy the entity once', async () => {
+      const deployment = await prepareSceneDeployment(
+        ['7,7'],
+        { 'a.txt': Buffer.from('parallel a'.repeat(50)), 'b.txt': Buffer.from('parallel b'.repeat(60)) },
+        identity
+      )
+      const [hashA, hashB] = deployment.contentHashes
+
+      expect((await postForm(server, buildPartialForm(deployment, [deployment.entityId]))).status).toBe(202)
+
+      // Fire the two remaining content batches concurrently.
+      const [resA, resB] = await Promise.all([
+        postForm(server, buildPartialForm(deployment, [hashA])),
+        postForm(server, buildPartialForm(deployment, [hashB]))
+      ])
+
+      // No 500s: each request either finalizes (200) or reports remaining content (202), and exactly
+      // one completes the set. The entity is deployed exactly once, with no leftover pending row.
+      const statuses = [resA.status, resB.status].sort()
+      expect(statuses.every((status) => status === 200 || status === 202)).toBe(true)
+      expect(statuses).toContain(200)
+      expect(await countDeployments(server, deployment.entityId)).toBe(1)
+      expect(await countPendingDeployments(server)).toBe(0)
+    })
+
+    it('should deploy once when two requests complete the content set at the same time', async () => {
+      const deployment = await prepareSceneDeployment(
+        ['8,8'],
+        { 'a.txt': Buffer.from('finalize a'.repeat(50)), 'b.txt': Buffer.from('finalize b'.repeat(60)) },
+        identity
+      )
+      const [hashA, hashB] = deployment.contentHashes
+
+      // Stage entity + A, leaving only B missing.
+      expect((await postForm(server, buildPartialForm(deployment, [deployment.entityId, hashA]))).status).toBe(202)
+
+      // Two identical completing requests (both upload B) race to finalize.
+      const [res1, res2] = await Promise.all([
+        postForm(server, buildPartialForm(deployment, [hashB])),
+        postForm(server, buildPartialForm(deployment, [hashB]))
+      ])
+
+      expect(res1.status).toBe(200)
+      expect(res2.status).toBe(200)
+      expect(await countDeployments(server, deployment.entityId)).toBe(1)
       expect(await countPendingDeployments(server)).toBe(0)
     })
   })

--- a/test/integration/controller/partial-deployments.spec.ts
+++ b/test/integration/controller/partial-deployments.spec.ts
@@ -280,4 +280,20 @@ describe('Integration - Partial deployments', () => {
       expect(await countPendingDeployments(server)).toBe(0)
     })
   })
+
+  describe('when a staging request is rate limited', () => {
+    it('should respond 429 (a transient, resumable status) rather than 400', async () => {
+      jest.spyOn(server.components.deployer, 'isRateLimited').mockReturnValue(true)
+
+      const deployment = await prepareSceneDeployment(
+        ['9,9'],
+        { 'a.txt': Buffer.from('rate limited content') },
+        identity
+      )
+      const res = await postForm(server, buildPartialForm(deployment, [deployment.entityId]))
+
+      expect(res.status).toBe(429)
+      expect(await countPendingDeployments(server)).toBe(0)
+    })
+  })
 })

--- a/test/integration/controller/partial-deployments.spec.ts
+++ b/test/integration/controller/partial-deployments.spec.ts
@@ -397,9 +397,13 @@ describe('Integration - Partial deployments', () => {
           ])
         })
 
-        it('should return 200 to both requests', () => {
-          expect(firstResponse.status).toBe(200)
-          expect(secondResponse.status).toBe(200)
+        it('should finalize exactly one and respond 200 or 202 to each (lease-gated)', () => {
+          // The finalization lease lets only one request run the deploy pipeline: the winner returns 200;
+          // the other returns 200 (idempotent, if the winner already committed) or 202 (in progress).
+          expect([firstResponse.status, secondResponse.status].every((status) => status === 200 || status === 202)).toBe(
+            true
+          )
+          expect([firstResponse.status, secondResponse.status]).toContain(200)
         })
 
         it('should deploy the entity exactly once with no leftover pending row', async () => {
@@ -594,6 +598,64 @@ describe('Integration - Partial deployments', () => {
         expect(response.status).toBe(400)
         expect(await pendingEntityIds(server)).toEqual([newer.entityId])
       })
+    })
+  })
+
+  describe('when a completing request arrives while finalization is already in progress', () => {
+    let deployment: PreparedDeployment
+    let hashA: string
+    let hashB: string
+    let completingResponse: Response
+
+    beforeEach(async () => {
+      const nonce = `${Date.now()}-${Math.random()}`
+      deployment = await prepareSceneDeployment(
+        ['12,12'],
+        { 'a.txt': Buffer.from(`lease a ${nonce}`), 'b.txt': Buffer.from(`lease b ${nonce}`) },
+        identity
+      )
+      ;[hashA, hashB] = deployment.contentHashes
+      // Stage entity + first file (incomplete → pending row, status UPLOADING).
+      await postForm(server, buildPartialForm(deployment, [deployment.entityId, hashA]))
+      // Simulate another request holding a FRESH finalization lease on this upload.
+      await server.components.database.query(
+        `UPDATE pending_deployments SET status = 'FINALIZING', finalizing_at = now() WHERE entity_id = '${deployment.entityId}'`
+      )
+      // The completing request uploads the last file but can't claim the lease.
+      completingResponse = await postForm(server, buildPartialForm(deployment, [hashB]))
+    })
+
+    it('should respond 202 (finalization in progress) without deploying the entity', async () => {
+      expect(completingResponse.status).toBe(202)
+      expect(await countDeployments(server, deployment.entityId)).toBe(0)
+    })
+  })
+
+  describe('when a completing request finds a stale (crashed) finalization lease', () => {
+    let deployment: PreparedDeployment
+    let hashA: string
+    let hashB: string
+    let completingResponse: Response
+
+    beforeEach(async () => {
+      const nonce = `${Date.now()}-${Math.random()}`
+      deployment = await prepareSceneDeployment(
+        ['13,13'],
+        { 'a.txt': Buffer.from(`stale a ${nonce}`), 'b.txt': Buffer.from(`stale b ${nonce}`) },
+        identity
+      )
+      ;[hashA, hashB] = deployment.contentHashes
+      await postForm(server, buildPartialForm(deployment, [deployment.entityId, hashA]))
+      // A crashed finalizer left a lease older than the 2-minute TTL.
+      await server.components.database.query(
+        `UPDATE pending_deployments SET status = 'FINALIZING', finalizing_at = now() - interval '10 minutes' WHERE entity_id = '${deployment.entityId}'`
+      )
+      completingResponse = await postForm(server, buildPartialForm(deployment, [hashB]))
+    })
+
+    it('should take over the stale lease and finalize with 200', async () => {
+      expect(completingResponse.status).toBe(200)
+      expect(await countDeployments(server, deployment.entityId)).toBe(1)
     })
   })
 })

--- a/test/integration/controller/partial-deployments.spec.ts
+++ b/test/integration/controller/partial-deployments.spec.ts
@@ -1,0 +1,228 @@
+import { Authenticator, IdentityType } from '@dcl/crypto'
+import { EntityType } from '@dcl/schemas'
+import { buildEntity } from 'dcl-catalyst-client/dist/client/utils/DeploymentBuilder'
+import FormData = require('form-data')
+import { makeNoopValidator } from '../../helpers/logic/server-validator/NoOpValidator'
+import { createDefaultServer, resetServer } from '../simpleTestEnvironment'
+import { TestProgram } from '../TestProgram'
+import { createIdentity } from '../E2ETestUtils'
+
+type PreparedDeployment = {
+  entityId: string
+  authChain: ReturnType<typeof Authenticator.createSimpleAuthChain>
+  files: Map<string, Uint8Array>
+  contentHashes: string[]
+}
+
+async function prepareSceneDeployment(
+  pointers: string[],
+  contents: Record<string, Buffer>,
+  identity: IdentityType
+): Promise<PreparedDeployment> {
+  const files = new Map<string, Uint8Array>(Object.entries(contents))
+  const prepared = await buildEntity({
+    type: EntityType.SCENE,
+    pointers,
+    files,
+    metadata: { main: 'bin/main.js', scene: { base: pointers[0], parcels: pointers } },
+    timestamp: Date.now()
+  })
+  const signature = Authenticator.createSignature(identity, prepared.entityId)
+  const authChain = Authenticator.createSimpleAuthChain(prepared.entityId, identity.address, signature)
+  const contentHashes = Array.from(prepared.files.keys()).filter((k) => k !== prepared.entityId)
+  return { entityId: prepared.entityId, authChain, files: prepared.files, contentHashes }
+}
+
+function buildPartialForm(deployment: PreparedDeployment, keysToInclude: string[], partial = true): FormData {
+  const form = new FormData()
+  form.append('entityId', deployment.entityId)
+  if (partial) {
+    form.append('partial', 'true')
+  }
+  form.append('authChain', JSON.stringify(deployment.authChain))
+  for (const key of keysToInclude) {
+    const content = deployment.files.get(key)
+    if (!content) {
+      throw new Error(`Test setup error: no file for key ${key}`)
+    }
+    form.append(key, Buffer.from(content), { filename: key })
+  }
+  return form
+}
+
+async function postForm(server: TestProgram, form: FormData): Promise<Response> {
+  return fetch(server.getUrl() + '/entities', {
+    method: 'POST',
+    body: form.getBuffer(),
+    headers: form.getHeaders()
+  })
+}
+
+async function countPendingDeployments(server: TestProgram): Promise<number> {
+  const result = await server.components.database.query<{ count: string }>('SELECT COUNT(*) as count FROM pending_deployments')
+  return parseInt(result.rows[0].count)
+}
+
+describe('Integration - Partial deployments', () => {
+  let server: TestProgram
+  let identity: IdentityType
+
+  beforeAll(async () => {
+    server = await createDefaultServer()
+  })
+
+  afterAll(async () => {
+    jest.restoreAllMocks()
+    await server.stopProgram()
+    server = null as any
+  })
+
+  beforeEach(async () => {
+    await resetServer(server)
+    // The staging + finalize validation subsets are exercised in unit tests; here we bypass them to
+    // focus on the multi-request staging protocol, storage, pending-row lifecycle, and auto-finalize.
+    makeNoopValidator(server.components)
+    identity = createIdentity()
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe('when uploading a scene across multiple partial requests', () => {
+    it('should return 202 with the missing hashes until the last request, which returns 200 and makes the entity live', async () => {
+      const deployment = await prepareSceneDeployment(
+        ['0,0'],
+        { 'a.txt': Buffer.from('content of file a'), 'b.txt': Buffer.from('content of file b') },
+        identity
+      )
+      const [hashA, hashB] = deployment.contentHashes
+
+      // Request 1: entity file only.
+      const res1 = await postForm(server, buildPartialForm(deployment, [deployment.entityId]))
+      expect(res1.status).toBe(202)
+      const body1 = await res1.json()
+      expect(new Set(body1.missing)).toEqual(new Set([hashA, hashB]))
+      expect(await countPendingDeployments(server)).toBe(1)
+
+      // Request 2: first content file.
+      const res2 = await postForm(server, buildPartialForm(deployment, [hashA]))
+      expect(res2.status).toBe(202)
+      expect(await res2.json()).toEqual({ missing: [hashB] })
+
+      // Request 3: last content file → auto-finalize.
+      const res3 = await postForm(server, buildPartialForm(deployment, [hashB]))
+      expect(res3.status).toBe(200)
+      expect(typeof (await res3.json()).creationTimestamp).toBe('number')
+
+      // The pending row is gone and the entity is deployed.
+      expect(await countPendingDeployments(server)).toBe(0)
+      const deployed = await server.components.deploymentsRepository.getEntityById(
+        server.components.database,
+        deployment.entityId
+      )
+      expect(deployed?.entityId).toBe(deployment.entityId)
+    })
+
+    it('should not require the entity file on requests after the first', async () => {
+      const deployment = await prepareSceneDeployment(
+        ['1,1'],
+        { 'a.txt': Buffer.from('another file a') },
+        identity
+      )
+      const [hashA] = deployment.contentHashes
+
+      const res1 = await postForm(server, buildPartialForm(deployment, [deployment.entityId]))
+      expect(res1.status).toBe(202)
+
+      // Second request omits the entity file entirely; the server reads it back from storage.
+      const res2 = await postForm(server, buildPartialForm(deployment, [hashA]))
+      expect(res2.status).toBe(200)
+      expect(await countPendingDeployments(server)).toBe(0)
+    })
+  })
+
+  describe('when a single partial request already contains all the content', () => {
+    it('should finalize immediately and return 200', async () => {
+      const deployment = await prepareSceneDeployment(
+        ['2,2'],
+        { 'a.txt': Buffer.from('single batch file') },
+        identity
+      )
+      const res = await postForm(
+        server,
+        buildPartialForm(deployment, [deployment.entityId, ...deployment.contentHashes])
+      )
+      expect(res.status).toBe(200)
+      expect(await countPendingDeployments(server)).toBe(0)
+    })
+  })
+
+  describe('when the same partial request is replayed', () => {
+    it('should respond idempotently with the same missing hashes and keep a single pending row', async () => {
+      const deployment = await prepareSceneDeployment(
+        ['3,3'],
+        { 'a.txt': Buffer.from('replay file a'), 'b.txt': Buffer.from('replay file b') },
+        identity
+      )
+
+      const first = await postForm(server, buildPartialForm(deployment, [deployment.entityId]))
+      const second = await postForm(server, buildPartialForm(deployment, [deployment.entityId]))
+
+      expect(first.status).toBe(202)
+      expect(second.status).toBe(202)
+      expect(new Set((await second.json()).missing)).toEqual(new Set(deployment.contentHashes))
+      expect(await countPendingDeployments(server)).toBe(1)
+    })
+  })
+
+  describe('when the first partial request omits the entity file', () => {
+    it('should return 400', async () => {
+      const deployment = await prepareSceneDeployment(
+        ['4,4'],
+        { 'a.txt': Buffer.from('orphan content') },
+        identity
+      )
+      const [hashA] = deployment.contentHashes
+      const res = await postForm(server, buildPartialForm(deployment, [hashA]))
+      expect(res.status).toBe(400)
+    })
+  })
+
+  describe('when an uploaded file does not match its declared hash key', () => {
+    it('should return 400', async () => {
+      const deployment = await prepareSceneDeployment(
+        ['5,5'],
+        { 'a.txt': Buffer.from('mismatch content') },
+        identity
+      )
+      const form = new FormData()
+      form.append('entityId', deployment.entityId)
+      form.append('partial', 'true')
+      form.append('authChain', JSON.stringify(deployment.authChain))
+      // Entity file uploaded under a wrong key: its computed hash won't equal the key.
+      form.append('bafyWrongKey0000000000000000000000000000000000000000000000', Buffer.from(deployment.files.get(deployment.entityId)!), {
+        filename: 'wrong'
+      })
+      const res = await postForm(server, form)
+      expect(res.status).toBe(400)
+    })
+  })
+
+  describe('when a non-partial request is missing content (legacy behavior)', () => {
+    it('should still reach the deployer and not create a pending row', async () => {
+      const deployment = await prepareSceneDeployment(
+        ['6,6'],
+        { 'a.txt': Buffer.from('legacy file a') },
+        identity
+      )
+      // Full (non-partial) deploy with all content present → succeeds, no pending row involved.
+      const res = await postForm(
+        server,
+        buildPartialForm(deployment, [deployment.entityId, ...deployment.contentHashes], false)
+      )
+      expect(res.status).toBe(200)
+      expect(await countPendingDeployments(server)).toBe(0)
+    })
+  })
+})

--- a/test/integration/controller/partial-deployments.spec.ts
+++ b/test/integration/controller/partial-deployments.spec.ts
@@ -397,9 +397,10 @@ describe('Integration - Partial deployments', () => {
           ])
         })
 
-        it('should finalize exactly one and respond 200 or 202 to each (lease-gated)', () => {
-          // The finalization lease lets only one request run the deploy pipeline: the winner returns 200;
-          // the other returns 200 (idempotent, if the winner already committed) or 202 (in progress).
+        it('should finalize exactly one and respond 200 or 202 to each', () => {
+          // Concurrent completing requests race into the deploy pipeline; the deployments unique entity-id
+          // constraint plus finalize's pointer-conflict retry mean the winner returns 200 and the other
+          // returns 200 (idempotent, if the winner already committed) or 202 (its retries exhausted).
           expect([firstResponse.status, secondResponse.status].every((status) => status === 200 || status === 202)).toBe(
             true
           )
@@ -601,61 +602,4 @@ describe('Integration - Partial deployments', () => {
     })
   })
 
-  describe('when a completing request arrives while finalization is already in progress', () => {
-    let deployment: PreparedDeployment
-    let hashA: string
-    let hashB: string
-    let completingResponse: Response
-
-    beforeEach(async () => {
-      const nonce = `${Date.now()}-${Math.random()}`
-      deployment = await prepareSceneDeployment(
-        ['12,12'],
-        { 'a.txt': Buffer.from(`lease a ${nonce}`), 'b.txt': Buffer.from(`lease b ${nonce}`) },
-        identity
-      )
-      ;[hashA, hashB] = deployment.contentHashes
-      // Stage entity + first file (incomplete → pending row, status UPLOADING).
-      await postForm(server, buildPartialForm(deployment, [deployment.entityId, hashA]))
-      // Simulate another request holding a FRESH finalization lease on this upload.
-      await server.components.database.query(
-        `UPDATE pending_deployments SET status = 'FINALIZING', finalizing_at = now() WHERE entity_id = '${deployment.entityId}'`
-      )
-      // The completing request uploads the last file but can't claim the lease.
-      completingResponse = await postForm(server, buildPartialForm(deployment, [hashB]))
-    })
-
-    it('should respond 202 (finalization in progress) without deploying the entity', async () => {
-      expect(completingResponse.status).toBe(202)
-      expect(await countDeployments(server, deployment.entityId)).toBe(0)
-    })
-  })
-
-  describe('when a completing request finds a stale (crashed) finalization lease', () => {
-    let deployment: PreparedDeployment
-    let hashA: string
-    let hashB: string
-    let completingResponse: Response
-
-    beforeEach(async () => {
-      const nonce = `${Date.now()}-${Math.random()}`
-      deployment = await prepareSceneDeployment(
-        ['13,13'],
-        { 'a.txt': Buffer.from(`stale a ${nonce}`), 'b.txt': Buffer.from(`stale b ${nonce}`) },
-        identity
-      )
-      ;[hashA, hashB] = deployment.contentHashes
-      await postForm(server, buildPartialForm(deployment, [deployment.entityId, hashA]))
-      // A crashed finalizer left a lease older than the 2-minute TTL.
-      await server.components.database.query(
-        `UPDATE pending_deployments SET status = 'FINALIZING', finalizing_at = now() - interval '10 minutes' WHERE entity_id = '${deployment.entityId}'`
-      )
-      completingResponse = await postForm(server, buildPartialForm(deployment, [hashB]))
-    })
-
-    it('should take over the stale lease and finalize with 200', async () => {
-      expect(completingResponse.status).toBe(200)
-      expect(await countDeployments(server, deployment.entityId)).toBe(1)
-    })
-  })
 })

--- a/test/integration/controller/partial-deployments.spec.ts
+++ b/test/integration/controller/partial-deployments.spec.ts
@@ -281,6 +281,27 @@ describe('Integration - Partial deployments', () => {
     })
   })
 
+  describe('when uploading across multiple requests (resume fast-path)', () => {
+    it('should run the access check only on the request that creates the pending record', async () => {
+      const deployment = await prepareSceneDeployment(
+        ['10,10'],
+        { 'a.txt': Buffer.from('fast path a'), 'b.txt': Buffer.from('fast path b') },
+        identity
+      )
+      const [hashA, hashB] = deployment.contentHashes
+      const stagingSpy = server.components.validator.validateStagingScene as jest.Mock
+
+      expect((await postForm(server, buildPartialForm(deployment, [deployment.entityId]))).status).toBe(202)
+      expect((await postForm(server, buildPartialForm(deployment, [hashA]))).status).toBe(202)
+      expect((await postForm(server, buildPartialForm(deployment, [hashB]))).status).toBe(200)
+
+      // First request creates the pending record with the full staging validation (access included);
+      // the two resume batches pass skipAccessCheck (finalize re-runs the full validation separately).
+      const skipFlags = stagingSpy.mock.calls.map((call) => call[1]?.skipAccessCheck)
+      expect(skipFlags).toEqual([false, true, true])
+    })
+  })
+
   describe('when a staging request is rate limited', () => {
     it('should respond 429 (a transient, resumable status) rather than 400', async () => {
       jest.spyOn(server.components.deployer, 'isRateLimited').mockReturnValue(true)

--- a/test/integration/controller/partial-deployments.spec.ts
+++ b/test/integration/controller/partial-deployments.spec.ts
@@ -2,6 +2,7 @@ import { Authenticator, IdentityType } from '@dcl/crypto'
 import { EntityType } from '@dcl/schemas'
 import { buildEntity } from 'dcl-catalyst-client/dist/client/utils/DeploymentBuilder'
 import FormData = require('form-data')
+import { EnvironmentConfig } from '../../../src/Environment'
 import { makeNoopValidator } from '../../helpers/logic/server-validator/NoOpValidator'
 import { createDefaultServer, resetServer } from '../simpleTestEnvironment'
 import { TestProgram } from '../TestProgram'
@@ -299,6 +300,61 @@ describe('Integration - Partial deployments', () => {
       // the two resume batches pass skipAccessCheck (finalize re-runs the full validation separately).
       const skipFlags = stagingSpy.mock.calls.map((call) => call[1]?.skipAccessCheck)
       expect(skipFlags).toEqual([false, true, true])
+    })
+  })
+
+  describe('when the deployer loses access to the parcels mid-upload (e.g. the LAND is sold)', () => {
+    let deployment: PreparedDeployment
+    let originalTtlBackwards: number
+
+    beforeEach(async () => {
+      // Unique content per test run: storage is content-addressed and survives resetServer, so reused
+      // bytes from a previous test would satisfy the completeness check and auto-finalize early.
+      const nonce = `${Date.now()}-${Math.random()}`
+      deployment = await prepareSceneDeployment(
+        ['11,11'],
+        { 'a.txt': Buffer.from(`sold land a ${nonce}`), 'b.txt': Buffer.from(`sold land b ${nonce}`) },
+        identity
+      )
+      originalTtlBackwards = server.components.env.getConfig(EnvironmentConfig.REQUEST_TTL_BACKWARDS)
+
+      // Stage the entity and the first file while access is still valid.
+      const [hashA] = deployment.contentHashes
+      expect((await postForm(server, buildPartialForm(deployment, [deployment.entityId, hashA]))).status).toBe(202)
+
+      // Make the upload "long-running": shrink the vanilla freshness bound and let the entity age past
+      // it, so only the pending-upload TTL anchor lets the finalize through — the exact case where the
+      // current-access gate must fire. Then the "sale": the current-access check starts failing.
+      server.components.env.setConfig(EnvironmentConfig.REQUEST_TTL_BACKWARDS, 500)
+      await new Promise((resolve) => setTimeout(resolve, 700))
+      ;(server.components.validator.validateCurrentAccess as jest.Mock).mockResolvedValue({
+        ok: false,
+        errors: ['The provided Eth Address does not have access to the following parcel: (11,11)']
+      })
+    })
+
+    afterEach(() => {
+      server.components.env.setConfig(EnvironmentConfig.REQUEST_TTL_BACKWARDS, originalTtlBackwards)
+    })
+
+    it('should reject the completing request and not deploy the entity', async () => {
+      const [, hashB] = deployment.contentHashes
+      const res = await postForm(server, buildPartialForm(deployment, [hashB]))
+
+      expect(res.status).toBe(400)
+      expect(await countDeployments(server, deployment.entityId)).toBe(0)
+    })
+
+    it('should finalize once access is restored (e.g. the buyer grants operator rights back)', async () => {
+      const [, hashB] = deployment.contentHashes
+      expect((await postForm(server, buildPartialForm(deployment, [hashB]))).status).toBe(400)
+      ;(server.components.validator.validateCurrentAccess as jest.Mock).mockResolvedValue({ ok: true })
+
+      // All content is already staged; an empty resume request completes the upload.
+      const res = await postForm(server, buildPartialForm(deployment, []))
+
+      expect(res.status).toBe(200)
+      expect(await countDeployments(server, deployment.entityId)).toBe(1)
     })
   })
 

--- a/test/integration/controller/partial-deployments.spec.ts
+++ b/test/integration/controller/partial-deployments.spec.ts
@@ -96,107 +96,172 @@ describe('Integration - Partial deployments', () => {
   })
 
   describe('when uploading a scene across multiple partial requests', () => {
-    it('should return 202 with the missing hashes until the last request, which returns 200 and makes the entity live', async () => {
-      const deployment = await prepareSceneDeployment(
-        ['0,0'],
-        { 'a.txt': Buffer.from('content of file a'), 'b.txt': Buffer.from('content of file b') },
-        identity
-      )
-      const [hashA, hashB] = deployment.contentHashes
+    describe('and each content file is uploaded in its own batch', () => {
+      let deployment: PreparedDeployment
+      let hashA: string
+      let hashB: string
+      let firstResponse: Response
 
-      // Request 1: entity file only.
-      const res1 = await postForm(server, buildPartialForm(deployment, [deployment.entityId]))
-      expect(res1.status).toBe(202)
-      const body1 = await res1.json()
-      expect(new Set(body1.missing)).toEqual(new Set([hashA, hashB]))
-      expect(await countPendingDeployments(server)).toBe(1)
+      beforeEach(async () => {
+        // Unique content per test run: storage is content-addressed and survives resetServer, so reused
+        // bytes from a previous run would satisfy the completeness check and auto-finalize early.
+        const nonce = `${Date.now()}-${Math.random()}`
+        deployment = await prepareSceneDeployment(
+          ['0,0'],
+          { 'a.txt': Buffer.from(`content of file a ${nonce}`), 'b.txt': Buffer.from(`content of file b ${nonce}`) },
+          identity
+        )
+        ;[hashA, hashB] = deployment.contentHashes
 
-      // Request 2: first content file.
-      const res2 = await postForm(server, buildPartialForm(deployment, [hashA]))
-      expect(res2.status).toBe(202)
-      expect(await res2.json()).toEqual({ missing: [hashB] })
+        // Request 1: entity file only.
+        firstResponse = await postForm(server, buildPartialForm(deployment, [deployment.entityId]))
+      })
 
-      // Request 3: last content file → auto-finalize.
-      const res3 = await postForm(server, buildPartialForm(deployment, [hashB]))
-      expect(res3.status).toBe(200)
-      expect(typeof (await res3.json()).creationTimestamp).toBe('number')
+      it('should respond 202 with both content hashes missing and create a single pending row', async () => {
+        expect(firstResponse.status).toBe(202)
+        expect(new Set((await firstResponse.json()).missing)).toEqual(new Set([hashA, hashB]))
+        expect(await countPendingDeployments(server)).toBe(1)
+      })
 
-      // The pending row is gone and the entity is deployed.
-      expect(await countPendingDeployments(server)).toBe(0)
-      const deployed = await server.components.deploymentsRepository.getEntityById(
-        server.components.database,
-        deployment.entityId
-      )
-      expect(deployed?.entityId).toBe(deployment.entityId)
+      describe('and the second batch uploads the first content file', () => {
+        let secondResponse: Response
+
+        beforeEach(async () => {
+          secondResponse = await postForm(server, buildPartialForm(deployment, [hashA]))
+        })
+
+        it('should respond 202 with only the remaining hash missing', async () => {
+          expect(secondResponse.status).toBe(202)
+          expect(await secondResponse.json()).toEqual({ missing: [hashB] })
+        })
+
+        describe('and the last batch uploads the remaining content file', () => {
+          let thirdResponse: Response
+
+          beforeEach(async () => {
+            // Last content file → auto-finalize.
+            thirdResponse = await postForm(server, buildPartialForm(deployment, [hashB]))
+          })
+
+          it('should finalize with 200 and a creation timestamp', async () => {
+            expect(thirdResponse.status).toBe(200)
+            expect(typeof (await thirdResponse.json()).creationTimestamp).toBe('number')
+          })
+
+          it('should delete the pending row and make the entity live', async () => {
+            expect(await countPendingDeployments(server)).toBe(0)
+            const deployed = await server.components.deploymentsRepository.getEntityById(
+              server.components.database,
+              deployment.entityId
+            )
+            expect(deployed?.entityId).toBe(deployment.entityId)
+          })
+        })
+      })
     })
 
-    it('should not require the entity file on requests after the first', async () => {
-      const deployment = await prepareSceneDeployment(
-        ['1,1'],
-        { 'a.txt': Buffer.from('another file a') },
-        identity
-      )
-      const [hashA] = deployment.contentHashes
+    describe('and requests after the first omit the entity file', () => {
+      let deployment: PreparedDeployment
+      let hashA: string
+      let firstResponse: Response
 
-      const res1 = await postForm(server, buildPartialForm(deployment, [deployment.entityId]))
-      expect(res1.status).toBe(202)
+      beforeEach(async () => {
+        // Unique content per test run: storage is content-addressed and survives resetServer.
+        const nonce = `${Date.now()}-${Math.random()}`
+        deployment = await prepareSceneDeployment(['1,1'], { 'a.txt': Buffer.from(`another file a ${nonce}`) }, identity)
+        ;[hashA] = deployment.contentHashes
+        firstResponse = await postForm(server, buildPartialForm(deployment, [deployment.entityId]))
+      })
 
-      // Second request omits the entity file entirely; the server reads it back from storage.
-      const res2 = await postForm(server, buildPartialForm(deployment, [hashA]))
-      expect(res2.status).toBe(200)
-      expect(await countPendingDeployments(server)).toBe(0)
+      it('should accept the first batch with 202', () => {
+        expect(firstResponse.status).toBe(202)
+      })
+
+      describe('and the content file is uploaded without the entity file', () => {
+        let secondResponse: Response
+
+        beforeEach(async () => {
+          // The request omits the entity file entirely; the server reads it back from storage.
+          secondResponse = await postForm(server, buildPartialForm(deployment, [hashA]))
+        })
+
+        it('should finalize with 200 and no pending row', async () => {
+          expect(secondResponse.status).toBe(200)
+          expect(await countPendingDeployments(server)).toBe(0)
+        })
+      })
     })
   })
 
   describe('when a single partial request already contains all the content', () => {
-    it('should finalize immediately and return 200', async () => {
+    let response: Response
+
+    beforeEach(async () => {
       const deployment = await prepareSceneDeployment(
         ['2,2'],
         { 'a.txt': Buffer.from('single batch file') },
         identity
       )
-      const res = await postForm(
+      response = await postForm(
         server,
         buildPartialForm(deployment, [deployment.entityId, ...deployment.contentHashes])
       )
-      expect(res.status).toBe(200)
+    })
+
+    it('should finalize immediately with 200 and no pending row', async () => {
+      expect(response.status).toBe(200)
       expect(await countPendingDeployments(server)).toBe(0)
     })
   })
 
   describe('when the same partial request is replayed', () => {
-    it('should respond idempotently with the same missing hashes and keep a single pending row', async () => {
-      const deployment = await prepareSceneDeployment(
+    let deployment: PreparedDeployment
+    let firstResponse: Response
+    let secondResponse: Response
+
+    beforeEach(async () => {
+      deployment = await prepareSceneDeployment(
         ['3,3'],
         { 'a.txt': Buffer.from('replay file a'), 'b.txt': Buffer.from('replay file b') },
         identity
       )
+      firstResponse = await postForm(server, buildPartialForm(deployment, [deployment.entityId]))
+      secondResponse = await postForm(server, buildPartialForm(deployment, [deployment.entityId]))
+    })
 
-      const first = await postForm(server, buildPartialForm(deployment, [deployment.entityId]))
-      const second = await postForm(server, buildPartialForm(deployment, [deployment.entityId]))
+    it('should respond 202 to both requests with the same missing hashes', async () => {
+      expect(firstResponse.status).toBe(202)
+      expect(secondResponse.status).toBe(202)
+      expect(new Set((await secondResponse.json()).missing)).toEqual(new Set(deployment.contentHashes))
+    })
 
-      expect(first.status).toBe(202)
-      expect(second.status).toBe(202)
-      expect(new Set((await second.json()).missing)).toEqual(new Set(deployment.contentHashes))
+    it('should keep a single pending row', async () => {
       expect(await countPendingDeployments(server)).toBe(1)
     })
   })
 
   describe('when the first partial request omits the entity file', () => {
-    it('should return 400', async () => {
+    let response: Response
+
+    beforeEach(async () => {
       const deployment = await prepareSceneDeployment(
         ['4,4'],
         { 'a.txt': Buffer.from('orphan content') },
         identity
       )
       const [hashA] = deployment.contentHashes
-      const res = await postForm(server, buildPartialForm(deployment, [hashA]))
-      expect(res.status).toBe(400)
+      response = await postForm(server, buildPartialForm(deployment, [hashA]))
+    })
+
+    it('should return 400', () => {
+      expect(response.status).toBe(400)
     })
   })
 
   describe('when an uploaded file does not match its declared hash key', () => {
-    it('should return 400', async () => {
+    let response: Response
+
+    beforeEach(async () => {
       const deployment = await prepareSceneDeployment(
         ['5,5'],
         { 'a.txt': Buffer.from('mismatch content') },
@@ -210,102 +275,192 @@ describe('Integration - Partial deployments', () => {
       form.append('bafyWrongKey0000000000000000000000000000000000000000000000', Buffer.from(deployment.files.get(deployment.entityId)!), {
         filename: 'wrong'
       })
-      const res = await postForm(server, form)
-      expect(res.status).toBe(400)
+      response = await postForm(server, form)
+    })
+
+    it('should return 400', () => {
+      expect(response.status).toBe(400)
     })
   })
 
   describe('when a non-partial request is missing content (legacy behavior)', () => {
-    it('should still reach the deployer and not create a pending row', async () => {
+    let response: Response
+
+    beforeEach(async () => {
       const deployment = await prepareSceneDeployment(
         ['6,6'],
         { 'a.txt': Buffer.from('legacy file a') },
         identity
       )
       // Full (non-partial) deploy with all content present → succeeds, no pending row involved.
-      const res = await postForm(
+      response = await postForm(
         server,
         buildPartialForm(deployment, [deployment.entityId, ...deployment.contentHashes], false)
       )
-      expect(res.status).toBe(200)
+    })
+
+    it('should still reach the deployer and not create a pending row', async () => {
+      expect(response.status).toBe(200)
       expect(await countPendingDeployments(server)).toBe(0)
     })
   })
 
   describe('when staging requests for the same entity run in parallel', () => {
-    it('should accept two distinct content batches uploaded concurrently and deploy the entity once', async () => {
-      const deployment = await prepareSceneDeployment(
-        ['7,7'],
-        { 'a.txt': Buffer.from('parallel a'.repeat(50)), 'b.txt': Buffer.from('parallel b'.repeat(60)) },
-        identity
-      )
-      const [hashA, hashB] = deployment.contentHashes
+    describe('and two distinct content batches are uploaded concurrently', () => {
+      let deployment: PreparedDeployment
+      let hashA: string
+      let hashB: string
+      let stagingResponse: Response
 
-      expect((await postForm(server, buildPartialForm(deployment, [deployment.entityId]))).status).toBe(202)
+      beforeEach(async () => {
+        // Unique content per test run: storage is content-addressed and survives resetServer.
+        const nonce = `${Date.now()}-${Math.random()}`
+        deployment = await prepareSceneDeployment(
+          ['7,7'],
+          { 'a.txt': Buffer.from(`parallel a ${nonce}`.repeat(50)), 'b.txt': Buffer.from(`parallel b ${nonce}`.repeat(60)) },
+          identity
+        )
+        ;[hashA, hashB] = deployment.contentHashes
+        stagingResponse = await postForm(server, buildPartialForm(deployment, [deployment.entityId]))
+      })
 
-      // Fire the two remaining content batches concurrently.
-      const [resA, resB] = await Promise.all([
-        postForm(server, buildPartialForm(deployment, [hashA])),
-        postForm(server, buildPartialForm(deployment, [hashB]))
-      ])
+      it('should accept the staging request with 202', () => {
+        expect(stagingResponse.status).toBe(202)
+      })
 
-      // No 500s: each request either finalizes (200) or reports remaining content (202), and exactly
-      // one completes the set. The entity is deployed exactly once, with no leftover pending row.
-      const statuses = [resA.status, resB.status].sort()
-      expect(statuses.every((status) => status === 200 || status === 202)).toBe(true)
-      expect(statuses).toContain(200)
-      expect(await countDeployments(server, deployment.entityId)).toBe(1)
-      expect(await countPendingDeployments(server)).toBe(0)
+      describe('and the two remaining batches are sent at the same time', () => {
+        let responseA: Response
+        let responseB: Response
+
+        beforeEach(async () => {
+          // Fire the two remaining content batches concurrently.
+          ;[responseA, responseB] = await Promise.all([
+            postForm(server, buildPartialForm(deployment, [hashA])),
+            postForm(server, buildPartialForm(deployment, [hashB]))
+          ])
+        })
+
+        it('should respond to each batch with 200 or 202 and finalize exactly one', () => {
+          // No 500s: each request either finalizes (200) or reports remaining content (202), and exactly
+          // one completes the set.
+          expect([responseA.status, responseB.status].every((status) => status === 200 || status === 202)).toBe(true)
+          expect([responseA.status, responseB.status]).toContain(200)
+        })
+
+        it('should deploy the entity exactly once with no leftover pending row', async () => {
+          expect(await countDeployments(server, deployment.entityId)).toBe(1)
+          expect(await countPendingDeployments(server)).toBe(0)
+        })
+      })
     })
 
-    it('should deploy once when two requests complete the content set at the same time', async () => {
-      const deployment = await prepareSceneDeployment(
-        ['8,8'],
-        { 'a.txt': Buffer.from('finalize a'.repeat(50)), 'b.txt': Buffer.from('finalize b'.repeat(60)) },
-        identity
-      )
-      const [hashA, hashB] = deployment.contentHashes
+    describe('and two identical completing requests race to finalize', () => {
+      let deployment: PreparedDeployment
+      let hashA: string
+      let hashB: string
+      let stagingResponse: Response
 
-      // Stage entity + A, leaving only B missing.
-      expect((await postForm(server, buildPartialForm(deployment, [deployment.entityId, hashA]))).status).toBe(202)
+      beforeEach(async () => {
+        // Unique content per test run: storage is content-addressed and survives resetServer.
+        const nonce = `${Date.now()}-${Math.random()}`
+        deployment = await prepareSceneDeployment(
+          ['8,8'],
+          { 'a.txt': Buffer.from(`finalize a ${nonce}`.repeat(50)), 'b.txt': Buffer.from(`finalize b ${nonce}`.repeat(60)) },
+          identity
+        )
+        ;[hashA, hashB] = deployment.contentHashes
+        // Stage entity + A, leaving only B missing.
+        stagingResponse = await postForm(server, buildPartialForm(deployment, [deployment.entityId, hashA]))
+      })
 
-      // Two identical completing requests (both upload B) race to finalize.
-      const [res1, res2] = await Promise.all([
-        postForm(server, buildPartialForm(deployment, [hashB])),
-        postForm(server, buildPartialForm(deployment, [hashB]))
-      ])
+      it('should accept the staging request with 202', () => {
+        expect(stagingResponse.status).toBe(202)
+      })
 
-      expect(res1.status).toBe(200)
-      expect(res2.status).toBe(200)
-      expect(await countDeployments(server, deployment.entityId)).toBe(1)
-      expect(await countPendingDeployments(server)).toBe(0)
+      describe('and both completing requests are sent at the same time', () => {
+        let firstResponse: Response
+        let secondResponse: Response
+
+        beforeEach(async () => {
+          // Two identical completing requests (both upload B) race to finalize.
+          ;[firstResponse, secondResponse] = await Promise.all([
+            postForm(server, buildPartialForm(deployment, [hashB])),
+            postForm(server, buildPartialForm(deployment, [hashB]))
+          ])
+        })
+
+        it('should return 200 to both requests', () => {
+          expect(firstResponse.status).toBe(200)
+          expect(secondResponse.status).toBe(200)
+        })
+
+        it('should deploy the entity exactly once with no leftover pending row', async () => {
+          expect(await countDeployments(server, deployment.entityId)).toBe(1)
+          expect(await countPendingDeployments(server)).toBe(0)
+        })
+      })
     })
   })
 
   describe('when uploading across multiple requests (resume fast-path)', () => {
-    it('should run the access check only on the request that creates the pending record', async () => {
-      const deployment = await prepareSceneDeployment(
+    let deployment: PreparedDeployment
+    let hashA: string
+    let hashB: string
+    let stagingSpy: jest.Mock
+    let firstResponse: Response
+
+    beforeEach(async () => {
+      // Unique content per test run: storage is content-addressed and survives resetServer.
+      const nonce = `${Date.now()}-${Math.random()}`
+      deployment = await prepareSceneDeployment(
         ['10,10'],
-        { 'a.txt': Buffer.from('fast path a'), 'b.txt': Buffer.from('fast path b') },
+        { 'a.txt': Buffer.from(`fast path a ${nonce}`), 'b.txt': Buffer.from(`fast path b ${nonce}`) },
         identity
       )
-      const [hashA, hashB] = deployment.contentHashes
-      const stagingSpy = server.components.validator.validateStagingScene as jest.Mock
+      ;[hashA, hashB] = deployment.contentHashes
+      stagingSpy = server.components.validator.validateStagingScene as jest.Mock
+      firstResponse = await postForm(server, buildPartialForm(deployment, [deployment.entityId]))
+    })
 
-      expect((await postForm(server, buildPartialForm(deployment, [deployment.entityId]))).status).toBe(202)
-      expect((await postForm(server, buildPartialForm(deployment, [hashA]))).status).toBe(202)
-      expect((await postForm(server, buildPartialForm(deployment, [hashB]))).status).toBe(200)
+    it('should accept the request that creates the pending record with 202', () => {
+      expect(firstResponse.status).toBe(202)
+    })
 
-      // First request creates the pending record with the full staging validation (access included);
-      // the two resume batches pass skipAccessCheck (finalize re-runs the full validation separately).
-      const skipFlags = stagingSpy.mock.calls.map((call) => call[1]?.skipAccessCheck)
-      expect(skipFlags).toEqual([false, true, true])
+    describe('and the first content batch is uploaded', () => {
+      let secondResponse: Response
+
+      beforeEach(async () => {
+        secondResponse = await postForm(server, buildPartialForm(deployment, [hashA]))
+      })
+
+      it('should accept the resume batch with 202', () => {
+        expect(secondResponse.status).toBe(202)
+      })
+
+      describe('and the last content batch is uploaded', () => {
+        let thirdResponse: Response
+
+        beforeEach(async () => {
+          thirdResponse = await postForm(server, buildPartialForm(deployment, [hashB]))
+        })
+
+        it('should finalize the upload with 200', () => {
+          expect(thirdResponse.status).toBe(200)
+        })
+
+        it('should run the access check only on the request that creates the pending record', () => {
+          // First request creates the pending record with the full staging validation (access included);
+          // the two resume batches pass skipAccessCheck (finalize re-runs the full validation separately).
+          expect(stagingSpy.mock.calls.map((call) => call[1]?.skipAccessCheck)).toEqual([false, true, true])
+        })
+      })
     })
   })
 
   describe('when the deployer loses access to the parcels mid-upload (e.g. the LAND is sold)', () => {
     let deployment: PreparedDeployment
     let originalTtlBackwards: number
+    let stagingResponse: Response
 
     beforeEach(async () => {
       // Unique content per test run: storage is content-addressed and survives resetServer, so reused
@@ -320,7 +475,7 @@ describe('Integration - Partial deployments', () => {
 
       // Stage the entity and the first file while access is still valid.
       const [hashA] = deployment.contentHashes
-      expect((await postForm(server, buildPartialForm(deployment, [deployment.entityId, hashA]))).status).toBe(202)
+      stagingResponse = await postForm(server, buildPartialForm(deployment, [deployment.entityId, hashA]))
 
       // Make the upload "long-running": shrink the vanilla freshness bound and let the entity age past
       // it, so only the pending-upload TTL anchor lets the finalize through — the exact case where the
@@ -337,29 +492,45 @@ describe('Integration - Partial deployments', () => {
       server.components.env.setConfig(EnvironmentConfig.REQUEST_TTL_BACKWARDS, originalTtlBackwards)
     })
 
-    it('should reject the completing request and not deploy the entity', async () => {
-      const [, hashB] = deployment.contentHashes
-      const res = await postForm(server, buildPartialForm(deployment, [hashB]))
-
-      expect(res.status).toBe(400)
-      expect(await countDeployments(server, deployment.entityId)).toBe(0)
+    it('should accept the staging request sent while access was still valid', () => {
+      expect(stagingResponse.status).toBe(202)
     })
 
-    it('should finalize once access is restored (e.g. the buyer grants operator rights back)', async () => {
-      const [, hashB] = deployment.contentHashes
-      expect((await postForm(server, buildPartialForm(deployment, [hashB]))).status).toBe(400)
-      ;(server.components.validator.validateCurrentAccess as jest.Mock).mockResolvedValue({ ok: true })
+    describe('and the completing request is sent after the sale', () => {
+      let completingResponse: Response
 
-      // All content is already staged; an empty resume request completes the upload.
-      const res = await postForm(server, buildPartialForm(deployment, []))
+      beforeEach(async () => {
+        const [, hashB] = deployment.contentHashes
+        completingResponse = await postForm(server, buildPartialForm(deployment, [hashB]))
+      })
 
-      expect(res.status).toBe(200)
-      expect(await countDeployments(server, deployment.entityId)).toBe(1)
+      it('should reject the completing request and not deploy the entity', async () => {
+        expect(completingResponse.status).toBe(400)
+        expect(await countDeployments(server, deployment.entityId)).toBe(0)
+      })
+
+      describe('and access is later restored (e.g. the buyer grants operator rights back)', () => {
+        let resumeResponse: Response
+
+        beforeEach(async () => {
+          ;(server.components.validator.validateCurrentAccess as jest.Mock).mockResolvedValue({ ok: true })
+
+          // All content is already staged; an empty resume request completes the upload.
+          resumeResponse = await postForm(server, buildPartialForm(deployment, []))
+        })
+
+        it('should finalize the upload and deploy the entity', async () => {
+          expect(resumeResponse.status).toBe(200)
+          expect(await countDeployments(server, deployment.entityId)).toBe(1)
+        })
+      })
     })
   })
 
   describe('when a staging request is rate limited', () => {
-    it('should respond 429 (a transient, resumable status) rather than 400', async () => {
+    let response: Response
+
+    beforeEach(async () => {
       jest.spyOn(server.components.deployer, 'isRateLimited').mockReturnValue(true)
 
       const deployment = await prepareSceneDeployment(
@@ -367,9 +538,11 @@ describe('Integration - Partial deployments', () => {
         { 'a.txt': Buffer.from('rate limited content') },
         identity
       )
-      const res = await postForm(server, buildPartialForm(deployment, [deployment.entityId]))
+      response = await postForm(server, buildPartialForm(deployment, [deployment.entityId]))
+    })
 
-      expect(res.status).toBe(429)
+    it('should respond 429 (a transient, resumable status) rather than 400', async () => {
+      expect(response.status).toBe(429)
       expect(await countPendingDeployments(server)).toBe(0)
     })
   })

--- a/test/integration/controller/partial-deployments.spec.ts
+++ b/test/integration/controller/partial-deployments.spec.ts
@@ -18,7 +18,8 @@ type PreparedDeployment = {
 async function prepareSceneDeployment(
   pointers: string[],
   contents: Record<string, Buffer>,
-  identity: IdentityType
+  identity: IdentityType,
+  timestamp: number = Date.now()
 ): Promise<PreparedDeployment> {
   const files = new Map<string, Uint8Array>(Object.entries(contents))
   const prepared = await buildEntity({
@@ -26,7 +27,7 @@ async function prepareSceneDeployment(
     pointers,
     files,
     metadata: { main: 'bin/main.js', scene: { base: pointers[0], parcels: pointers } },
-    timestamp: Date.now()
+    timestamp
   })
   const signature = Authenticator.createSignature(identity, prepared.entityId)
   const authChain = Authenticator.createSimpleAuthChain(prepared.entityId, identity.address, signature)
@@ -62,6 +63,13 @@ async function postForm(server: TestProgram, form: FormData): Promise<Response> 
 async function countPendingDeployments(server: TestProgram): Promise<number> {
   const result = await server.components.database.query<{ count: string }>('SELECT COUNT(*) as count FROM pending_deployments')
   return parseInt(result.rows[0].count)
+}
+
+async function pendingEntityIds(server: TestProgram): Promise<string[]> {
+  const result = await server.components.database.query<{ entity_id: string }>(
+    'SELECT entity_id FROM pending_deployments'
+  )
+  return result.rows.map((r) => r.entity_id)
 }
 
 async function countDeployments(server: TestProgram, entityId: string): Promise<number> {
@@ -544,6 +552,48 @@ describe('Integration - Partial deployments', () => {
     it('should respond 429 (a transient, resumable status) rather than 400', async () => {
       expect(response.status).toBe(429)
       expect(await countPendingDeployments(server)).toBe(0)
+    })
+  })
+
+  describe('when a second partial upload targets pointers held by a pending upload', () => {
+    let older: PreparedDeployment
+    let newer: PreparedDeployment
+
+    beforeEach(async () => {
+      // Unique content per run (content-addressed storage survives resetServer); the two entities differ
+      // by timestamp so they order deterministically on the same pointers.
+      const nonce = `${Date.now()}-${Math.random()}`
+      const now = Date.now()
+      older = await prepareSceneDeployment(['5,5'], { 'a.txt': Buffer.from(`older ${nonce}`) }, identity, now - 60_000)
+      newer = await prepareSceneDeployment(['5,5'], { 'a.txt': Buffer.from(`newer ${nonce}`) }, identity, now)
+    })
+
+    describe('and the incoming upload is newer than the pending one', () => {
+      let response: Response
+
+      beforeEach(async () => {
+        await postForm(server, buildPartialForm(older, [older.entityId]))
+        response = await postForm(server, buildPartialForm(newer, [newer.entityId]))
+      })
+
+      it('should accept it and replace the older pending upload', async () => {
+        expect(response.status).toBe(202)
+        expect(await pendingEntityIds(server)).toEqual([newer.entityId])
+      })
+    })
+
+    describe('and the incoming upload is older than the pending one', () => {
+      let response: Response
+
+      beforeEach(async () => {
+        await postForm(server, buildPartialForm(newer, [newer.entityId]))
+        response = await postForm(server, buildPartialForm(older, [older.entityId]))
+      })
+
+      it('should reject the older upload with 400 and keep the newer one pending', async () => {
+        expect(response.status).toBe(400)
+        expect(await pendingEntityIds(server)).toEqual([newer.entityId])
+      })
     })
   })
 })

--- a/test/integration/simpleTestEnvironment.ts
+++ b/test/integration/simpleTestEnvironment.ts
@@ -55,7 +55,7 @@ export async function createDB() {
 
 export async function clearDatabase(server: TestProgram): Promise<void> {
   await server.components.database.query(
-    'TRUNCATE TABLE deployments, content_files, active_pointers, processed_snapshots, failed_deployments CASCADE'
+    'TRUNCATE TABLE deployments, content_files, active_pointers, processed_snapshots, failed_deployments, pending_deployments CASCADE'
   )
   // Refresh materialized view to reflect truncated data
   await server.components.database.query(

--- a/test/mocks/deploy-rate-limiter-mock.ts
+++ b/test/mocks/deploy-rate-limiter-mock.ts
@@ -5,6 +5,7 @@ export function createNoOpDeployRateLimiter(): IDeployRateLimiterComponent {
     newDeployment: () => {},
     isRateLimited: () => false,
     newUnchangedDeployment: () => {},
-    isUnchangedDeploymentRateLimited: () => false
+    isUnchangedDeploymentRateLimited: () => false,
+    getRateLimitTtlSeconds: () => 0
   }
 }

--- a/test/unit/ports/deployer.spec.ts
+++ b/test/unit/ports/deployer.spec.ts
@@ -23,6 +23,7 @@ import { createPointersRepository } from '../../../src/adapters/pointers-reposit
 import { createActiveEntitiesRepository } from '../../../src/adapters/active-entities-repository'
 import { createContentFilesRepository } from '../../../src/adapters/content-files-repository'
 import { createDeploymentsRepository } from '../../../src/adapters/deployments-repository'
+import { createPendingDeploymentsRepository } from '../../../src/adapters/pending-deployments-repository'
 import * as deploymentLogic from '../../../src/logic/deployments'
 import * as deployments from '../../../src/logic/deployments'
 import { metricsDeclaration } from '../../../src/metrics'
@@ -264,6 +265,7 @@ describe('Deployer', function () {
       denylist,
       contentFilesRepository,
       deploymentsRepository,
+      pendingDeploymentsRepository: createPendingDeploymentsRepository(),
       entities: createEntities({ env })
     }
     const deployer = createDeploymentService(deployerComponents)

--- a/yarn.lock
+++ b/yarn.lock
@@ -325,10 +325,10 @@
   dependencies:
     ethers "^5.6.8"
 
-"@dcl/content-validator@^7.3.3":
-  version "7.3.3"
-  resolved "https://registry.yarnpkg.com/@dcl/content-validator/-/content-validator-7.3.3.tgz#cae0ad676a91da39524471800c3d5843d59c3a57"
-  integrity sha512-Sxx7+plfYYtNUUnMzXLHOOtXzgTVTQtYfXXcylpIpZWGrUoW4vP4ACTRKT8cXvV+5phRxHVYz8LYHFN9DrO9NQ==
+"@dcl/content-validator@^7.4.0":
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/@dcl/content-validator/-/content-validator-7.4.0.tgz#b14cc318195011bbce2fbc9c447aa13165442e04"
+  integrity sha512-tAxiJNsZjTDian2UD7/l/rIhBQi5YXmXUVYgYTbaZEqBm7wJoJpEdFINyQ66+4nCiUGON9ZD2i0dWN7/IlYxoA==
   dependencies:
     "@dcl/block-indexer" "^1.1.2"
     "@dcl/content-hash-tree" "^1.1.4"


### PR DESCRIPTION
## what

adds support for uploading a scene's content across several `POST /entities` requests instead of a single one, so scenes too large for one request can be deployed. an entity is not counted as live until all of its content is present.

## how

- a new optional `partial=true` form field on `POST /entities` marks a staging request. requests without the flag behave exactly as today.
- per staging request the server authenticates the auth chain, runs every validation that does not depend on the full content set (structure, schema, pointers/coordinates/dimensions, land access/ownership, signature, rate limits, "reject extras"), stores the uploaded files, and records/refreshes a pending deployment.
- a cumulative size check enforces the per-parcel budget as content accumulates.
- when a request completes the content set the server runs the full validation + deploy pipeline in that same request and returns `200 { creationTimestamp }` (auto-finalize); otherwise it returns `202 { missing: [hashes] }`.
- at most one pending deployment may exist per parcel set: a newer partial deploy on overlapping pointers replaces it.
- the deployment-timestamp ttl check is anchored on when the upload started (the pending row's `created_at`) so an upload can span longer than the ttl.
- garbage collection treats non-expired pending entity ids + content hashes as referenced, so in-flight staged content is never reclaimed. a dedicated job expires stale pending rows after `PENDING_DEPLOYMENT_TTL` (default 24h).

## key changes

- new `pending_deployments` table (migration) + `src/adapters/pending-deployments-repository/`.
- new `src/logic/partial-deployments/` orchestration component.
- staging validation subset built by composing the content-validator's individual validate fns (`src/adapters/content-validator/component.ts`).
- deployment-service: ttl anchoring, in-transaction pending-row deletion, `isRateLimited` exposed.
- gc protection in `content-files-repository` + `garbage-collection` component; new cleanup job.

## testing

- new integration tests in `test/integration/controller/partial-deployments.spec.ts` (multi-batch upload, resume/idempotency, single-request auto-finalize, missing entity file, hash mismatch, legacy behavior unchanged).
- existing deploy, upload, entities and garbage-collection suites pass unchanged.
- `yarn build` and `yarn lint` clean.

## follow-ups (out of scope)

- add a `PostEntity202` type to `@dcl/catalyst-api-specs`.
- update `dcl-catalyst-client` to a batched deploy method and bump the dependency here.
