### PR TITLE
fix: associate third party item content with its own deployment

### DIFF
--- a/src/logic/deployments/component.ts
+++ b/src/logic/deployments/component.ts
@@ -17,7 +17,7 @@ import { FailedDeployment } from '../../adapters/failed-deployments'
 import { DatabaseClient, DatabaseTransactionalClient } from '../../adapters/database'
 import { IGNORING_FIX_ERROR } from '../deployment-service'
 import { AppComponents, DeploymentField, DeploymentId, EntityVersion } from '../../types'
-import { DeploymentPointerChanges, IDeploymentsComponent } from './types'
+import { DeploymentPointerChanges, IDeploymentsComponent, ThirdPartyItemDeploymentRow } from './types'
 
 export async function isEntityDeployed(
   database: DatabaseClient,
@@ -359,19 +359,26 @@ export const createDeploymentsComponent = (
       SELECT * FROM active_third_party_collection_items_deployments_with_content
       WHERE entity_id = ANY(${entityIds});
     `
-    const deployments = await database.queryWithValues<
-      HistoricalDeploymentsRow & { content_keys: string[]; content_hashes: string[] }
-    >(query, 'get_deployments_for_active_third_party_collection_items_by_entity_ids')
+    const deployments = await database.queryWithValues<ThirdPartyItemDeploymentRow>(
+      query,
+      'get_deployments_for_active_third_party_collection_items_by_entity_ids'
+    )
+    // The view exposes the deployment key as `deployment_id`, so rows must be keyed and looked up by
+    // that column. Keying by the absent `id` collapsed every row onto a single `undefined` entry and
+    // served the last row's files as the content of every entity in the batch.
     const contents = new Map<DeploymentId, DeploymentContent[]>(
       deployments.rows.map((row) => [
-        row.id,
+        row.deployment_id,
         row.content_keys.map((content_key, index) => ({ key: content_key, hash: row.content_hashes[index] }))
       ])
     )
 
     return deployments.rows.map(
-      (row: HistoricalDeploymentsRow & { content_keys: string[]; content_hashes: string[] }): Deployment =>
-        buildDeploymentFromHistoricalDeployment(buildHistoricalDeploymentsFromRow(row), contents)
+      (row: ThirdPartyItemDeploymentRow): Deployment =>
+        buildDeploymentFromHistoricalDeployment(
+          buildHistoricalDeploymentsFromRow({ ...row, id: row.deployment_id }),
+          contents
+        )
     )
   }
 

--- a/src/logic/deployments/component.ts
+++ b/src/logic/deployments/component.ts
@@ -17,7 +17,12 @@ import { FailedDeployment } from '../../adapters/failed-deployments'
 import { DatabaseClient, DatabaseTransactionalClient } from '../../adapters/database'
 import { IGNORING_FIX_ERROR } from '../deployment-service'
 import { AppComponents, DeploymentField, DeploymentId, EntityVersion } from '../../types'
-import { DeploymentPointerChanges, IDeploymentsComponent, ThirdPartyItemDeploymentRow } from './types'
+import {
+  DeploymentPointerChanges,
+  IDeploymentsComponent,
+  MappableDeploymentRow,
+  ThirdPartyItemDeploymentRow
+} from './types'
 
 export async function isEntityDeployed(
   database: DatabaseClient,
@@ -198,9 +203,7 @@ export function buildDeploymentFromHistoricalDeployment(
 // Takes only the columns it reads, so rows from sources that expose a subset of `deployments`
 // (such as the third-party materialized view, which has no `deleter_deployment`) can be mapped
 // without claiming columns they do not carry.
-export function buildHistoricalDeploymentsFromRow(
-  row: Omit<HistoricalDeploymentsRow, 'deleter_deployment'>
-): HistoricalDeployment {
+export function buildHistoricalDeploymentsFromRow(row: MappableDeploymentRow): HistoricalDeployment {
   return {
     deploymentId: row.id,
     entityType: row.entity_type,

--- a/src/logic/deployments/component.ts
+++ b/src/logic/deployments/component.ts
@@ -195,7 +195,12 @@ export function buildDeploymentFromHistoricalDeployment(
   }
 }
 
-export function buildHistoricalDeploymentsFromRow(row: HistoricalDeploymentsRow): HistoricalDeployment {
+// Takes only the columns it reads, so rows from sources that expose a subset of `deployments`
+// (such as the third-party materialized view, which has no `deleter_deployment`) can be mapped
+// without claiming columns they do not carry.
+export function buildHistoricalDeploymentsFromRow(
+  row: Omit<HistoricalDeploymentsRow, 'deleter_deployment'>
+): HistoricalDeployment {
   return {
     deploymentId: row.id,
     entityType: row.entity_type,

--- a/src/logic/deployments/index.ts
+++ b/src/logic/deployments/index.ts
@@ -14,4 +14,9 @@ export {
   getPointerChanges,
   createDeploymentsComponent
 } from './component'
-export type { IDeploymentsComponent, DeploymentPointerChanges, PointerChangesFilters } from './types'
+export type {
+  IDeploymentsComponent,
+  DeploymentPointerChanges,
+  PointerChangesFilters,
+  ThirdPartyItemDeploymentRow
+} from './types'

--- a/src/logic/deployments/index.ts
+++ b/src/logic/deployments/index.ts
@@ -14,10 +14,7 @@ export {
   getPointerChanges,
   createDeploymentsComponent
 } from './component'
-export type {
-  IDeploymentsComponent,
-  DeploymentPointerChanges,
-  PointerChangesFilters,
-  MappableDeploymentRow,
-  ThirdPartyItemDeploymentRow
-} from './types'
+// The row-shape types (MappableDeploymentRow, ThirdPartyItemDeploymentRow) are deliberately absent:
+// they describe SQL result shapes this component consumes internally, not its public surface. The
+// component and its tests import them from './types' directly.
+export type { IDeploymentsComponent, DeploymentPointerChanges, PointerChangesFilters } from './types'

--- a/src/logic/deployments/index.ts
+++ b/src/logic/deployments/index.ts
@@ -18,5 +18,6 @@ export type {
   IDeploymentsComponent,
   DeploymentPointerChanges,
   PointerChangesFilters,
+  MappableDeploymentRow,
   ThirdPartyItemDeploymentRow
 } from './types'

--- a/src/logic/deployments/types.ts
+++ b/src/logic/deployments/types.ts
@@ -5,15 +5,6 @@ import { HistoricalDeploymentsRow } from '../../adapters/deployments-repository'
 import { DeploymentId } from '../../types'
 
 /**
- * A row of `active_third_party_collection_items_deployments_with_content`, listing the view's columns
- * exactly. It is deliberately spelled out rather than derived from `HistoricalDeploymentsRow`: the
- * view renames `deployments.id` to `deployment_id`, joins in the `active_pointers` pointer, inlines
- * the deployment's content files, and selects neither `deleter_deployment` nor `overwritten_by`
- * (every row is an active, non-deleted deployment by construction). Deriving the type would promise
- * columns that never arrive, which is what let a reader key its content map by a non-existent `id`.
- * Keep this in sync with the view definition in `src/migrations/scripts`.
- */
-/**
  * The columns `buildHistoricalDeploymentsFromRow` reads. Declared as a `Pick<>` rather than the whole
  * `HistoricalDeploymentsRow` (or an `Omit<>` of it) so the mapper's input is closed: a column added to
  * `HistoricalDeploymentsRow` later cannot silently become a required input of a mapper that never
@@ -34,6 +25,15 @@ export type MappableDeploymentRow = Pick<
   | 'overwritten_by'
 >
 
+/**
+ * A row of `active_third_party_collection_items_deployments_with_content`, listing the view's columns
+ * exactly. It is deliberately spelled out rather than derived from `HistoricalDeploymentsRow`: the
+ * view renames `deployments.id` to `deployment_id`, joins in the `active_pointers` pointer, inlines
+ * the deployment's content files, and selects neither `deleter_deployment` nor `overwritten_by`
+ * (every row is an active, non-deleted deployment by construction). Deriving the type would promise
+ * columns that never arrive, which is what let a reader key its content map by a non-existent `id`.
+ * Keep this in sync with the view definition in `src/migrations/scripts`.
+ */
 export type ThirdPartyItemDeploymentRow = {
   pointer: string
   entity_id: string

--- a/src/logic/deployments/types.ts
+++ b/src/logic/deployments/types.ts
@@ -1,6 +1,7 @@
 import { AuthChain } from '@dcl/crypto'
 import { EntityType, PointerChangesSyncDeployment } from '@dcl/schemas'
 import { Deployment, DeploymentFilters } from '../../deployment-types'
+import { HistoricalDeploymentsRow } from '../../adapters/deployments-repository'
 import { DeploymentId } from '../../types'
 
 /**
@@ -12,6 +13,27 @@ import { DeploymentId } from '../../types'
  * columns that never arrive, which is what let a reader key its content map by a non-existent `id`.
  * Keep this in sync with the view definition in `src/migrations/scripts`.
  */
+/**
+ * The columns `buildHistoricalDeploymentsFromRow` reads. Declared as a `Pick<>` rather than the whole
+ * `HistoricalDeploymentsRow` (or an `Omit<>` of it) so the mapper's input is closed: a column added to
+ * `HistoricalDeploymentsRow` later cannot silently become a required input of a mapper that never
+ * reads it, which would break callers whose source exposes only a subset of `deployments`.
+ */
+export type MappableDeploymentRow = Pick<
+  HistoricalDeploymentsRow,
+  | 'id'
+  | 'entity_type'
+  | 'entity_id'
+  | 'entity_pointers'
+  | 'entity_timestamp'
+  | 'entity_metadata'
+  | 'deployer_address'
+  | 'version'
+  | 'auth_chain'
+  | 'local_timestamp'
+  | 'overwritten_by'
+>
+
 export type ThirdPartyItemDeploymentRow = {
   pointer: string
   entity_id: string

--- a/src/logic/deployments/types.ts
+++ b/src/logic/deployments/types.ts
@@ -1,5 +1,18 @@
 import { PointerChangesSyncDeployment } from '@dcl/schemas'
 import { Deployment, DeploymentFilters } from '../../deployment-types'
+import { HistoricalDeploymentsRow } from '../../adapters/deployments-repository'
+import { DeploymentId } from '../../types'
+
+/**
+ * A row of `active_third_party_collection_items_deployments_with_content`. The view renames
+ * `deployments.id` to `deployment_id` and inlines the deployment's content files, so it is not a
+ * `HistoricalDeploymentsRow`: typing it as one silently promises an `id` column that never arrives.
+ */
+export type ThirdPartyItemDeploymentRow = Omit<HistoricalDeploymentsRow, 'id'> & {
+  deployment_id: DeploymentId
+  content_keys: string[]
+  content_hashes: string[]
+}
 
 export interface IDeploymentsComponent {
   getDeploymentsForActiveThirdPartyItemsByEntityIds(entityIds: string[]): Promise<Deployment[]>

--- a/src/logic/deployments/types.ts
+++ b/src/logic/deployments/types.ts
@@ -1,15 +1,29 @@
-import { PointerChangesSyncDeployment } from '@dcl/schemas'
+import { AuthChain } from '@dcl/crypto'
+import { EntityType, PointerChangesSyncDeployment } from '@dcl/schemas'
 import { Deployment, DeploymentFilters } from '../../deployment-types'
-import { HistoricalDeploymentsRow } from '../../adapters/deployments-repository'
 import { DeploymentId } from '../../types'
 
 /**
- * A row of `active_third_party_collection_items_deployments_with_content`. The view renames
- * `deployments.id` to `deployment_id` and inlines the deployment's content files, so it is not a
- * `HistoricalDeploymentsRow`: typing it as one silently promises an `id` column that never arrives.
+ * A row of `active_third_party_collection_items_deployments_with_content`, listing the view's columns
+ * exactly. It is deliberately spelled out rather than derived from `HistoricalDeploymentsRow`: the
+ * view renames `deployments.id` to `deployment_id`, joins in the `active_pointers` pointer, inlines
+ * the deployment's content files, and selects neither `deleter_deployment` nor `overwritten_by`
+ * (every row is an active, non-deleted deployment by construction). Deriving the type would promise
+ * columns that never arrive, which is what let a reader key its content map by a non-existent `id`.
+ * Keep this in sync with the view definition in `src/migrations/scripts`.
  */
-export type ThirdPartyItemDeploymentRow = Omit<HistoricalDeploymentsRow, 'id'> & {
+export type ThirdPartyItemDeploymentRow = {
+  pointer: string
+  entity_id: string
   deployment_id: DeploymentId
+  entity_type: EntityType
+  entity_pointers: string[]
+  entity_timestamp: number
+  entity_metadata: any
+  deployer_address: string
+  version: string
+  auth_chain: AuthChain
+  local_timestamp: number
   content_keys: string[]
   content_hashes: string[]
 }

--- a/test/integration/controller/active-entities.spec.ts
+++ b/test/integration/controller/active-entities.spec.ts
@@ -442,6 +442,41 @@ describe('Integration - Get Active Entities', () => {
       expect(response.entities).toHaveLength(3)
     })
 
+    it('when fetching several entities by collection name, then each one keeps its own content', async () => {
+      const pointer1 = ['urn:decentraland:mumbai:collections-thirdparty:aThirdParty:winterCollection:1']
+      const deployResult1 = await buildDeployData(pointer1, {
+        metadata: { a: 'first item' },
+        contentPaths: [getIntegrationResourcePathFor('some-binary-file.png')]
+      })
+      const pointer2 = ['urn:decentraland:mumbai:collections-thirdparty:aThirdParty:winterCollection:2']
+      const deployResult2 = await buildDeployData(pointer2, {
+        metadata: { a: 'second item' },
+        contentPaths: [getIntegrationResourcePathFor('some-text-file.txt')]
+      })
+
+      await server.deployEntity(deployResult1.deployData)
+      await server.deployEntity(deployResult2.deployData)
+
+      // Deploying warms the in-process entity cache, which would serve these reads without ever
+      // touching the materialized view. Drop it so the listing is resolved from the DB, the way a
+      // server that restarted or evicted these entries resolves it.
+      server.components.activeEntities.reset()
+
+      const response = await fetchActiveEntityByUrnPrefix(
+        server,
+        'urn:decentraland:mumbai:collections-thirdparty:aThirdParty'
+      )
+
+      expect(response.total).toBe(2)
+      expect(response.entities).toHaveLength(2)
+
+      for (const deployResult of [deployResult1, deployResult2]) {
+        const entity = response.entities.find((e) => e.id === deployResult.entity.id)
+        expect(entity).toBeDefined()
+        expect(entity!.content).toEqual(deployResult.entity.content)
+      }
+    })
+
     it('when fetching entities by not matching urn prefix, then none is retrieved', async () => {
       const pointer = ['urn:dcl:collection:itemId']
       const deployResult = await buildDeployData(pointer, {

--- a/test/mocks/logger-component-mock.ts
+++ b/test/mocks/logger-component-mock.ts
@@ -1,5 +1,6 @@
 import { ILoggerComponent } from '@well-known-components/interfaces'
 import { HistoricalDeploymentsRow } from '../../src/adapters/deployments-repository'
+import { ThirdPartyItemDeploymentRow } from '../../src/logic/deployments'
 import { EntityType } from '@dcl/schemas'
 
 export function createLogsMockedComponent({
@@ -38,10 +39,16 @@ export const createHistoricalDeploymentRowMock = (
   ...overrides
 })
 
-export const createHistoricalDeploymentRowWithContentMock = (
-  overrides?: Partial<jest.Mocked<HistoricalDeploymentsRow & { content_keys: string[]; content_hashes: string[] }>>
-): HistoricalDeploymentsRow & { content_keys: string[]; content_hashes: string[] } => ({
-  ...createHistoricalDeploymentRowMock(overrides),
-  content_keys: overrides?.content_keys ?? ['1', '2'],
-  content_hashes: overrides?.content_hashes ?? ['hash1', 'hash2']
-})
+// Mirrors the third-party materialized view, which exposes `deployment_id` rather than `id`. Keep the
+// column names in sync with the view: mocking an `id` here hides content-association bugs in its reader.
+export const createThirdPartyItemDeploymentRowMock = (
+  overrides?: Partial<jest.Mocked<ThirdPartyItemDeploymentRow>>
+): ThirdPartyItemDeploymentRow => {
+  const { id: _id, ...rowWithoutId } = createHistoricalDeploymentRowMock(overrides as Partial<HistoricalDeploymentsRow>)
+  return {
+    ...rowWithoutId,
+    deployment_id: overrides?.deployment_id ?? 123,
+    content_keys: overrides?.content_keys ?? ['1', '2'],
+    content_hashes: overrides?.content_hashes ?? ['hash1', 'hash2']
+  }
+}

--- a/test/mocks/logger-component-mock.ts
+++ b/test/mocks/logger-component-mock.ts
@@ -39,16 +39,25 @@ export const createHistoricalDeploymentRowMock = (
   ...overrides
 })
 
-// Mirrors the third-party materialized view, which exposes `deployment_id` rather than `id`. Keep the
-// column names in sync with the view: mocking an `id` here hides content-association bugs in its reader.
+// Mirrors the third-party materialized view column for column. Built independently of
+// createHistoricalDeploymentRowMock on purpose: the view exposes `deployment_id` instead of `id` and
+// carries no `deleter_deployment`/`overwritten_by`, so reusing the deployments-row mock would hand the
+// reader columns production never returns and hide content-association bugs.
 export const createThirdPartyItemDeploymentRowMock = (
   overrides?: Partial<jest.Mocked<ThirdPartyItemDeploymentRow>>
-): ThirdPartyItemDeploymentRow => {
-  const { id: _id, ...rowWithoutId } = createHistoricalDeploymentRowMock(overrides as Partial<HistoricalDeploymentsRow>)
-  return {
-    ...rowWithoutId,
-    deployment_id: overrides?.deployment_id ?? 123,
-    content_keys: overrides?.content_keys ?? ['1', '2'],
-    content_hashes: overrides?.content_hashes ?? ['hash1', 'hash2']
-  }
-}
+): ThirdPartyItemDeploymentRow => ({
+  pointer: 'urn:decentraland:matic:collections-thirdparty:aThirdParty:aCollection:1',
+  entity_id: '123',
+  deployment_id: 123,
+  entity_type: EntityType.WEARABLE,
+  entity_pointers: ['urn:decentraland:matic:collections-thirdparty:aThirdParty:aCollection:1'],
+  entity_timestamp: 123,
+  entity_metadata: { v: { name: '123' } },
+  deployer_address: '123',
+  version: '123',
+  auth_chain: [],
+  local_timestamp: 123,
+  content_keys: ['1', '2'],
+  content_hashes: ['hash1', 'hash2'],
+  ...overrides
+})

--- a/test/mocks/logger-component-mock.ts
+++ b/test/mocks/logger-component-mock.ts
@@ -1,6 +1,6 @@
 import { ILoggerComponent } from '@well-known-components/interfaces'
 import { HistoricalDeploymentsRow } from '../../src/adapters/deployments-repository'
-import { ThirdPartyItemDeploymentRow } from '../../src/logic/deployments'
+import { ThirdPartyItemDeploymentRow } from '../../src/logic/deployments/types'
 import { EntityType } from '@dcl/schemas'
 
 export function createLogsMockedComponent({

--- a/test/unit/logic/deployments-componen.spec.ts
+++ b/test/unit/logic/deployments-componen.spec.ts
@@ -1,19 +1,12 @@
 import { ILoggerComponent } from '@well-known-components/interfaces'
 import {
-  buildDeploymentFromHistoricalDeployment,
-  buildHistoricalDeploymentsFromRow,
   createDeploymentsComponent,
-  IDeploymentsComponent
+  IDeploymentsComponent,
+  ThirdPartyItemDeploymentRow
 } from '../../../src/logic/deployments'
 import { IDatabaseComponent } from '../../../src/adapters/database'
 import { createDatabaseMockedComponent } from '../../mocks/database-component-mock'
-import {
-  createHistoricalDeploymentRowWithContentMock,
-  createLogsMockedComponent
-} from '../../mocks/logger-component-mock'
-import { HistoricalDeploymentsRow } from '../../../src/adapters/deployments-repository'
-import { DeploymentContent } from '../../../src/deployment-types'
-import { DeploymentId } from '../../../src/types'
+import { createThirdPartyItemDeploymentRowMock, createLogsMockedComponent } from '../../mocks/logger-component-mock'
 
 let deployments: IDeploymentsComponent
 let database: jest.Mocked<IDatabaseComponent>
@@ -43,36 +36,18 @@ describe('when getting the deployments for active third party collection items b
   })
 
   describe('when entity ids are found', () => {
-    let rowEntities: HistoricalDeploymentsRow[]
-    let contents: Map<DeploymentId, DeploymentContent[]>
+    let rowEntities: ThirdPartyItemDeploymentRow[]
 
     beforeEach(() => {
-      contents = new Map([
-        [
-          1,
-          [
-            { key: '1', hash: 'hash1' },
-            { key: '2', hash: 'hash2' }
-          ]
-        ],
-        [
-          2,
-          [
-            { key: '3', hash: 'hash3' },
-            { key: '4', hash: 'hash4' }
-          ]
-        ]
-      ])
-
       rowEntities = [
-        createHistoricalDeploymentRowWithContentMock({
-          id: 1,
+        createThirdPartyItemDeploymentRowMock({
+          deployment_id: 1,
           entity_id: '123',
           content_keys: ['1', '2'],
           content_hashes: ['hash1', 'hash2']
         }),
-        createHistoricalDeploymentRowWithContentMock({
-          id: 2,
+        createThirdPartyItemDeploymentRowMock({
+          deployment_id: 2,
           entity_id: '456',
           content_keys: ['3', '4'],
           content_hashes: ['hash3', 'hash4']
@@ -88,8 +63,20 @@ describe('when getting the deployments for active third party collection items b
     it('should return the deployments', async () => {
       const result = await deployments.getDeploymentsForActiveThirdPartyItemsByEntityIds(['123', '456'])
       expect(result).toEqual([
-        buildDeploymentFromHistoricalDeployment(buildHistoricalDeploymentsFromRow(rowEntities[0]), contents),
-        buildDeploymentFromHistoricalDeployment(buildHistoricalDeploymentsFromRow(rowEntities[1]), contents)
+        expect.objectContaining({ entityId: '123' }),
+        expect.objectContaining({ entityId: '456' })
+      ])
+    })
+
+    it('should return each deployment with its own content files', async () => {
+      const result = await deployments.getDeploymentsForActiveThirdPartyItemsByEntityIds(['123', '456'])
+      expect(result[0].content).toEqual([
+        { key: '1', hash: 'hash1' },
+        { key: '2', hash: 'hash2' }
+      ])
+      expect(result[1].content).toEqual([
+        { key: '3', hash: 'hash3' },
+        { key: '4', hash: 'hash4' }
       ])
     })
   })

--- a/test/unit/logic/deployments-componen.spec.ts
+++ b/test/unit/logic/deployments-componen.spec.ts
@@ -1,9 +1,6 @@
 import { ILoggerComponent } from '@well-known-components/interfaces'
-import {
-  createDeploymentsComponent,
-  IDeploymentsComponent,
-  ThirdPartyItemDeploymentRow
-} from '../../../src/logic/deployments'
+import { createDeploymentsComponent, IDeploymentsComponent } from '../../../src/logic/deployments'
+import { ThirdPartyItemDeploymentRow } from '../../../src/logic/deployments/types'
 import { IDatabaseComponent } from '../../../src/adapters/database'
 import { createDatabaseMockedComponent } from '../../mocks/database-component-mock'
 import { createThirdPartyItemDeploymentRowMock, createLogsMockedComponent } from '../../mocks/logger-component-mock'


### PR DESCRIPTION
## Problem

`GET /entities/active/collections/:collectionUrn` serves the wrong content files for third-party collections. Content from one deployment is returned for other third-party entities, so the `content` in the response does not match the entity's Merkle-committed `metadata.content`.

## Cause

`getDeploymentsForActiveThirdPartyItemsByEntityIds` keys its content map by `row.id`:

```ts
const contents = new Map(deployments.rows.map((row) => [row.id, ...]))
```

but `active_third_party_collection_items_deployments_with_content` selects `d.id as deployment_id` and has no `id` column. Every row therefore maps to `undefined`, the `Map` constructor keeps only the last one, and `content.get(undefined)` hands that last row's files to every entity in the batch.

The query result was annotated as `HistoricalDeploymentsRow & { content_keys, content_hashes }` — a type that promises an `id` the view never returns — so the compiler could not see the mismatch.

The reader batches a whole page of entity ids per request, so with the default page size roughly 99 of every 100 listed items were served foreign content. The survivors are last-in-batch rows and entities already warm in the in-process entity cache, which `findThirdPartyItemsEntities` consults before touching the database.

## Fix

- Key and look up the content map by `deployment_id`.
- Add `ThirdPartyItemDeploymentRow` describing what the view actually returns (`Omit<HistoricalDeploymentsRow, 'id'> & { deployment_id, content_keys, content_hashes }`), so this class of mismatch is a compile error rather than a silent `undefined`.

Only the reader mis-joined. The view aggregates content per deployment correctly and nothing incorrect was persisted, so **no data repair is needed** — deploying the fix is sufficient.

## Tests

The existing unit test could not catch this: its mock supplied an `id` column the view does not have, and it asserted against the same builder functions it was exercising, so it passed either way.

- The row mock now mirrors the view's real columns, and the unit test asserts each deployment carries its own content files. Verified it fails when the old lookup is reinstated.
- Added an integration test deploying two third-party items with distinct files and asserting each entity keeps its own content. It resets the entity cache before reading, because deploying warms that cache and the listing would otherwise never reach the database — which is why no existing integration test caught this either.

`tsc`, lint, the full unit suite (363 tests) and the active-entities integration suite (24 tests) pass.