### PR TITLE
fix: reflect requested CORS headers so ADR-44 signed fetch works from browsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,11 +47,11 @@
     "@dcl/catalyst-contracts": "^4.4.2",
     "@dcl/catalyst-storage": "5.0.0",
     "@dcl/content-validator": "^8.1.0",
-    "@dcl/core-commons": "^0.10.1",
+    "@dcl/core-commons": "^0.11.0",
     "@dcl/crypto": "^3.7.0",
     "@dcl/fetch-component": "1.1.1",
     "@dcl/hashing": "1.2.0",
-    "@dcl/http-server": "^2.2.1",
+    "@dcl/http-server": "^2.4.0",
     "@dcl/http-tracer-component": "^2.0.1",
     "@dcl/job-component": "^0.3.5",
     "@dcl/memory-cache-component": "^2.4.3",
@@ -120,7 +120,7 @@
   },
   "resolutions": {
     "@dcl/catalyst-storage": "5.0.0",
-    "@dcl/core-commons": "0.10.1",
+    "@dcl/core-commons": "0.11.0",
     "@dcl/http-server/path-to-regexp": "^6.2.1",
     "express/path-to-regexp": "0.1.7"
   },

--- a/src/components.ts
+++ b/src/components.ts
@@ -437,12 +437,13 @@ export async function initComponentsWithEnv(env: Environment): Promise<AppCompon
     {
       cors: {
         // Requests are authenticated by signature (auth-chain), not cookies/sessions, so credentialed
-        // CORS is unnecessary — and `origin: true` + `credentials: true` is the wildcard-with-credentials
-        // pattern that would let any site ride a user's credentials the moment cookie auth is added.
-        origin: true,
-        methods: ['GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'],
-        allowedHeaders: ['Cache-Control', 'Content-Type', 'Origin', 'Accept', 'User-Agent', 'X-Upload-Origin'],
-        maxAge: 86400
+        // CORS is unnecessary — and `*` + `credentials: true` is the wildcard-with-credentials pattern
+        // that would let any site ride a user's credentials the moment cookie auth is added.
+        origin: '*',
+        methods: ['GET', 'HEAD', 'POST', 'OPTIONS'],
+        // No `allowedHeaders` on purpose: the preflight reflects whatever was requested. ADR-44 sends
+        // `X-Identity-Auth-Chain-<N>` for an open-ended N, so any fixed list has to guess a chain depth.
+        maxAge: 600
       }
     }
   )

--- a/test/integration/controller/cors.spec.ts
+++ b/test/integration/controller/cors.spec.ts
@@ -1,0 +1,109 @@
+import LeakDetector from 'jest-leak-detector'
+import { createDefaultServer } from '../simpleTestEnvironment'
+import { TestProgram } from '../TestProgram'
+
+describe('Integration - CORS', () => {
+  let server: TestProgram
+
+  beforeAll(async () => {
+    server = await createDefaultServer()
+  })
+
+  afterAll(async () => {
+    jest.restoreAllMocks()
+    const detector = new LeakDetector(server)
+    await server.stopProgram()
+    server = null as any
+    expect(await detector.isLeaking()).toBe(false)
+  })
+
+  describe('when preflighting a request that carries the ADR-44 signed-fetch identity headers', () => {
+    const requestedHeaders =
+      'x-identity-auth-chain-0,x-identity-auth-chain-1,x-identity-auth-chain-2,x-identity-timestamp,x-identity-metadata'
+    let response: Response
+
+    beforeEach(async () => {
+      response = await fetch(`${server.getUrl()}/available-content?cid=abc`, {
+        method: 'OPTIONS',
+        headers: {
+          origin: 'https://play.decentraland.org',
+          'access-control-request-method': 'GET',
+          'access-control-request-headers': requestedHeaders
+        }
+      })
+    })
+
+    it('should answer the preflight successfully', () => {
+      expect(response.status).toBe(204)
+    })
+
+    it('should grant every requested identity header', () => {
+      expect(response.headers.get('access-control-allow-headers')).toBe(requestedHeaders)
+    })
+
+    it('should allow the requested method', () => {
+      expect(response.headers.get('access-control-allow-methods')).toContain('GET')
+    })
+
+    it('should allow any origin', () => {
+      expect(response.headers.get('access-control-allow-origin')).toBe('*')
+    })
+
+    it('should vary on the requested headers so a shared cache keys preflights per header set', () => {
+      expect(response.headers.get('vary')).toBe('Access-Control-Request-Headers')
+    })
+  })
+
+  describe('when preflighting a request whose auth chain is deeper than a fixed allow-list would anticipate', () => {
+    const requestedHeaders = Array.from({ length: 12 }, (_, index) => `x-identity-auth-chain-${index}`).join(',')
+    let response: Response
+
+    beforeEach(async () => {
+      response = await fetch(`${server.getUrl()}/available-content?cid=abc`, {
+        method: 'OPTIONS',
+        headers: {
+          origin: 'https://play.decentraland.org',
+          'access-control-request-method': 'GET',
+          'access-control-request-headers': requestedHeaders
+        }
+      })
+    })
+
+    it('should grant the whole chain regardless of its depth', () => {
+      expect(response.headers.get('access-control-allow-headers')).toBe(requestedHeaders)
+    })
+  })
+
+  describe('when preflighting a request that carries no identity headers', () => {
+    let response: Response
+
+    beforeEach(async () => {
+      response = await fetch(`${server.getUrl()}/available-content?cid=abc`, {
+        method: 'OPTIONS',
+        headers: {
+          origin: 'https://play.decentraland.org',
+          'access-control-request-method': 'GET',
+          'access-control-request-headers': 'content-type,cache-control'
+        }
+      })
+    })
+
+    it('should keep granting the headers uploads and cache-aware clients rely on', () => {
+      expect(response.headers.get('access-control-allow-headers')).toBe('content-type,cache-control')
+    })
+  })
+
+  describe('when a cross-origin client makes an actual request', () => {
+    let response: Response
+
+    beforeEach(async () => {
+      response = await fetch(`${server.getUrl()}/available-content?cid=abc`, {
+        headers: { origin: 'https://play.decentraland.org' }
+      })
+    })
+
+    it('should allow any origin to read the response', () => {
+      expect(response.headers.get('access-control-allow-origin')).toBe('*')
+    })
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -575,10 +575,10 @@
     ms "^2.1.3"
     p-queue "^6.6.2"
 
-"@dcl/core-commons@0.10.1", "@dcl/core-commons@^0.10.1":
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/@dcl/core-commons/-/core-commons-0.10.1.tgz#f6b38fd623a5043a571e80d7ba1ac40e9db41973"
-  integrity sha512-iLBpIg15czlzV7No5Wzb3FyreXpqYx8YnVJ8xYKczXpl6C3eqBQoqEA02hRkd/UASbzqcPJeG1wH1wHSxYTmQw==
+"@dcl/core-commons@0.10.1", "@dcl/core-commons@0.11.0", "@dcl/core-commons@^0.10.1", "@dcl/core-commons@^0.11.0":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@dcl/core-commons/-/core-commons-0.11.0.tgz#a5d36935cc1d4151073971cfa82a17f96d403298"
+  integrity sha512-VJ6FgMQoF242slJy1EDJkfkOqYKrywSKJf/ZNg5buGsZj2CAc+RLyBnp0XSl/iCp3VJfpJA3lm5yuKCqWralCA==
   dependencies:
     "@well-known-components/interfaces" "^1.5.2"
 
@@ -623,12 +623,12 @@
   resolved "https://registry.npmjs.org/@dcl/hashing/-/hashing-3.0.4.tgz"
   integrity sha512-Cg+MoIOn+BYmQV2q8zSFnNYY+GldlnUazwBnfgrq3i66ZxOaZ65h01btd8OUtSAlfWG4VTNIOHDjtKqmuwJNBg==
 
-"@dcl/http-server@^2.2.1":
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/@dcl/http-server/-/http-server-2.2.1.tgz#9b518de3afc54aa7cb9591906a7151375e6d7b5f"
-  integrity sha512-ibhFXABkKpK2X3W83Y1FYM3lShP1NrEzpxE4HtphPZol4oq/GOLNa64Kj7mOR1Rw7Vo5dTjJQFMPq061SvxrwA==
+"@dcl/http-server@^2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@dcl/http-server/-/http-server-2.4.0.tgz#8fa7c175f43854146137eec2951796a84c9f0363"
+  integrity sha512-MauDdR9LrqCJSDvvXPoChMybsmxG0RvsRr3Wa2y39W7lTBrqbAFkHUYurL1KcEWjrl1MnX2Lp5ny97fDRFmhIA==
   dependencies:
-    "@dcl/core-commons" "0.10.1"
+    "@dcl/core-commons" "0.11.0"
     "@well-known-components/interfaces" "^1.5.1"
     destroy "^1.2.0"
     fp-future "^1.0.1"


### PR DESCRIPTION
Closes #1962.

## Problem

The content server pinned a CORS `allowedHeaders` list that never contained the ADR-44 `X-Identity-*` family, so a browser preflight carrying an auth chain was answered without them and the browser blocked the request before it was ever sent. Native clients don't do CORS and were unaffected, and `/lambdas` leaves `allowedHeaders` unset and so reflects whatever is asked for — which is why a single catalyst node answered preflights inconsistently between its two halves.

## Change

```diff
   cors: {
-    origin: true,
-    methods: ['GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'],
-    allowedHeaders: ['Cache-Control', 'Content-Type', 'Origin', 'Accept', 'User-Agent', 'X-Upload-Origin'],
-    maxAge: 86400
+    origin: '*',
+    methods: ['GET', 'HEAD', 'POST', 'OPTIONS'],
+    maxAge: 600
   }
```

**Dropping `allowedHeaders`** lets `@dcl/http-server` reflect `Access-Control-Request-Headers`, matching lamb2. Reflection rather than an explicit list because the chain header names are open-ended (`X-Identity-Auth-Chain-<N>`) and verification walks them by prefix until one is missing, so any fixed list has to invent a maximum depth the protocol doesn't impose.

This is not a loosening of access control. `Access-Control-Allow-Headers` constrains *browsers* only — curl, the native explorer and any server-to-server caller already send whatever headers they like. The one thing an allow-list can protect is a server that treats header presence as implicit CSRF defence while relying on ambient credentials, and this server has neither: there are no cookies or sessions (`credentials` was removed in #1945), and the only mutating route, `POST /entities`, verifies an auth chain carried in the multipart body. Of the six entries removed, `X-Upload-Origin` was never read anywhere in `src/`, `Accept` is CORS-safelisted, and `Origin` is browser-controlled and cannot be set by page script.

**`origin: '*'` instead of `true`.** With `credentials` already gone there is no behavioural difference for browsers, and `*` needs no `Vary: Origin` — so preflight responses stay cacheable by shared caches rather than varying per caller.

**`methods` trimmed** to the four verbs that have routes; `PUT`, `DELETE` and `PATCH` were advertised but unroutable.

**`maxAge` 86400 → 600** so a bad preflight verdict can't sit in browsers for a day. Worth raising again once this has settled.

## Dependencies

Bumps `@dcl/http-server` 2.2.1 → 2.4.0, which carries decentraland/core-components#139 — `Vary` in the same CORS middleware was written with `set` rather than accumulated, so an origin-reflecting config that also reflected headers lost `Vary: Origin`, and the actual-response path discarded any `Vary` a handler had set for itself. This config no longer depends on that fix (`origin: '*'` sets no `Vary: Origin` to lose), but it's the version that has it.

2.4.0 pins `@dcl/core-commons` to exactly `0.11.0`, which collided with the existing `resolutions` pin of `0.10.1`, so the dependency and the resolution both move to `0.11.0`. That resolution exists to keep one deduped copy across the nine `@dcl/*` packages that depend on it; 0.11.0 is an additive minor (a new `increment` on `ICacheStorageComponent`, plus an optional `remoteAddress` on `DefaultContext`) and this repo has no `ICacheStorageComponent` test doubles, which is the only place that minor is felt.

## Tests

`test/integration/controller/cors.spec.ts` is new — there was no CORS coverage in the repo at all, which is how the gap survived. It boots a real server via `createDefaultServer()` and asserts the preflight grants the full ADR-44 header set, grants a 12-deep chain (guarding against a capped list being reintroduced), still grants `content-type`/`cache-control`, and that `Vary` and the origin behave as configured.

Six of its eight assertions fail against the previous config and pass here. Full suite green: 70 suites, 678 passed, 4 skipped.

## Note

The header list is older than the issue's history section suggests. It predates the well-known-components migration by 21 months — `c6948601` (PR #600, 2021-08-02) replaced a bare `cors()` call, whose defaults reflected requested headers, with this pinned list across all three servers of the day. ADR-44 is dated 2022-01-26, so browser signed-fetch against `/content` never worked; the door was closed six months before the feature existed. That commit also introduced the `credentials: true` that #1945 later removed. This restores, near-exactly, the pre-#600 behaviour.