### PR TITLE
fix: stop logging full error stack per failed deployment retry

### DIFF
--- a/src/logic/deployments/component.ts
+++ b/src/logic/deployments/component.ts
@@ -100,7 +100,7 @@ export async function retryFailedDeploymentExecution(
         )
       } catch (error) {
         // it failed again, override failed deployment error description
-        const errorDescription = error.message + ''
+        const errorDescription = error instanceof Error ? error.message : String(error)
 
         if (!errorDescription.includes(IGNORING_FIX_ERROR)) {
           await components.failedDeployments.reportFailure({ ...failedDeployment, errorDescription })

--- a/src/logic/deployments/component.ts
+++ b/src/logic/deployments/component.ts
@@ -107,7 +107,6 @@ export async function retryFailedDeploymentExecution(
         }
 
         logs.error(`Failed to fix deployment of entity`, { entityId, entityType, errorDescription })
-        logs.error(error)
       }
     })
   }


### PR DESCRIPTION
## What

Two small changes to the retry-failed-deployments catch block (`src/logic/deployments/component.ts`):

1. Remove the redundant `logs.error(error)` call, keeping only the structured error line.
2. Narrow the catch variable when building the error description so a non-`Error` throw can't produce the string `"undefined"`.

## Why

### 1. Log noise
`retryFailedDeploymentExecution` re-attempts **every** failed deployment on each cycle. Most failures are permanent — invalid schema (e.g. emotes missing `emoteDataADR74`) or missing parcel access — so they re-fail every cycle. Each failure was logged twice:

```ts
logs.error(`Failed to fix deployment of entity`, { entityId, entityType, errorDescription })
logs.error(error) // full Error object → full stack trace
```

Since the retry loop moved to a `p-queue` (bounded parallelism), that second call's stack now bottoms out in `p-queue/dist/index.js` and carries no useful signal — while the parallelism makes the same permanent failures land in dense bursts, flooding the logs. The remaining structured line already carries `entityId`, `entityType`, and `errorDescription`, so no diagnostic information is lost.

### 2. Robust error description
`const errorDescription = error.message + ''` produced the literal string `"undefined"` if a non-`Error` value was thrown, persisting a useless reason into the failed deployment. Removing the `logs.error(error)` fallback (change 1) also removed the only place the raw thrown value was captured, so this is now narrowed:

```ts
const errorDescription = error instanceof Error ? error.message : String(error)
```

`error instanceof Error ? error.message : String(error)` is used rather than plain `String(error)` to keep the exact message format for `Error` instances (no `"Error: "` prefix), which preserves the existing `IGNORING_FIX_ERROR` match.

## Notes / out of scope

This only reduces log noise and hardens the error description. It intentionally does **not** change retry behavior — permanent failures are still re-reported and retried every cycle. Making the job classify permanent vs. transient failures (or add the long-standing `TODO: exponential backoff`) is a separate follow-up.