### PR TITLE
chore: bump @dcl/content-validator to 7.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@dcl/catalyst-api-specs": "^3.8.0",
     "@dcl/catalyst-contracts": "^4.4.2",
     "@dcl/catalyst-storage": "4.6.1",
-    "@dcl/content-validator": "^7.3.3",
+    "@dcl/content-validator": "^7.4.2",
     "@dcl/core-commons": "^0.10.1",
     "@dcl/crypto": "^3.7.0",
     "@dcl/fetch-component": "1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -325,10 +325,10 @@
   dependencies:
     ethers "^5.6.8"
 
-"@dcl/content-validator@^7.3.3":
-  version "7.3.3"
-  resolved "https://registry.yarnpkg.com/@dcl/content-validator/-/content-validator-7.3.3.tgz#cae0ad676a91da39524471800c3d5843d59c3a57"
-  integrity sha512-Sxx7+plfYYtNUUnMzXLHOOtXzgTVTQtYfXXcylpIpZWGrUoW4vP4ACTRKT8cXvV+5phRxHVYz8LYHFN9DrO9NQ==
+"@dcl/content-validator@^7.4.2":
+  version "7.4.2"
+  resolved "https://registry.yarnpkg.com/@dcl/content-validator/-/content-validator-7.4.2.tgz#30b08b38cf33450386927c02b44ab62832dabad1"
+  integrity sha512-UhYhlpXmCOkGB7iKzc75/X2GwlW6ubTjD7p/A2DfgvjaS3RXzyoisE/fS1QlzW//zhYKmUiHtDpW3Fxl/4RRTw==
   dependencies:
     "@dcl/block-indexer" "^1.1.2"
     "@dcl/content-hash-tree" "^1.1.4"


### PR DESCRIPTION
bumps `@dcl/content-validator` from 7.3.3 to 7.4.2.

- **7.4.2** — enforce content/pointer binding for third-party items: a reused third-party wearable proof can no longer be deployed as an emote at the wearable's pointer, and third-party wearable/emote proofs must commit `id`/`content`/`data` (or `emoteDataADR74`). ([core-libs #57](https://github.com/decentraland/core-libs/pull/57))
- **7.4.1** — require a scene's `display.navmapThumbnail` to be a relative embedded-content path (stored-XSS hardening).

no api changes: only the `content-validator` entry changed in `package.json`/`yarn.lock` (same transitive deps). catalyst typecheck and the unit suite (359) pass against 7.4.2.

> note: `test/integration/syncronization/bootstrapping.spec.ts` is a pre-existing flaky sync suite (bootstrap fetch/ENOENT races in CI) unrelated to this bump — the suite stubs the validator. it's being stabilized in a dedicated PR; if it flakes here, re-run CI.
