### PR TITLE
fix: enforce scene base parcel integrity

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@dcl/memory-cache-component": "^2.4.3",
     "@dcl/metrics": "^1.0.1",
     "@dcl/schema-validator-component": "^1.0.2",
-    "@dcl/schemas": "^26.5.0",
+    "@dcl/schemas": "^27.0.0",
     "@dcl/snapshots-fetcher": "11.0.0",
     "@dcl/thegraph-component": "^0.1.2",
     "@dcl/traced-fetch-component": "^1.0.8",

--- a/src/adapters/content-validator/component.ts
+++ b/src/adapters/content-validator/component.ts
@@ -32,6 +32,7 @@ import { createEthereumProvider } from './ethereum-provider'
 import { createThirdPartyItemChecker } from './third-party-item-checker'
 import { AppComponents } from '../../types'
 import { IContentValidator } from './types'
+import { createSceneBaseAwareAccessValidateFn } from './scene-base-validation'
 
 type ContentValidatorDeps = Pick<
   AppComponents,
@@ -85,7 +86,7 @@ async function createIgnoreBlockchainAccessValidateFn(
   return createValidator({
     logs,
     externalCalls,
-    accessValidateFn: (_d: DeploymentToValidate) => Promise.resolve(OK)
+    accessValidateFn: createSceneBaseAwareAccessValidateFn((_d: DeploymentToValidate) => Promise.resolve(OK))
   })
 }
 
@@ -184,7 +185,7 @@ async function createOnChainValidateFn(
   return createValidator({
     logs,
     externalCalls,
-    accessValidateFn: createAccessValidateFn({ externalCalls }, validateFns)
+    accessValidateFn: createSceneBaseAwareAccessValidateFn(createAccessValidateFn({ externalCalls }, validateFns))
   })
 }
 
@@ -242,7 +243,7 @@ async function createSubgraphValidateFn(
   return createValidator({
     logs,
     externalCalls,
-    accessValidateFn: createAccessValidateFn({ externalCalls }, validateFns)
+    accessValidateFn: createSceneBaseAwareAccessValidateFn(createAccessValidateFn({ externalCalls }, validateFns))
   })
 }
 

--- a/src/adapters/content-validator/scene-base-validation.ts
+++ b/src/adapters/content-validator/scene-base-validation.ts
@@ -1,15 +1,12 @@
-import { EntityType } from '@dcl/schemas'
+import { EntityType, SceneParcels } from '@dcl/schemas'
 import { ValidateFn, validationFailed } from '@dcl/content-validator'
 
-const PARCEL_COORDINATE_PATTERN = /^(?:0|-?[1-9]\d*),(?:0|-?[1-9]\d*)$/
-
 function isCanonicalParcelList(value: unknown): value is string[] {
-  return (
-    Array.isArray(value) &&
-    value.length > 0 &&
-    value.every((parcel): parcel is string => typeof parcel === 'string' && PARCEL_COORDINATE_PATTERN.test(parcel)) &&
-    new Set(value).size === value.length
-  )
+  if (!Array.isArray(value) || value.length === 0 || !value.every((parcel) => typeof parcel === 'string')) {
+    return false
+  }
+
+  return SceneParcels.validate({ base: value[0], parcels: value })
 }
 
 /**
@@ -23,21 +20,15 @@ export function createSceneBaseAwareAccessValidateFn(accessValidateFn: ValidateF
   return async (deployment) => {
     if (deployment.entity.type === EntityType.SCENE) {
       const scene = deployment.entity.metadata?.scene
-      const base = scene?.base
       const pointers = deployment.entity.pointers
-      const parcels = scene?.parcels
-      const sameParcels =
-        isCanonicalParcelList(pointers) &&
-        isCanonicalParcelList(parcels) &&
-        pointers.length === parcels.length &&
-        parcels.every((parcel) => pointers.includes(parcel))
+      if (!SceneParcels.validate(scene) || !isCanonicalParcelList(pointers)) {
+        return validationFailed(
+          'The scene base must be included in matching, unique canonical scene parcels and entity pointers.'
+        )
+      }
 
-      if (
-        typeof base !== 'string' ||
-        !PARCEL_COORDINATE_PATTERN.test(base) ||
-        !sameParcels ||
-        !parcels.includes(base)
-      ) {
+      const pointerSet = new Set(pointers)
+      if (pointerSet.size !== scene.parcels.length || scene.parcels.some((parcel) => !pointerSet.has(parcel))) {
         return validationFailed(
           'The scene base must be included in matching, unique canonical scene parcels and entity pointers.'
         )

--- a/src/adapters/content-validator/scene-base-validation.ts
+++ b/src/adapters/content-validator/scene-base-validation.ts
@@ -1,6 +1,9 @@
 import { EntityType, SceneParcels } from '@dcl/schemas'
 import { ValidateFn, validationFailed } from '@dcl/content-validator'
 
+const SCENE_PARCEL_INTEGRITY_ERROR =
+  'The scene base must be included in matching, unique canonical scene parcels and entity pointers.'
+
 function isCanonicalParcelList(value: unknown): value is string[] {
   if (!Array.isArray(value) || value.length === 0 || !value.every((parcel) => typeof parcel === 'string')) {
     return false
@@ -22,16 +25,12 @@ export function createSceneBaseAwareAccessValidateFn(accessValidateFn: ValidateF
       const scene = deployment.entity.metadata?.scene
       const pointers = deployment.entity.pointers
       if (!SceneParcels.validate(scene) || !isCanonicalParcelList(pointers)) {
-        return validationFailed(
-          'The scene base must be included in matching, unique canonical scene parcels and entity pointers.'
-        )
+        return validationFailed(SCENE_PARCEL_INTEGRITY_ERROR)
       }
 
       const pointerSet = new Set(pointers)
       if (pointerSet.size !== scene.parcels.length || scene.parcels.some((parcel) => !pointerSet.has(parcel))) {
-        return validationFailed(
-          'The scene base must be included in matching, unique canonical scene parcels and entity pointers.'
-        )
+        return validationFailed(SCENE_PARCEL_INTEGRITY_ERROR)
       }
     }
 

--- a/src/adapters/content-validator/scene-base-validation.ts
+++ b/src/adapters/content-validator/scene-base-validation.ts
@@ -1,0 +1,54 @@
+import { EntityType } from '@dcl/schemas'
+import { ValidateFn, validationFailed } from '@dcl/content-validator'
+
+const PARCEL_COORDINATE_PATTERN = /^(?:0|-?[1-9]\d*),(?:0|-?[1-9]\d*)$/
+const MAX_SCENE_PARCELS = 1000
+
+function isCanonicalParcelList(value: unknown): value is string[] {
+  return (
+    Array.isArray(value) &&
+    value.length > 0 &&
+    value.length <= MAX_SCENE_PARCELS &&
+    value.every(
+      (parcel): parcel is string =>
+        typeof parcel === 'string' && parcel.length <= 32 && PARCEL_COORDINATE_PATTERN.test(parcel)
+    ) &&
+    new Set(value).size === value.length
+  )
+}
+
+/**
+ * Wraps an access validator with the scene base-parcel invariant that is missing from
+ * `Scene.validate` in the currently deployed content-validator version.
+ *
+ * @param accessValidateFn The configured on-chain, subgraph, or no-op access validator.
+ * @returns A validator that rejects an out-of-scene base before invoking the access check.
+ */
+export function createSceneBaseAwareAccessValidateFn(accessValidateFn: ValidateFn): ValidateFn {
+  return async (deployment) => {
+    if (deployment.entity.type === EntityType.SCENE) {
+      const scene = deployment.entity.metadata?.scene
+      const base = scene?.base
+      const pointers = deployment.entity.pointers
+      const parcels = scene?.parcels
+      const sameParcels =
+        isCanonicalParcelList(pointers) &&
+        isCanonicalParcelList(parcels) &&
+        pointers.length === parcels.length &&
+        parcels.every((parcel) => pointers.includes(parcel))
+
+      if (
+        typeof base !== 'string' ||
+        !PARCEL_COORDINATE_PATTERN.test(base) ||
+        !sameParcels ||
+        !parcels.includes(base)
+      ) {
+        return validationFailed(
+          'The scene base must be included in matching, unique canonical scene parcels and entity pointers.'
+        )
+      }
+    }
+
+    return accessValidateFn(deployment)
+  }
+}

--- a/src/adapters/content-validator/scene-base-validation.ts
+++ b/src/adapters/content-validator/scene-base-validation.ts
@@ -2,17 +2,12 @@ import { EntityType } from '@dcl/schemas'
 import { ValidateFn, validationFailed } from '@dcl/content-validator'
 
 const PARCEL_COORDINATE_PATTERN = /^(?:0|-?[1-9]\d*),(?:0|-?[1-9]\d*)$/
-const MAX_SCENE_PARCELS = 1000
 
 function isCanonicalParcelList(value: unknown): value is string[] {
   return (
     Array.isArray(value) &&
     value.length > 0 &&
-    value.length <= MAX_SCENE_PARCELS &&
-    value.every(
-      (parcel): parcel is string =>
-        typeof parcel === 'string' && parcel.length <= 32 && PARCEL_COORDINATE_PATTERN.test(parcel)
-    ) &&
+    value.every((parcel): parcel is string => typeof parcel === 'string' && PARCEL_COORDINATE_PATTERN.test(parcel)) &&
     new Set(value).size === value.length
   )
 }

--- a/test/unit/adapters/content-validator/scene-base-validation.spec.ts
+++ b/test/unit/adapters/content-validator/scene-base-validation.spec.ts
@@ -1,5 +1,5 @@
 import { EntityType } from '@dcl/schemas'
-import { DeploymentToValidate, OK, ValidateFn } from '@dcl/content-validator'
+import { DeploymentToValidate, OK, ValidateFn, validationFailed } from '@dcl/content-validator'
 import { createSceneBaseAwareAccessValidateFn } from '../../../../src/adapters/content-validator/scene-base-validation'
 
 describe('when validating scene access with a base-aware validator', () => {
@@ -33,23 +33,46 @@ describe('when validating scene access with a base-aware validator', () => {
   })
 
   describe('and the base belongs to the pointers and scene parcels', () => {
+    let delegatedResult: ReturnType<typeof validationFailed>
+
+    beforeEach(() => {
+      delegatedResult = validationFailed('delegated validation result')
+      accessValidateFn.mockResolvedValue(delegatedResult)
+    })
+
     it('should delegate to the configured access validator', async () => {
       await validate(deployment)
 
       expect(accessValidateFn).toHaveBeenCalledWith(deployment)
+    })
+
+    it('should return the configured access validator result', async () => {
+      const result = await validate(deployment)
+
+      expect(result).toBe(delegatedResult)
     })
   })
 
   describe('and the pointers and scene parcels contain the same parcels in a different order', () => {
+    let delegatedResult: ReturnType<typeof validationFailed>
+
     beforeEach(() => {
       deployment.entity.pointers = ['1,2', '1,1']
       deployment.entity.metadata.scene = { base: '1,1', parcels: ['1,1', '1,2'] }
+      delegatedResult = validationFailed('delegated validation result')
+      accessValidateFn.mockResolvedValue(delegatedResult)
     })
 
     it('should delegate to the configured access validator', async () => {
       await validate(deployment)
 
       expect(accessValidateFn).toHaveBeenCalledWith(deployment)
+    })
+
+    it('should return the configured access validator result', async () => {
+      const result = await validate(deployment)
+
+      expect(result).toBe(delegatedResult)
     })
   })
 
@@ -86,6 +109,30 @@ describe('when validating scene access with a base-aware validator', () => {
   describe('and a pointer is a non-canonical alias of the scene parcel', () => {
     beforeEach(() => {
       deployment.entity.pointers = ['01,1']
+    })
+
+    it('should reject the deployment', async () => {
+      const result = await validate(deployment)
+
+      expect(result.ok).toBe(false)
+    })
+  })
+
+  describe('and the entity pointers contain a duplicate parcel', () => {
+    beforeEach(() => {
+      deployment.entity.pointers = ['1,1', '1,1']
+    })
+
+    it('should reject the deployment', async () => {
+      const result = await validate(deployment)
+
+      expect(result.ok).toBe(false)
+    })
+  })
+
+  describe('and the metadata scene parcels contain a duplicate parcel', () => {
+    beforeEach(() => {
+      deployment.entity.metadata.scene.parcels = ['1,1', '1,1']
     })
 
     it('should reject the deployment', async () => {

--- a/test/unit/adapters/content-validator/scene-base-validation.spec.ts
+++ b/test/unit/adapters/content-validator/scene-base-validation.spec.ts
@@ -1,0 +1,84 @@
+import { EntityType } from '@dcl/schemas'
+import { DeploymentToValidate, OK, ValidateFn } from '@dcl/content-validator'
+import { createSceneBaseAwareAccessValidateFn } from '../../../../src/adapters/content-validator/scene-base-validation'
+
+describe('when validating scene access with a base-aware validator', () => {
+  let accessValidateFn: jest.MockedFunction<ValidateFn>
+  let validate: ValidateFn
+  let deployment: DeploymentToValidate
+
+  beforeEach(() => {
+    accessValidateFn = jest.fn().mockResolvedValue(OK)
+    validate = createSceneBaseAwareAccessValidateFn(accessValidateFn)
+    deployment = {
+      entity: {
+        id: 'entity-id',
+        version: 'v3',
+        type: EntityType.SCENE,
+        pointers: ['1,1'],
+        timestamp: Date.now(),
+        content: [],
+        metadata: {
+          main: 'bin/game.js',
+          scene: { base: '1,1', parcels: ['1,1'] }
+        }
+      },
+      files: new Map(),
+      auditInfo: { authChain: [] }
+    }
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('and the base belongs to the pointers and scene parcels', () => {
+    it('should delegate to the configured access validator', async () => {
+      await validate(deployment)
+
+      expect(accessValidateFn).toHaveBeenCalledWith(deployment)
+    })
+  })
+
+  describe('and the base does not belong to the pointers or scene parcels', () => {
+    beforeEach(() => {
+      deployment.entity.metadata.scene.base = '2,2'
+    })
+
+    it('should reject the deployment', async () => {
+      const result = await validate(deployment)
+
+      expect(result.ok).toBe(false)
+    })
+
+    it('should not invoke the configured access validator', async () => {
+      await validate(deployment)
+
+      expect(accessValidateFn).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('and the scene parcels contain a parcel that is not authorized by the pointers', () => {
+    beforeEach(() => {
+      deployment.entity.metadata.scene.parcels = ['1,1', '2,2']
+    })
+
+    it('should reject the deployment', async () => {
+      const result = await validate(deployment)
+
+      expect(result.ok).toBe(false)
+    })
+  })
+
+  describe('and a pointer is a non-canonical alias of the scene parcel', () => {
+    beforeEach(() => {
+      deployment.entity.pointers = ['01,1']
+    })
+
+    it('should reject the deployment', async () => {
+      const result = await validate(deployment)
+
+      expect(result.ok).toBe(false)
+    })
+  })
+})

--- a/test/unit/adapters/content-validator/scene-base-validation.spec.ts
+++ b/test/unit/adapters/content-validator/scene-base-validation.spec.ts
@@ -40,6 +40,19 @@ describe('when validating scene access with a base-aware validator', () => {
     })
   })
 
+  describe('and the pointers and scene parcels contain the same parcels in a different order', () => {
+    beforeEach(() => {
+      deployment.entity.pointers = ['1,2', '1,1']
+      deployment.entity.metadata.scene = { base: '1,1', parcels: ['1,1', '1,2'] }
+    })
+
+    it('should delegate to the configured access validator', async () => {
+      await validate(deployment)
+
+      expect(accessValidateFn).toHaveBeenCalledWith(deployment)
+    })
+  })
+
   describe('and the base does not belong to the pointers or scene parcels', () => {
     beforeEach(() => {
       deployment.entity.metadata.scene.base = '2,2'

--- a/test/unit/adapters/content-validator/scene-base-validation.spec.ts
+++ b/test/unit/adapters/content-validator/scene-base-validation.spec.ts
@@ -81,4 +81,18 @@ describe('when validating scene access with a base-aware validator', () => {
       expect(result.ok).toBe(false)
     })
   })
+
+  describe('and more than one thousand unique canonical parcels match the pointers', () => {
+    beforeEach(() => {
+      const parcels = Array.from({ length: 1001 }, (_, index) => `${index},0`)
+      deployment.entity.pointers = parcels
+      deployment.entity.metadata.scene = { base: '0,0', parcels }
+    })
+
+    it('should delegate platform-specific parcel limits to the configured validator', async () => {
+      await validate(deployment)
+
+      expect(accessValidateFn).toHaveBeenCalledWith(deployment)
+    })
+  })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -711,10 +711,10 @@
     ajv-keywords "^5.1.0"
     mitt "^3.0.1"
 
-"@dcl/schemas@^26.5.0":
-  version "26.5.0"
-  resolved "https://registry.yarnpkg.com/@dcl/schemas/-/schemas-26.5.0.tgz#58beee57bfa8ab15797aa8c54053cdebd4aa250a"
-  integrity sha512-R7/IXI3g4SFGsVKtsLzwUk7romfV9vxWtI0A7pbwlNEyfPtIVgdIqpgHAXD06vDTAyrEZAWMyzhHxcBEoIXniQ==
+"@dcl/schemas@^27.0.0":
+  version "27.0.0"
+  resolved "https://registry.yarnpkg.com/@dcl/schemas/-/schemas-27.0.0.tgz#fbda0293c221db90b83cf89b300c43b4b6111cc6"
+  integrity sha512-KwW6ms2p2k8WW+167ta4AOLwQeqJGV1L8jrPcuRiw06kZhbDnlcnOkTqwBibigeIFtN5aoae9you0W3+SceAiA==
   dependencies:
     ajv "^8.11.0"
     ajv-errors "^3.0.0"


### PR DESCRIPTION
## Summary

- add defense-in-depth validation for scene pointers, parcels, and base
- run the integrity check in the production content-validator adapter
- reject malformed scene metadata before access validation can authorize it
- preserve order-independent pointer and parcel set comparison

## Rollout note

This intentionally tightens validation for new, replayed, or backfilled scene deployments. Entity pointers must equal the unique canonical metadata.scene.parcels set, and metadata.scene.base must be included in that set. Deployments that were historically accepted without satisfying these invariants will be rejected when replayed or revalidated by an upgraded Catalyst.

## Verification

- build and lint passed
- full unit suite passed
- focused scene integrity suite passed with 7 tests
- different pointer and parcel ordering is covered
- diff checks passed