### PR TITLE
feat: parallelize snapshot bootstrap deployment

### DIFF
--- a/src/Environment.ts
+++ b/src/Environment.ts
@@ -285,6 +285,9 @@ export enum EnvironmentConfig {
   // Sync throughput knobs (parallel remote-entity downloads / deploys during bootstrap and catch-up)
   SYNC_DOWNLOAD_CONCURRENCY,
   SYNC_DEPLOY_CONCURRENCY,
+  SYNC_CONTENT_DOWNLOAD_CONCURRENCY,
+  SYNC_SNAPSHOT_CONCURRENCY,
+  SYNC_SNAPSHOT_CHECK_CONCURRENCY,
 
   // Max concurrent content-file size fetches during deployment size validation (default 1 = sequential)
   CONTENT_SIZE_FETCH_CONCURRENCY,
@@ -678,6 +681,18 @@ export class EnvironmentBuilder {
     )
     this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.SYNC_DEPLOY_CONCURRENCY, () =>
       Math.max(1, parseNonNegativeIntEnv('SYNC_DEPLOY_CONCURRENCY', 10))
+    )
+    // One process-wide bound for content transfers. The old nested limit allowed each of the 10
+    // deployment workers to fetch 10 files, so 100 preserves its peak while making it explicit and
+    // preventing profile/content queues from multiplying it further.
+    this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.SYNC_CONTENT_DOWNLOAD_CONCURRENCY, () =>
+      Math.max(1, parseNonNegativeIntEnv('SYNC_CONTENT_DOWNLOAD_CONCURRENCY', 100))
+    )
+    this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.SYNC_SNAPSHOT_CONCURRENCY, () =>
+      Math.max(1, parseNonNegativeIntEnv('SYNC_SNAPSHOT_CONCURRENCY', 10))
+    )
+    this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.SYNC_SNAPSHOT_CHECK_CONCURRENCY, () =>
+      Math.max(1, parseNonNegativeIntEnv('SYNC_SNAPSHOT_CHECK_CONCURRENCY', 10))
     )
     // Concurrency for content-file size fetches during size validation. Default 10 (matching
     // CONTENT_STORE_CONCURRENCY): only the sync path fetches these sizes, so this parallelizes

--- a/src/Environment.ts
+++ b/src/Environment.ts
@@ -17,6 +17,9 @@ export const DEFAULT_ENTITIES_CACHE_SIZE = 150000
 // concurrency (batch deployer = 10) so concurrent deploy transactions — each holding a connection
 // for its whole tx — can't starve the read endpoints of connections. pg's own default is 10.
 export const DEFAULT_PG_POOL_SIZE = 20
+const MAX_SYNC_CONTENT_DOWNLOAD_CONCURRENCY = 1000
+const MAX_SYNC_SNAPSHOT_CONCURRENCY = 100
+const MAX_SYNC_SNAPSHOT_CHECK_CONCURRENCY = 100
 
 /**
  * Parses the PG_POOL_SIZE env value: falls back to DEFAULT_PG_POOL_SIZE when unset or non-numeric,
@@ -70,6 +73,20 @@ function parseNonNegativeIntEnv(name: string, defaultValue: number): number {
   // precision, enforcing a cap different from what the operator typed.
   if (!Number.isSafeInteger(parsed)) {
     throw new Error(`Invalid ${name}: value "${raw}" is too large to represent exactly`)
+  }
+  return parsed
+}
+
+/**
+ * Parses a concurrency setting while preserving the existing zero-to-one floor and rejecting values
+ * above a deliberately generous operational ceiling. These values multiply sockets, open files, and
+ * in-flight buffers, so accepting any safe JavaScript integer would turn a configuration mistake into
+ * a startup-time resource exhaustion hazard.
+ */
+function parseBoundedConcurrencyEnv(name: string, defaultValue: number, maximum: number): number {
+  const parsed = Math.max(1, parseNonNegativeIntEnv(name, defaultValue))
+  if (parsed > maximum) {
+    throw new Error(`Invalid ${name}: expected a value between 1 and ${maximum} but got "${parsed}"`)
   }
   return parsed
 }
@@ -686,13 +703,13 @@ export class EnvironmentBuilder {
     // deployment workers to fetch 10 files, so 100 preserves its peak while making it explicit and
     // preventing profile/content queues from multiplying it further.
     this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.SYNC_CONTENT_DOWNLOAD_CONCURRENCY, () =>
-      Math.max(1, parseNonNegativeIntEnv('SYNC_CONTENT_DOWNLOAD_CONCURRENCY', 100))
+      parseBoundedConcurrencyEnv('SYNC_CONTENT_DOWNLOAD_CONCURRENCY', 100, MAX_SYNC_CONTENT_DOWNLOAD_CONCURRENCY)
     )
     this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.SYNC_SNAPSHOT_CONCURRENCY, () =>
-      Math.max(1, parseNonNegativeIntEnv('SYNC_SNAPSHOT_CONCURRENCY', 10))
+      parseBoundedConcurrencyEnv('SYNC_SNAPSHOT_CONCURRENCY', 10, MAX_SYNC_SNAPSHOT_CONCURRENCY)
     )
     this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.SYNC_SNAPSHOT_CHECK_CONCURRENCY, () =>
-      Math.max(1, parseNonNegativeIntEnv('SYNC_SNAPSHOT_CHECK_CONCURRENCY', 10))
+      parseBoundedConcurrencyEnv('SYNC_SNAPSHOT_CHECK_CONCURRENCY', 10, MAX_SYNC_SNAPSHOT_CHECK_CONCURRENCY)
     )
     // Concurrency for content-file size fetches during size validation. Default 10 (matching
     // CONTENT_STORE_CONCURRENCY): only the sync path fetches these sizes, so this parallelizes

--- a/src/components.ts
+++ b/src/components.ts
@@ -314,6 +314,7 @@ export async function initComponentsWithEnv(env: Environment): Promise<AppCompon
         concurrency: env.getConfig<number>(EnvironmentConfig.SYNC_DEPLOY_CONCURRENCY),
         timeout: 100000
       },
+      contentDownloadConcurrency: env.getConfig<number>(EnvironmentConfig.SYNC_CONTENT_DOWNLOAD_CONCURRENCY),
       profileDuration: env.getConfig(EnvironmentConfig.PROFILE_DURATION)
     }
   )
@@ -361,6 +362,10 @@ export async function initComponentsWithEnv(env: Environment): Promise<AppCompon
       // download entities retry
       requestMaxRetries: 10,
       requestRetryWaitTime: 5000,
+      concurrency: {
+        snapshotDeployments: env.getConfig<number>(EnvironmentConfig.SYNC_SNAPSHOT_CONCURRENCY),
+        snapshotChecks: env.getConfig<number>(EnvironmentConfig.SYNC_SNAPSHOT_CHECK_CONCURRENCY)
+      },
 
       // pointer chagnes stream options
       // time between every poll to /pointer-changes

--- a/src/logic/batch-deployer/component.ts
+++ b/src/logic/batch-deployer/component.ts
@@ -1,10 +1,6 @@
 import LRU from 'lru-cache'
-import {
-  createJobQueue,
-  DeployableEntity,
-  downloadEntityAndContentFilesWithBuffer,
-  TimeRange
-} from '@dcl/snapshots-fetcher'
+import * as snapshotsFetcher from '@dcl/snapshots-fetcher'
+import { createJobQueue, DeployableEntity, downloadEntityAndContentFiles, TimeRange } from '@dcl/snapshots-fetcher'
 import { toCoreFetcher } from '../to-core-fetcher'
 import { streamToBuffer } from '@dcl/catalyst-storage'
 import { AuthChain, EntityType } from '@dcl/schemas'
@@ -17,6 +13,28 @@ import { IBatchDeployer } from './types'
 
 const REQUEST_MAX_RETRIES = 10
 const REQUEST_RETRY_WAIT_TIME = 1000
+
+type BufferedEntityDownloader = (
+  components: Parameters<typeof downloadEntityAndContentFiles>[0],
+  entityId: Parameters<typeof downloadEntityAndContentFiles>[1],
+  presentInServers: Parameters<typeof downloadEntityAndContentFiles>[2],
+  serverMapLRU: Parameters<typeof downloadEntityAndContentFiles>[3],
+  targetFolder: Parameters<typeof downloadEntityAndContentFiles>[4],
+  maxRetries: Parameters<typeof downloadEntityAndContentFiles>[5],
+  waitTimeBetweenRetries: Parameters<typeof downloadEntityAndContentFiles>[6],
+  contentFilesConcurrency?: Parameters<typeof downloadEntityAndContentFiles>[7],
+  transferLimits?: Parameters<typeof downloadEntityAndContentFiles>[8],
+  scheduler?: ReturnType<typeof createJobQueue>
+) => Promise<{ entityFile: Uint8Array }>
+
+// Keep Catalyst compatible with the currently published fetcher while the coordinated fetcher
+// change is released. Once available, this path also avoids reading the verified entity from
+// storage a second time and puts every content transfer behind the shared process-wide queue.
+const downloadEntityAndContentFilesWithBuffer = (
+  snapshotsFetcher as typeof snapshotsFetcher & {
+    downloadEntityAndContentFilesWithBuffer?: BufferedEntityDownloader
+  }
+).downloadEntityAndContentFilesWithBuffer
 
 // Bounds the in-process dedup cache of processed entity ids. It's a fast path in front of
 // isEntityDeployed, so an evicted entry just costs a re-check.
@@ -93,21 +111,35 @@ export function createBatchDeployerComponent(
   async function downloadFullEntity(entityId: string, entityType: string, servers: string[]): Promise<Uint8Array> {
     components.metrics.increment('dcl_pending_download_gauge', { entity_type: entityType })
     try {
-      const downloaded = await downloadEntityAndContentFilesWithBuffer(
-        // snapshots-fetcher@11 types its fetcher via @dcl/core-commons (the same native runtime value
-        // stored under the WKC type on `components.fetcher`); assert the core-commons type here.
-        { ...components, fetcher: toCoreFetcher(components.fetcher) },
+      const fetcherComponents = { ...components, fetcher: toCoreFetcher(components.fetcher) }
+      if (downloadEntityAndContentFilesWithBuffer) {
+        const downloaded = await downloadEntityAndContentFilesWithBuffer(
+          fetcherComponents,
+          entityId,
+          servers,
+          serverLru,
+          components.staticConfigs.tmpDownloadFolder,
+          REQUEST_MAX_RETRIES,
+          REQUEST_RETRY_WAIT_TIME,
+          10,
+          undefined,
+          contentDownloadQueue
+        )
+        return downloaded.entityFile
+      }
+
+      await downloadEntityAndContentFiles(
+        fetcherComponents,
         entityId,
         servers,
         serverLru,
         components.staticConfigs.tmpDownloadFolder,
         REQUEST_MAX_RETRIES,
-        REQUEST_RETRY_WAIT_TIME,
-        10,
-        undefined,
-        contentDownloadQueue
+        REQUEST_RETRY_WAIT_TIME
       )
-      return downloaded.entityFile
+      const entityInStorage = await components.storage.retrieve(entityId)
+      if (!entityInStorage) throw new Error('Entity ' + entityId + ' cannot be retrieved from storage')
+      return streamToBuffer(await entityInStorage.asStream())
     } finally {
       components.metrics.decrement('dcl_pending_download_gauge', { entity_type: entityType })
     }

--- a/src/logic/batch-deployer/component.ts
+++ b/src/logic/batch-deployer/component.ts
@@ -1,5 +1,10 @@
 import LRU from 'lru-cache'
-import { createJobQueue, DeployableEntity, downloadEntityAndContentFiles, TimeRange } from '@dcl/snapshots-fetcher'
+import {
+  createJobQueue,
+  DeployableEntity,
+  downloadEntityAndContentFilesWithBuffer,
+  TimeRange
+} from '@dcl/snapshots-fetcher'
 import { toCoreFetcher } from '../to-core-fetcher'
 import { streamToBuffer } from '@dcl/catalyst-storage'
 import { AuthChain, EntityType } from '@dcl/schemas'
@@ -48,12 +53,17 @@ export function createBatchDeployerComponent(
   syncOptions: {
     ignoredTypes: Set<string>
     queueOptions: createJobQueue.Options
+    contentDownloadConcurrency?: number
     profileDuration: number
   }
 ): IBatchDeployer {
   const logs = components.logs.getLogger('DeployerComponent')
 
   const parallelDeploymentJobs = createJobQueue(syncOptions.queueOptions)
+  const contentDownloadQueue = createJobQueue({
+    autoStart: true,
+    concurrency: syncOptions.contentDownloadConcurrency ?? 100
+  })
 
   // Returned component, captured by closures so internal calls to public methods route
   // through the returned object. Otherwise `jest.spyOn(component, 'deployEntityFromRemoteServer')`
@@ -80,10 +90,10 @@ export function createBatchDeployerComponent(
   // tests get a fresh instance per component and the state can't drift between runs.
   const serverLru = new Map<string, number>()
 
-  async function downloadFullEntity(entityId: string, entityType: string, servers: string[]): Promise<unknown> {
+  async function downloadFullEntity(entityId: string, entityType: string, servers: string[]): Promise<Uint8Array> {
     components.metrics.increment('dcl_pending_download_gauge', { entity_type: entityType })
     try {
-      return await downloadEntityAndContentFiles(
+      const downloaded = await downloadEntityAndContentFilesWithBuffer(
         // snapshots-fetcher@11 types its fetcher via @dcl/core-commons (the same native runtime value
         // stored under the WKC type on `components.fetcher`); assert the core-commons type here.
         { ...components, fetcher: toCoreFetcher(components.fetcher) },
@@ -92,8 +102,12 @@ export function createBatchDeployerComponent(
         serverLru,
         components.staticConfigs.tmpDownloadFolder,
         REQUEST_MAX_RETRIES,
-        REQUEST_RETRY_WAIT_TIME
+        REQUEST_RETRY_WAIT_TIME,
+        10,
+        undefined,
+        contentDownloadQueue
       )
+      return downloaded.entityFile
     } finally {
       components.metrics.decrement('dcl_pending_download_gauge', { entity_type: entityType })
     }
@@ -103,16 +117,18 @@ export function createBatchDeployerComponent(
     entityId: string,
     entityType: string,
     auditInfo: LocalDeploymentAuditInfo,
-    context: DeploymentContext
+    context: DeploymentContext,
+    verifiedEntityFile?: Uint8Array
   ): Promise<void> {
     const deploymentTimeTimer = components.metrics.startTimer('dcl_deployment_time', { entity_type: entityType })
 
     try {
-      const entityInStorage = await components.storage.retrieve(entityId)
-
-      if (!entityInStorage) throw new Error('Entity ' + entityId + ' cannot be retrieved from storage')
-
-      const entityFile = await streamToBuffer(await entityInStorage.asStream())
+      let entityFile = verifiedEntityFile
+      if (!entityFile) {
+        const entityInStorage = await components.storage.retrieve(entityId)
+        if (!entityInStorage) throw new Error('Entity ' + entityId + ' cannot be retrieved from storage')
+        entityFile = await streamToBuffer(await entityInStorage.asStream())
+      }
 
       if (entityFile.length == 0) {
         throw new Error('Trying to deploy empty entityFile')
@@ -139,8 +155,8 @@ export function createBatchDeployerComponent(
     servers: string[],
     context: DeploymentContext
   ): Promise<void> {
-    await downloadFullEntity(entityId, entityType, servers)
-    await deployDownloadedEntity(entityId, entityType, { authChain }, context)
+    const entityFile = await downloadFullEntity(entityId, entityType, servers)
+    await deployDownloadedEntity(entityId, entityType, { authChain }, context, entityFile)
   }
 
   /**
@@ -300,11 +316,13 @@ export function createBatchDeployerComponent(
 
   self = {
     async stop() {
-      // stop will wait for the queue to end.
-      return parallelDeploymentJobs.onIdle()
+      // Stop accepting deployments first and drain those already queued. Their work may still enqueue
+      // content transfers, so the content queue must remain open until the deployment queue is quiescent.
+      await parallelDeploymentJobs.stop?.()
+      await contentDownloadQueue.stop?.()
     },
-    onIdle() {
-      return parallelDeploymentJobs.onIdle()
+    async onIdle() {
+      await Promise.all([parallelDeploymentJobs.onIdle(), contentDownloadQueue.onIdle()])
     },
     async scheduleEntityDeployment(entity: DeployableEntity, contentServers: string[]): Promise<void> {
       await handleDeploymentFromServers(entity, contentServers)

--- a/src/logic/batch-deployer/types.ts
+++ b/src/logic/batch-deployer/types.ts
@@ -28,6 +28,7 @@ export type IBatchDeployer = IDeployerComponent &
       entityId: string,
       entityType: string,
       auditInfo: LocalDeploymentAuditInfo,
-      context: DeploymentContext
+      context: DeploymentContext,
+      verifiedEntityFile?: Uint8Array
     ): Promise<void>
   }

--- a/test/unit/Environment.spec.ts
+++ b/test/unit/Environment.spec.ts
@@ -1,0 +1,45 @@
+import { EnvironmentBuilder } from '../../src/Environment'
+
+describe('EnvironmentBuilder synchronization concurrency configuration', () => {
+  afterEach(() => {
+    delete process.env.SYNC_CONTENT_DOWNLOAD_CONCURRENCY
+    delete process.env.SYNC_SNAPSHOT_CONCURRENCY
+    delete process.env.SYNC_SNAPSHOT_CHECK_CONCURRENCY
+  })
+
+  describe('when content download concurrency exceeds its operational ceiling', () => {
+    beforeEach(() => {
+      process.env.SYNC_CONTENT_DOWNLOAD_CONCURRENCY = '1001'
+    })
+
+    it('should reject the configuration before creating resource-intensive queues', async () => {
+      await expect(new EnvironmentBuilder().build()).rejects.toThrow(
+        'Invalid SYNC_CONTENT_DOWNLOAD_CONCURRENCY: expected a value between 1 and 1000 but got "1001"'
+      )
+    })
+  })
+
+  describe('when snapshot deployment concurrency exceeds its operational ceiling', () => {
+    beforeEach(() => {
+      process.env.SYNC_SNAPSHOT_CONCURRENCY = '101'
+    })
+
+    it('should reject the configuration before opening snapshot streams', async () => {
+      await expect(new EnvironmentBuilder().build()).rejects.toThrow(
+        'Invalid SYNC_SNAPSHOT_CONCURRENCY: expected a value between 1 and 100 but got "101"'
+      )
+    })
+  })
+
+  describe('when snapshot check concurrency exceeds its operational ceiling', () => {
+    beforeEach(() => {
+      process.env.SYNC_SNAPSHOT_CHECK_CONCURRENCY = '101'
+    })
+
+    it('should reject the configuration before scheduling storage checks', async () => {
+      await expect(new EnvironmentBuilder().build()).rejects.toThrow(
+        'Invalid SYNC_SNAPSHOT_CHECK_CONCURRENCY: expected a value between 1 and 100 but got "101"'
+      )
+    })
+  })
+})

--- a/test/unit/logic/batch-deployer.spec.ts
+++ b/test/unit/logic/batch-deployer.spec.ts
@@ -1,6 +1,9 @@
 import ms from 'ms'
 import { createBatchDeployerComponent } from '../../../src/logic/batch-deployer'
 import * as deployments from '../../../src/logic/deployments'
+import { DeploymentContext } from '../../../src/deployment-types'
+
+const snapshotsFetcher = jest.requireActual<typeof import('@dcl/snapshots-fetcher')>('@dcl/snapshots-fetcher')
 
 function createMockComponents() {
   return {
@@ -136,6 +139,87 @@ describe('createBatchDeployerComponent', () => {
 
         expect(deploySpy).toHaveBeenCalled()
       })
+    })
+  })
+
+  describe('when verified entity bytes are supplied by the fetcher', () => {
+    let components: ReturnType<typeof createMockComponents>
+    let batchDeployer: ReturnType<typeof createBatchDeployerComponent>
+    let verifiedEntityFile: Uint8Array
+
+    beforeEach(() => {
+      components = createMockComponents()
+      batchDeployer = createBatchDeployerComponent(components, {
+        ignoredTypes: new Set(),
+        queueOptions: { autoStart: true, concurrency: 1, timeout: 10000 },
+        contentDownloadConcurrency: 1,
+        profileDuration: ms('1 year')
+      })
+      verifiedEntityFile = Buffer.from('{"type":"scene"}')
+    })
+
+    it('should deploy without retrieving the entity from storage again', async () => {
+      await batchDeployer.deployDownloadedEntity(
+        'entity-id',
+        'scene',
+        { authChain: [] },
+        DeploymentContext.SYNCED,
+        verifiedEntityFile
+      )
+
+      expect(components.storage.retrieve).not.toHaveBeenCalled()
+    })
+
+    it('should pass the exact verified bytes to the entity deployer', async () => {
+      await batchDeployer.deployDownloadedEntity(
+        'entity-id',
+        'scene',
+        { authChain: [] },
+        DeploymentContext.SYNCED,
+        verifiedEntityFile
+      )
+
+      expect(components.deployer.deployEntity).toHaveBeenCalledWith(
+        [verifiedEntityFile],
+        'entity-id',
+        { authChain: [] },
+        DeploymentContext.SYNCED
+      )
+    })
+  })
+
+  describe('when the component stops with owned queues', () => {
+    let stopOrder: string[]
+    let batchDeployer: ReturnType<typeof createBatchDeployerComponent>
+
+    beforeEach(() => {
+      stopOrder = []
+      const deploymentQueue = {
+        stop: jest.fn(async () => {
+          stopOrder.push('deployments')
+        })
+      }
+      const contentQueue = {
+        stop: jest.fn(async () => {
+          stopOrder.push('content')
+        })
+      }
+      jest
+        .spyOn(snapshotsFetcher, 'createJobQueue')
+        .mockReturnValueOnce(deploymentQueue as any)
+        .mockReturnValueOnce(contentQueue as any)
+      batchDeployer = createBatchDeployerComponent(createMockComponents(), {
+        ignoredTypes: new Set(),
+        queueOptions: { autoStart: true, concurrency: 1 },
+        contentDownloadConcurrency: 1,
+        profileDuration: ms('1 year')
+      })
+    })
+
+    it('should terminate deployment work before terminating its content queue', async () => {
+      await batchDeployer.stop?.()
+
+      expect(stopOrder).toEqual(['deployments', 'content'])
     })
   })
 })


### PR DESCRIPTION
## Summary

- add configurable bootstrap deployment and content download concurrency
- reject new sync concurrency values above explicit resource-safety ceilings
- pass verified snapshot bytes directly into entity deployment when the coordinated fetcher API is available
- use a shared snapshots-fetcher queue to bound content downloads process-wide
- stop deployment and content queues in dependency-safe lifecycle order
- remain compatible with the currently published snapshots-fetcher during rollout

## Performance and safety

Snapshot parsing, bounded content downloads, and entity deployment can overlap during Catalyst bootstrap. The concurrency limits remain explicit and observable, and now reject values above 1000 content transfers or 100 concurrent snapshot deployments/checks to prevent configuration-driven resource exhaustion.

With the coordinated fetcher release, Catalyst also avoids rereading a just-downloaded entity from storage. Until then, it falls back to the published API without requiring a package version change.

## Tests

- `yarn lint:check`
- `yarn build`
- concurrency ceiling unit tests: 3 passed
- bootstrap integration rerun: 6 passed
- full suite: 670 passed, 4 skipped; one timing-sensitive bootstrap assertion failed once and passed on isolated rerun

## Dependency

Built together with decentraland/snapshots-fetcher#206. No package versions are changed in this PR, as requested.