### PR TITLE
chore: bump @dcl/content-validator to 8.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@dcl/catalyst-api-specs": "^3.8.0",
     "@dcl/catalyst-contracts": "^4.4.2",
     "@dcl/catalyst-storage": "5.0.0",
-    "@dcl/content-validator": "^8.0.0",
+    "@dcl/content-validator": "^8.1.0",
     "@dcl/core-commons": "^0.10.1",
     "@dcl/crypto": "^3.7.0",
     "@dcl/fetch-component": "1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -560,10 +560,10 @@
   dependencies:
     ethers "^5.6.8"
 
-"@dcl/content-validator@^8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@dcl/content-validator/-/content-validator-8.0.0.tgz#3827c466df930b60c8c75c8e64d0ec6657e79725"
-  integrity sha512-/uN09neoHIPPFonwozSTiyHsvmKl0/tgmLd54LXa3+bmkp8Bsy9XEOBqxCknVFgMog2TCfyU6cHDRN0bbR8RoA==
+"@dcl/content-validator@^8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@dcl/content-validator/-/content-validator-8.1.0.tgz#2207cd414cc14c3cb1effae37676d5d4b516b62c"
+  integrity sha512-viWvoolSis/lwQXXotFyQ9ycLdmORkahzIIlqXuUO9HoOKuZlg0H+yjnA6da6Hk7Om6fzUjAvTiRf8k2UAHilw==
   dependencies:
     "@dcl/block-indexer" "^1.1.2"
     "@dcl/content-hash-tree" "^1.1.4"


### PR DESCRIPTION
## Why

`@dcl/content-validator@8.1.0` adds a validation for profile deployments: an avatar's `userId` and `ethAddress` must match the entity pointer. This picks it up here so the rule runs at deploy time.

Until now those fields were only checked for shape — `@dcl/schemas` requires `ethAddress` to look like an address and does not list `userId` in its `required` set — while the pointer validation compared the pointer against the auth-chain signer and left the avatar metadata alone. A profile could therefore be deployed whose stored identity named a different address than the pointer it is served under, and consumers of the profile endpoints treat those fields as the address of the profile.

## What changed

Dependency bump only, `^8.0.0` → `^8.1.0`, resolving `8.0.0` → `8.1.0`. No changes needed on this side: the check lives in the shared profile pointer access path that `createPointerCommonAccessValidateFn` already runs, so both the on-chain and subgraph access validators inherit it.

The rule is gated on `PROFILE_IDENTITY_TIMESTAMP` (`2026-08-13T00:00:00Z`, overridable through the environment like the ADR timestamps), so:

- profiles deployed before the cutoff keep validating, which matters for re-validation of historical content while bootstrapping — a large amount of existing profiles predate the rule;
- new deployments cannot be dated before it to avoid the check, since `localChecks` already bounds a submitted `entity.timestamp` to `REQUEST_TTL_BACKWARDS` (20 minutes by default) behind wall-clock;
- default profiles are exempt, as their pointer is a name (`default10`) rather than an address and their metadata legitimately carries the Decentraland deployer address.

Only fields that are present are compared, so a profile omitting `userId` keeps working, and the comparison is case-insensitive so checksummed values pass.

## Verification

- `tsc -b` clean.
- `363/363` unit tests pass.
- `yarn.lock` diff is the single `@dcl/content-validator` entry with no transitive changes, so `8.1.0` carries the same dependency set as `8.0.0`.
- Confirmed the resolved package exports `PROFILE_IDENTITY_TIMESTAMP` as `1786579200000` (`2026-08-13T00:00:00Z`).

Integration tests were not run locally — they need the Postgres testcontainer and the image pull did not finish in a reasonable time here — so I am relying on CI for those.

## Related

- decentraland/core-libs#63 is the release this bumps to.