### PR TITLE
fix: avoid traces for deployment validation failures

### DIFF
--- a/src/logic/deployment-service/component.ts
+++ b/src/logic/deployment-service/component.ts
@@ -443,7 +443,7 @@ export function createDeploymentService(
           })
           return InvalidResult({ errors: ['An internal server error occurred. This will raise an automatic alarm.'] })
         } else if (isInvalidDeployment(storeResult)) {
-          logger.error(`Error deploying entity`, {
+          logger.warn(`Error deploying entity`, {
             entityId,
             pointers: entity.pointers.join(' '),
             errors: storeResult.errors.join(' ')

--- a/src/logic/deployments/component.ts
+++ b/src/logic/deployments/component.ts
@@ -106,7 +106,7 @@ export async function retryFailedDeploymentExecution(
           await components.failedDeployments.reportFailure({ ...failedDeployment, errorDescription })
         }
 
-        logs.error(`Failed to fix deployment of entity`, { entityId, entityType, errorDescription })
+        logs.warn(`Failed to fix deployment of entity`, { entityId, entityType, errorDescription })
       }
     })
   }


### PR DESCRIPTION
## Summary

- log rejected deployments as warnings instead of errors
- log failed deployment retries as warnings
- prevent @well-known-components/logger from emitting synthetic console traces for expected validation failures

## Verification

- npm run build
- npx eslint src/logic/deployments/component.ts src/logic/deployment-service/component.ts
- npm run test:unit -- --runTestsByPath test/unit/ports/deployer.spec.ts --coverage=false
- git diff --check