### PR TITLE
feat: quota deployments per entity type and client address

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -7,3 +7,38 @@ The content server can be configured by environment variables.
 - `DENYLIST_URLS`: List of denylists used by the content server. Separated by new lines `\n`. Default: "https://config.decentraland.org/denylist"
 - `DENYLIST_FILE_NAME`: Filename to be used as local denylist. Default: "denylist.txt"
 - `SYNC_IGNORED_ENTITY_TYPES`: Ignored entity types, separated by comma. Prevents certain entities from being pulled from DAO catalysts. Default: ""
+
+## Deployment quota (`POST /entities`)
+
+Bounds how much a single client address can deploy of one entity type over four fixed windows. It is
+separate from `POST_ENTITIES_RATE_LIMIT_*`, which is a per-client *request* budget over one 60s window
+and is blind to entity type, and from `DEPLOYMENT_RATE_LIMIT_*`, which throttles redeployments of the
+same *pointer*. Every deploy attempt counts, including one that later fails validation.
+
+Counters are held in memory, so a restart resets them.
+
+- `DEPLOYMENT_QUOTA_MAX_PER_MINUTE`: deployments of one entity type allowed per address per minute. Default: 60
+- `DEPLOYMENT_QUOTA_MAX_PER_HOUR`: same, per hour. Default: 600
+- `DEPLOYMENT_QUOTA_MAX_PER_DAY`: same, per day. Default: 3000
+- `DEPLOYMENT_QUOTA_MAX_PER_WEEK`: same, per week. Default: 10000
+- `DEPLOYMENT_QUOTA_MAX_PER_{MINUTE,HOUR,DAY,WEEK}_{ENTITY_TYPE}`: overrides one window for one entity
+  type, e.g. `DEPLOYMENT_QUOTA_MAX_PER_HOUR_SCENE=200`. The suffix must be an entity type's exact name
+  (`SCENE`, `PROFILE`, `WEARABLE`, `STORE`, `EMOTE`, `OUTFITS`); an unknown one fails startup.
+- `DEPLOYMENT_QUOTA_EXEMPT_IPS`: comma-separated addresses and CIDRs that skip the quota, for a backend
+  deploying on behalf of many users from one address. Example: `203.0.113.7,198.51.100.0/24,2001:db8::/32`. Default: ""
+- `DEPLOYMENT_QUOTA_CACHE_MAX_KEYS`: maximum counters held in memory. An eviction resets one client's
+  budget rather than failing a deploy. Default: 100000
+- `TRUSTED_CLIENT_IP_HEADER`: header naming the client address, e.g. `cf-connecting-ip`. Shared with
+  `POST_ENTITIES_RATE_LIMIT_*`. **Set this whenever the process sits behind a proxy** — otherwise the
+  socket address is the proxy's and every client shares one budget. Only set it when the origin cannot
+  be reached except through that proxy: the header is forgeable, so a caller with direct access could
+  otherwise pick its own bucket or spend a victim's. Default: unset (correct for a directly exposed process)
+
+A window's budget must not be tighter than a shorter window's, or the shorter one's budget could never
+be spent; that, a zero, and a malformed address all fail startup rather than run misconfigured.
+
+A rejected deployment answers `429` with `Retry-After`, and says only when to retry — not which budget
+or window it hit. Every attempt is reported on
+`dcl_content_deployment_quota_attempts_total{entity_type, window, outcome}`, where `outcome` is
+`allowed`, `limited` (rejected) or `degraded` (the counter was unreachable, so the attempt was let
+through uncounted).

--- a/src/Environment.ts
+++ b/src/Environment.ts
@@ -57,6 +57,19 @@ export const DEFAULT_MAX_ACTIVE_ENTITIES_BODY_SIZE = 10 * 1024 * 1024 // 10 MB
 export const DEFAULT_POST_ENTITIES_RATE_LIMIT_MAX = 200
 export const DEFAULT_POST_ENTITIES_RATE_LIMIT_WINDOW_SECONDS = 60
 
+// Per-client, per-entity-type deployment budget over four horizons. Neither guard above bounds it:
+// `POST_ENTITIES_RATE_LIMIT_*` is a request budget over one 60s window and is blind to entity type,
+// and `DEPLOYMENT_RATE_LIMIT_*` throttles redeployments of one *pointer* rather than one caller's
+// total. Sized well above a creator iterating from a single address; a shared-IP aggregator that
+// deploys for many users belongs in `DEPLOYMENT_QUOTA_EXEMPT_IPS` rather than driving these up.
+export const DEFAULT_DEPLOYMENT_QUOTA_MAX_PER_MINUTE = 60
+export const DEFAULT_DEPLOYMENT_QUOTA_MAX_PER_HOUR = 600
+export const DEFAULT_DEPLOYMENT_QUOTA_MAX_PER_DAY = 3000
+export const DEFAULT_DEPLOYMENT_QUOTA_MAX_PER_WEEK = 10000
+// Bounds the counters' memory. Keys are (window, entity type, address), so the week's windows are what
+// dominate. An LRU eviction resets one client's budget rather than failing a deploy.
+export const DEFAULT_DEPLOYMENT_QUOTA_CACHE_MAX_KEYS = 100000
+
 /**
  * Parse a non-negative integer env var, falling back to `defaultValue` when it is unset/empty.
  * Throws on an invalid value (including partial parses like "256MB") rather than letting `parseInt`
@@ -94,6 +107,41 @@ function parsePositiveIntEnv(name: string, defaultValue: number): number {
     throw new Error(`Invalid ${name}: expected a positive integer but got "${process.env[name]}"`)
   }
   return parsed
+}
+
+/**
+ * Reads the per-entity-type overrides of one deployment quota window, configured as
+ * `DEPLOYMENT_QUOTA_MAX_PER_{WINDOW}_{ENTITY_TYPE}` (e.g. `DEPLOYMENT_QUOTA_MAX_PER_HOUR_SCENE`).
+ *
+ * The suffix must be an entity type's exact name. An unknown one throws instead of becoming an
+ * `undefined` key nothing will ever read — the failure mode of the `DEPLOYMENT_RATE_LIMIT_MAX_*` scan
+ * below, where a typo silently leaves the entity type on its default.
+ */
+function parseQuotaOverridesEnv(window: string): Map<EntityType, number> {
+  const prefix = `DEPLOYMENT_QUOTA_MAX_PER_${window}_`
+  const overrides: Map<EntityType, number> = new Map()
+  for (const [name, value] of Object.entries(process.env)) {
+    if (!name.startsWith(prefix) || !value) {
+      continue
+    }
+    const suffix = name.slice(prefix.length)
+    const entityType = parseEntityType(suffix)
+    if (!entityType) {
+      throw new Error(
+        `Invalid ${name}: "${suffix}" is not an entity type. Expected one of ${Object.keys(EntityType).join(', ')}`
+      )
+    }
+    overrides.set(entityType, parsePositiveIntEnv(name, 0))
+  }
+  return overrides
+}
+
+/** Splits a comma-separated list, dropping empty entries. Each entry is validated by its consumer. */
+function parseCommaSeparatedEnv(name: string): string[] {
+  return (process.env[name] ?? '')
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0)
 }
 
 /**
@@ -323,6 +371,19 @@ export enum EnvironmentConfig {
   POST_ENTITIES_RATE_LIMIT_MAX,
   POST_ENTITIES_RATE_LIMIT_WINDOW_SECONDS,
   TRUSTED_CLIENT_IP_HEADER,
+
+  // Per-client, per-entity-type deployment quota over four fixed windows. The `*_BY_ENTITY_TYPE`
+  // entries hold the per-type overrides of the window above them.
+  DEPLOYMENT_QUOTA_MAX_PER_MINUTE,
+  DEPLOYMENT_QUOTA_MAX_PER_MINUTE_BY_ENTITY_TYPE,
+  DEPLOYMENT_QUOTA_MAX_PER_HOUR,
+  DEPLOYMENT_QUOTA_MAX_PER_HOUR_BY_ENTITY_TYPE,
+  DEPLOYMENT_QUOTA_MAX_PER_DAY,
+  DEPLOYMENT_QUOTA_MAX_PER_DAY_BY_ENTITY_TYPE,
+  DEPLOYMENT_QUOTA_MAX_PER_WEEK,
+  DEPLOYMENT_QUOTA_MAX_PER_WEEK_BY_ENTITY_TYPE,
+  DEPLOYMENT_QUOTA_EXEMPT_IPS,
+  DEPLOYMENT_QUOTA_CACHE_MAX_KEYS,
 
   SUBGRAPH_COMPONENT_RETRIES,
   SUBGRAPH_COMPONENT_QUERY_TIMEOUT,
@@ -690,6 +751,43 @@ export class EnvironmentBuilder {
     // proxy writes, or every client shares one bucket — see the startup warning in `components.ts`.
     this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.TRUSTED_CLIENT_IP_HEADER, () =>
       parseOptionalHeaderNameEnv('TRUSTED_CLIENT_IP_HEADER')
+    )
+
+    // Per-client, per-entity-type deployment quota. A zero fails startup for the same reason a zero
+    // POST_ENTITIES_RATE_LIMIT_MAX does: it is an outage that looks like working configuration.
+    this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.DEPLOYMENT_QUOTA_MAX_PER_MINUTE, () =>
+      parsePositiveIntEnv('DEPLOYMENT_QUOTA_MAX_PER_MINUTE', DEFAULT_DEPLOYMENT_QUOTA_MAX_PER_MINUTE)
+    )
+    this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.DEPLOYMENT_QUOTA_MAX_PER_MINUTE_BY_ENTITY_TYPE, () =>
+      parseQuotaOverridesEnv('MINUTE')
+    )
+    this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.DEPLOYMENT_QUOTA_MAX_PER_HOUR, () =>
+      parsePositiveIntEnv('DEPLOYMENT_QUOTA_MAX_PER_HOUR', DEFAULT_DEPLOYMENT_QUOTA_MAX_PER_HOUR)
+    )
+    this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.DEPLOYMENT_QUOTA_MAX_PER_HOUR_BY_ENTITY_TYPE, () =>
+      parseQuotaOverridesEnv('HOUR')
+    )
+    this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.DEPLOYMENT_QUOTA_MAX_PER_DAY, () =>
+      parsePositiveIntEnv('DEPLOYMENT_QUOTA_MAX_PER_DAY', DEFAULT_DEPLOYMENT_QUOTA_MAX_PER_DAY)
+    )
+    this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.DEPLOYMENT_QUOTA_MAX_PER_DAY_BY_ENTITY_TYPE, () =>
+      parseQuotaOverridesEnv('DAY')
+    )
+    this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.DEPLOYMENT_QUOTA_MAX_PER_WEEK, () =>
+      parsePositiveIntEnv('DEPLOYMENT_QUOTA_MAX_PER_WEEK', DEFAULT_DEPLOYMENT_QUOTA_MAX_PER_WEEK)
+    )
+    this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.DEPLOYMENT_QUOTA_MAX_PER_WEEK_BY_ENTITY_TYPE, () =>
+      parseQuotaOverridesEnv('WEEK')
+    )
+
+    // Addresses and CIDRs that skip the quota, for a backend deploying on behalf of many users from one
+    // address. Parsed into matchers (and rejected if malformed) by the deployment-quota component.
+    this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.DEPLOYMENT_QUOTA_EXEMPT_IPS, () =>
+      parseCommaSeparatedEnv('DEPLOYMENT_QUOTA_EXEMPT_IPS')
+    )
+
+    this.registerConfigIfNotAlreadySet(env, EnvironmentConfig.DEPLOYMENT_QUOTA_CACHE_MAX_KEYS, () =>
+      parsePositiveIntEnv('DEPLOYMENT_QUOTA_CACHE_MAX_KEYS', DEFAULT_DEPLOYMENT_QUOTA_CACHE_MAX_KEYS)
     )
 
     this.registerConfigIfNotAlreadySet(

--- a/src/components.ts
+++ b/src/components.ts
@@ -58,6 +58,7 @@ import { createCrypto } from './logic/crypto'
 import { createContentCluster, createCustomDAOSource, createDAOSource } from './logic/peer-cluster'
 import { createDeploymentsComponent, retryFailedDeploymentExecution } from './logic/deployments'
 import { createDeploymentService } from './logic/deployment-service'
+import { createDeploymentQuota } from './logic/deployment-quota'
 import { createEntities } from './logic/entities'
 import { createGarbageCollectionComponent } from './logic/garbage-collection'
 import { createQueryParams } from './logic/query-params'
@@ -509,11 +510,20 @@ export async function initComponentsWithEnv(env: Environment): Promise<AppCompon
   // presence proves nothing and would let an outsider raise this.
   if (!trustedClientIpHeader) {
     rateLimiterLogger.warn(
-      'TRUSTED_CLIENT_IP_HEADER is unset, so POST /entities is rate limited by socket address. That is ' +
-        'correct only if this process is reached directly; behind a proxy every client shares one budget. ' +
-        'Watch the key_source label on rate_limiter_requests_total to tell which is happening.'
+      'TRUSTED_CLIENT_IP_HEADER is unset, so the POST /entities rate limit and the deployment quota are ' +
+        'both keyed on the socket address. That is correct only if this process is reached directly; ' +
+        'behind a proxy every client shares one budget. The key_source label on ' +
+        'rate_limiter_requests_total tells which is happening, and it speaks for the quota too: both ' +
+        'resolve the client address from the same header with the same precedence.'
     )
   }
+
+  // ---------------------------------------------------------------------------
+  // 13. Deployment quota
+  // ---------------------------------------------------------------------------
+  // Enforced in the POST /entities handler rather than at its mount: the entity type it buckets on
+  // only exists inside the uploaded entity file, so it cannot be known before the multipart parse.
+  const deploymentQuota = createDeploymentQuota({ env, logs, metrics })
 
   const buildInfo = {
     version: CURRENT_VERSION,
@@ -546,6 +556,7 @@ export async function initComponentsWithEnv(env: Environment): Promise<AppCompon
     denylistReloadJob,
     deployedEntitiesBloomFilter,
     deployer,
+    deploymentQuota,
     deployments,
     deploymentsRepository,
     downloadQueue,

--- a/src/controllers/errors.ts
+++ b/src/controllers/errors.ts
@@ -34,3 +34,18 @@ export class PayloadTooLargeError extends Error {
     Error.captureStackTrace(this, this.constructor)
   }
 }
+
+/**
+ * Rejects a caller that has spent a budget. `retryAfterSeconds` becomes the `Retry-After` header.
+ *
+ * Deliberately says only *when* to come back: naming the limit, the window or the remaining budget is
+ * itself disclosure, and this matches the default of `@dcl/rate-limiter-component` that the rest of
+ * the fleet follows.
+ */
+export class TooManyRequestsError extends Error {
+  constructor(message: string, public readonly retryAfterSeconds?: number) {
+    super(message)
+    this.name = 'TooManyRequestsError'
+    Error.captureStackTrace(this, this.constructor)
+  }
+}

--- a/src/controllers/handlers/create-entity-handler.ts
+++ b/src/controllers/handlers/create-entity-handler.ts
@@ -1,9 +1,12 @@
 import { PostEntity200, PostEntity400 } from '@dcl/catalyst-api-specs/lib/client'
 import { Field } from '@well-known-components/multipart-wrapper'
 import { AuthChain, AuthLink, EthAddress } from '@dcl/crypto'
+import { EntityType } from '@dcl/schemas'
 import { DeploymentContext, isInvalidDeployment, isSuccessfulDeployment } from '../../deployment-types'
+import { DeploymentQuotaExceededError } from '../../logic/deployment-quota'
+import { hashFiles } from '../../logic/deployment-service'
 import { FormHandlerContextWithPath } from '../../types'
-import { InvalidRequestError } from '../errors'
+import { InvalidRequestError, TooManyRequestsError } from '../errors'
 
 // A real auth chain has 2-3 links; cap generously. This bounds the index-parsing loop below so a
 // crafted `authChain[<huge>][...]` field name can't drive a large iteration count on the public,
@@ -17,11 +20,15 @@ type ContentFile = {
 
 type Response = { status: 200; body: PostEntity200 } | { status: 400; body: PostEntity400 }
 
+/** The components a deploy needs beyond the response itself. */
+type CreateEntityContext = FormHandlerContextWithPath<
+  'logs' | 'fs' | 'metrics' | 'deployer' | 'crypto' | 'entities' | 'deploymentQuota',
+  '/entities'
+>
+
 // Method: POST
-export async function createEntity(
-  context: FormHandlerContextWithPath<'logs' | 'fs' | 'metrics' | 'deployer', '/entities'>
-): Promise<Response> {
-  const { metrics, deployer, logs } = context.components
+export async function createEntity(context: CreateEntityContext): Promise<Response> {
+  const { metrics, deployer, crypto, logs } = context.components
 
   const logger = logs.getLogger('create-entity')
   // Guard the required field explicitly: without it a missing `entityId` throws a TypeError and the
@@ -57,14 +64,18 @@ export async function createEntity(
       deployFiles.push({ path: filename, content: file.value })
     }
 
+    // Hashed here so the quota can read the entity type, which exists only inside the entity file.
+    // `deployEntity` takes the map as-is, so nothing is hashed twice.
+    const hashes = await hashFiles(
+      crypto,
+      deployFiles.map(({ content }) => content),
+      entityId
+    )
+    await enforceDeploymentQuota(context, hashes, entityId)
+
     const auditInfo = { authChain, version: 'v3' }
 
-    const deploymentResult = await deployer.deployEntity(
-      deployFiles.map(({ content }) => content),
-      entityId,
-      auditInfo,
-      DeploymentContext.LOCAL
-    )
+    const deploymentResult = await deployer.deployEntity(hashes, entityId, auditInfo, DeploymentContext.LOCAL)
 
     if (isSuccessfulDeployment(deploymentResult)) {
       metrics.increment('dcl_deployments_endpoint_counter', { kind: 'success' })
@@ -89,6 +100,11 @@ export async function createEntity(
       throw new Error('deploymentResult is invalid')
     }
   } catch (error) {
+    // A rejected caller is not an internal failure: counting and logging it here would let the abuse
+    // the quota exists to stop drive the error metric and the log volume.
+    if (error instanceof TooManyRequestsError) {
+      throw error
+    }
     metrics.increment('dcl_deployments_endpoint_counter', { kind: 'error' })
     // Never log `authChain` or `signature`: they are cryptographic credentials and
     // must not end up in logs/aggregation. `entityId` + `ethAddress` are enough to debug.
@@ -98,6 +114,52 @@ export async function createEntity(
       userAgent
     })
     logger.error(error)
+    throw error
+  }
+}
+
+/**
+ * Counts this attempt against the client's budget for the entity's type.
+ *
+ * The entity is located by its *computed* hash: the multipart field names are the caller's to choose,
+ * so trusting them would let anyone skip the quota by renaming the entity file.
+ *
+ * An entity file that is missing or unparseable is left to `deployEntity`, which already answers 400
+ * for it. Rejecting here instead would change that response's shape, and a caller gains nothing —
+ * the deployment fails either way, and its request still counts against POST_ENTITIES_RATE_LIMIT_MAX.
+ */
+async function enforceDeploymentQuota(
+  context: CreateEntityContext,
+  hashes: Map<string, Uint8Array>,
+  entityId: string
+): Promise<void> {
+  const { entities, deploymentQuota } = context.components
+
+  const entityFile = hashes.get(entityId)
+  if (!entityFile) {
+    return
+  }
+
+  let entityType: EntityType
+  try {
+    const entity = entities.parse(entityFile, entityId)
+    if (!entity) {
+      return
+    }
+    entityType = entity.type
+  } catch {
+    return
+  }
+
+  try {
+    await deploymentQuota.assertWithinQuota(context, entityType)
+  } catch (error) {
+    if (error instanceof DeploymentQuotaExceededError) {
+      throw new TooManyRequestsError(
+        `Too many deployments from this address. Retry in ${error.retryAfterSeconds} seconds.`,
+        error.retryAfterSeconds
+      )
+    }
     throw error
   }
 }

--- a/src/controllers/middlewares.ts
+++ b/src/controllers/middlewares.ts
@@ -3,7 +3,7 @@ import { IHttpServerComponent } from '@dcl/core-commons'
 import { AppComponents } from '../types'
 import { State } from '../logic/sync-orchestrator'
 import { Error } from '@dcl/catalyst-api-specs/lib/client'
-import { InvalidRequestError, NotFoundError, PayloadTooLargeError } from './errors'
+import { InvalidRequestError, NotFoundError, PayloadTooLargeError, TooManyRequestsError } from './errors'
 import { Middleware } from '@dcl/http-server/dist/middleware'
 
 export function preventExecutionIfBoostrapping({
@@ -27,7 +27,9 @@ export function preventExecutionIfBoostrapping({
   }
 }
 
-function handleError(logger: ILoggerComponent.ILogger, error: any): { status: number; body: Error } {
+type ErrorResponse = { status: number; body: Error; headers?: Record<string, string> }
+
+function handleError(logger: ILoggerComponent.ILogger, error: any): ErrorResponse {
   // Handlers throw HTTP-shaped errors (defined in `./errors.ts`) when they
   // want to surface a specific status. Add a new branch when a new HTTP error
   // class is introduced. Anything else is treated as an unexpected failure
@@ -40,6 +42,16 @@ function handleError(logger: ILoggerComponent.ILogger, error: any): { status: nu
   }
   if (error instanceof PayloadTooLargeError) {
     return { status: 413, body: { error: error.message } }
+  }
+  if (error instanceof TooManyRequestsError) {
+    return {
+      status: 429,
+      body: { error: error.message },
+      // `Access-Control-Expose-Headers: *` is set on this API, so a browser deployer can read this.
+      ...(error.retryAfterSeconds !== undefined
+        ? { headers: { 'Retry-After': error.retryAfterSeconds.toString() } }
+        : {})
+    }
   }
 
   logger.error(error)

--- a/src/logic/deployment-quota/component.ts
+++ b/src/logic/deployment-quota/component.ts
@@ -1,0 +1,175 @@
+import { EntityType } from '@dcl/schemas'
+import { createInMemoryCacheComponent } from '@dcl/memory-cache-component'
+import { canonicalizeIpAddress, clientIpFromForwardedHeader } from '@dcl/rate-limiter-component'
+import { EnvironmentConfig } from '../../Environment'
+import { AppComponents } from '../../types'
+import { countAttempt } from './counter'
+import { DeploymentQuotaExceededError } from './errors'
+import {
+  DEPLOYMENT_QUOTA_WINDOWS,
+  DEPLOYMENT_QUOTA_WINDOW_SECONDS,
+  assertMonotonicQuotaLadder,
+  budgetFor,
+  isExemptIp,
+  parseIpExemptions
+} from './logic'
+import {
+  DeploymentQuotaLadder,
+  DeploymentQuotaOutcome,
+  DeploymentQuotaWindow,
+  IDeploymentQuota,
+  QuotaClient
+} from './types'
+
+/** Mirrors the package default the POST /entities limiter runs with, so both read the same hop. */
+const TRUSTED_PROXY_COUNT = 1
+
+/**
+ * Bounds how much one client address can deploy of a given entity type over a minute, an hour, a day
+ * and a week.
+ *
+ * The existing guards do not cover this: `POST_ENTITIES_RATE_LIMIT_*` is a per-client *request*
+ * budget over a single 60s window and is blind to entity type, and `DEPLOYMENT_RATE_LIMIT_*` throttles
+ * redeployments of the same *pointer* rather than one caller's total.
+ *
+ * Counters live in a cache of this component's own. Sharing the request limiter's LRU would let
+ * minute-window churn evict the week counters.
+ */
+export function createDeploymentQuota(components: Pick<AppComponents, 'env' | 'logs' | 'metrics'>): IDeploymentQuota {
+  const { env, logs, metrics } = components
+  const logger = logs.getLogger('deployment-quota')
+
+  const ladder = readLadder(env)
+  assertMonotonicQuotaLadder(ladder)
+  const exemptions = parseIpExemptions(env.getConfig<string[]>(EnvironmentConfig.DEPLOYMENT_QUOTA_EXEMPT_IPS) ?? [])
+  // Resolved here rather than by the rate limiter, whose address handling lives in its middleware.
+  // Same header as the POST /entities limiter reads, so the two agree on who a client is.
+  const trustedClientIpHeader = env
+    .getConfig<string | undefined>(EnvironmentConfig.TRUSTED_CLIENT_IP_HEADER)
+    ?.toLowerCase()
+
+  const cache = createInMemoryCacheComponent({
+    max: env.getConfig<number>(EnvironmentConfig.DEPLOYMENT_QUOTA_CACHE_MAX_KEYS),
+    // Every counter carries the TTL of its own window; a cache-wide default would only mask a missing
+    // one, and the week's counter must outlive the one-hour library default.
+    ttl: 0
+  })
+
+  // Failing open is silent by construction, so say it once when it starts happening. The metric's
+  // `degraded` outcome carries the rest.
+  let warnedAboutUnavailableCounter = false
+
+  logger.info(`Deployment quota per client address:\n${describeLadder(ladder)}`, {
+    exemptAddresses: exemptions.length
+  })
+
+  /** Same precedence as the limiter's own middleware: trusted header, then the socket address. */
+  function resolveClientIp(client: QuotaClient): string | null {
+    if (trustedClientIpHeader) {
+      const fromHeader = clientIpFromForwardedHeader(
+        client.request.headers.get(trustedClientIpHeader),
+        TRUSTED_PROXY_COUNT
+      )
+      if (fromHeader) {
+        return fromHeader
+      }
+    }
+    return canonicalizeIpAddress(client.remoteAddress)
+  }
+
+  return {
+    async assertWithinQuota(client: QuotaClient, entityType: EntityType): Promise<void> {
+      const clientIp = resolveClientIp(client)
+      if (clientIp !== null && isExemptIp(clientIp, exemptions)) {
+        return
+      }
+
+      // An empty identity lands in `countAttempt`'s shared bucket at a tightened cap, which is what
+      // the rate limiter does with a request carrying no client address.
+      const identity = clientIp === null ? '' : `${entityType}:${clientIp}`
+
+      const now = Date.now()
+      for (const window of DEPLOYMENT_QUOTA_WINDOWS) {
+        const result = await countAttempt(
+          cache,
+          `deploy-quota-${window}`,
+          identity,
+          budgetFor(ladder, window, entityType),
+          DEPLOYMENT_QUOTA_WINDOW_SECONDS[window],
+          now
+        )
+
+        // Reported, not logged: a throttled client retries, so a line per rejection is write
+        // amplification driven by the abuse being blocked.
+        metrics.increment('dcl_content_deployment_quota_attempts_total', {
+          entity_type: entityType,
+          window,
+          outcome: result.storeUnavailable
+            ? DeploymentQuotaOutcome.DEGRADED
+            : result.allowed
+            ? DeploymentQuotaOutcome.ALLOWED
+            : DeploymentQuotaOutcome.LIMITED
+        })
+
+        if (result.storeUnavailable && !warnedAboutUnavailableCounter) {
+          warnedAboutUnavailableCounter = true
+          logger.warn(
+            'The deployment quota counter is unavailable, so deployments are being allowed through ' +
+              'uncounted. Watch the degraded outcome on dcl_content_deployment_quota_attempts_total.'
+          )
+        }
+
+        if (!result.allowed) {
+          // Stop at the first blown window, so a client that keeps retrying while throttled spends
+          // only the budget it already blew and the longer horizons stay meaningful.
+          //
+          // `result.limit` rather than the configured budget, so a rejection in the shared bucket
+          // reports the tightened cap it was actually measured against.
+          throw new DeploymentQuotaExceededError(entityType, window, result.limit, result.retryAfterSeconds)
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Read inside the function rather than from a module-level table: `Environment` imports `components`,
+ * which reaches this module, so `EnvironmentConfig` is still undefined while this module initializes.
+ */
+function readLadder(env: AppComponents['env']): DeploymentQuotaLadder {
+  const configs: Record<DeploymentQuotaWindow, { max: EnvironmentConfig; perEntityType: EnvironmentConfig }> = {
+    [DeploymentQuotaWindow.MINUTE]: {
+      max: EnvironmentConfig.DEPLOYMENT_QUOTA_MAX_PER_MINUTE,
+      perEntityType: EnvironmentConfig.DEPLOYMENT_QUOTA_MAX_PER_MINUTE_BY_ENTITY_TYPE
+    },
+    [DeploymentQuotaWindow.HOUR]: {
+      max: EnvironmentConfig.DEPLOYMENT_QUOTA_MAX_PER_HOUR,
+      perEntityType: EnvironmentConfig.DEPLOYMENT_QUOTA_MAX_PER_HOUR_BY_ENTITY_TYPE
+    },
+    [DeploymentQuotaWindow.DAY]: {
+      max: EnvironmentConfig.DEPLOYMENT_QUOTA_MAX_PER_DAY,
+      perEntityType: EnvironmentConfig.DEPLOYMENT_QUOTA_MAX_PER_DAY_BY_ENTITY_TYPE
+    },
+    [DeploymentQuotaWindow.WEEK]: {
+      max: EnvironmentConfig.DEPLOYMENT_QUOTA_MAX_PER_WEEK,
+      perEntityType: EnvironmentConfig.DEPLOYMENT_QUOTA_MAX_PER_WEEK_BY_ENTITY_TYPE
+    }
+  }
+
+  const ladder = {} as DeploymentQuotaLadder
+  for (const window of DEPLOYMENT_QUOTA_WINDOWS) {
+    ladder[window] = {
+      default: env.getConfig<number>(configs[window].max),
+      perEntityType: env.getConfig<Map<EntityType, number>>(configs[window].perEntityType) ?? new Map()
+    }
+  }
+  return ladder
+}
+
+function describeLadder(ladder: DeploymentQuotaLadder): string {
+  return DEPLOYMENT_QUOTA_WINDOWS.map((window) => {
+    const overrides = Array.from(ladder[window].perEntityType, ([entityType, max]) => `${entityType}: ${max}`)
+    const detail = overrides.length > 0 ? ` (${overrides.join(', ')})` : ''
+    return `${window}: ${ladder[window].default}${detail}`
+  }).join('\n')
+}

--- a/src/logic/deployment-quota/counter.ts
+++ b/src/logic/deployment-quota/counter.ts
@@ -1,0 +1,74 @@
+import { ICacheStorageComponent } from '@dcl/core-commons'
+import {
+  FALLBACK_IDENTITY,
+  buildCounterKey,
+  currentWindow,
+  encodeIdentity,
+  windowOffsetFor
+} from '@dcl/rate-limiter-component'
+import { QuotaCountResult } from './types'
+
+/** Namespaces every counter, so nothing else sharing the cache can collide with one. */
+export const QUOTA_KEY_PREFIX = 'catalyst-content:deploy-quota'
+
+/**
+ * Divisor applied to the budget when no client address could be established and every such caller
+ * shares one bucket. Mirrors the rate limiter's own default: the shared bucket is a global quota, so
+ * leaving the full budget there would let the first callers of each window spend it and throttle
+ * everyone else anyway. Tightening makes a misconfigured deployment fail small instead of funnelling
+ * all anonymous traffic through the full per-client cap.
+ */
+export const FALLBACK_MAX_DIVISOR = 10
+
+/** Extra second so a counter can never expire before the window it belongs to ends. */
+const COUNTER_TTL_GRACE_SECONDS = 1
+
+/**
+ * Counts one attempt against `identity` in a fixed window and reports whether it fits.
+ *
+ * Written against the cache rather than `IRateLimiterComponent.consume`, which rejects any window
+ * longer than a day as a seconds/milliseconds mix-up and therefore cannot express the week tier. The
+ * window arithmetic, key layout and identity encoding are still the limiter's own exported ones, so
+ * the two agree on all of it and a counter written here is readable there.
+ *
+ * An empty `identity` means the caller could not establish one; it is counted in a shared bucket at
+ * the tightened cap rather than given a bucket of its own at the full budget.
+ *
+ * Never throws for a counter failure: the quota is abuse mitigation, and an unreachable counter must
+ * not stop deployments. The result says so through `storeUnavailable`.
+ */
+export async function countAttempt(
+  cache: Pick<ICacheStorageComponent, 'increment'>,
+  bucket: string,
+  identity: string,
+  max: number,
+  windowSeconds: number,
+  now: number
+): Promise<QuotaCountResult> {
+  const isShared = identity.trim().length === 0
+  const limit = isShared ? Math.max(1, Math.floor(max / FALLBACK_MAX_DIVISOR)) : max
+  const countedIdentity = isShared ? FALLBACK_IDENTITY : identity
+
+  const windowMs = windowSeconds * 1000
+  // Phase the window per identity: a boundary shared by everyone is one a caller could compute from a
+  // single Retry-After and then spend a full budget on each side of.
+  const { windowId, resetAt } = currentWindow(now, windowMs, windowOffsetFor(countedIdentity, windowMs))
+  const secondsLeftInWindow = Math.max(1, Math.ceil((resetAt - now) / 1000))
+
+  const key = buildCounterKey(QUOTA_KEY_PREFIX, bucket, windowId, encodeIdentity(countedIdentity, false))
+
+  try {
+    const { value } = await cache.increment(key, {
+      ttlInSeconds: secondsLeftInWindow + COUNTER_TTL_GRACE_SECONDS
+    })
+    return {
+      allowed: value <= limit,
+      limit,
+      // Never 0: some clients read `Retry-After: 0` as "retry now", the storm the header prevents.
+      retryAfterSeconds: secondsLeftInWindow,
+      storeUnavailable: false
+    }
+  } catch {
+    return { allowed: true, limit, retryAfterSeconds: secondsLeftInWindow, storeUnavailable: true }
+  }
+}

--- a/src/logic/deployment-quota/errors.ts
+++ b/src/logic/deployment-quota/errors.ts
@@ -1,0 +1,35 @@
+import { EntityType } from '@dcl/schemas'
+import { DeploymentQuotaWindow } from './types'
+
+/**
+ * Thrown when a client has spent its budget for an entity type in one of the windows. The window and
+ * the limit are carried for the metric and the operator-facing log; the HTTP response deliberately
+ * discloses only `Retry-After`, matching the fleet's rate limit convention.
+ */
+export class DeploymentQuotaExceededError extends Error {
+  constructor(
+    public readonly entityType: EntityType,
+    public readonly window: DeploymentQuotaWindow,
+    public readonly limit: number,
+    public readonly retryAfterSeconds: number
+  ) {
+    super(
+      `Deployment quota exceeded for '${entityType}': ${limit} per ${window} from one client address. ` +
+        `Retry in ${retryAfterSeconds} seconds.`
+    )
+    this.name = 'DeploymentQuotaExceededError'
+    Error.captureStackTrace(this, this.constructor)
+  }
+}
+
+/**
+ * Thrown while the component is built, so a bad quota fails at startup instead of silently rejecting
+ * every deployment or none of them.
+ */
+export class InvalidDeploymentQuotaConfigurationError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'InvalidDeploymentQuotaConfigurationError'
+    Error.captureStackTrace(this, this.constructor)
+  }
+}

--- a/src/logic/deployment-quota/index.ts
+++ b/src/logic/deployment-quota/index.ts
@@ -1,0 +1,20 @@
+export { createDeploymentQuota } from './component'
+export { DeploymentQuotaExceededError, InvalidDeploymentQuotaConfigurationError } from './errors'
+export {
+  DEPLOYMENT_QUOTA_WINDOWS,
+  DEPLOYMENT_QUOTA_WINDOW_SECONDS,
+  assertMonotonicQuotaLadder,
+  budgetFor,
+  isExemptIp,
+  parseIpExemptions
+} from './logic'
+export { FALLBACK_MAX_DIVISOR, QUOTA_KEY_PREFIX, countAttempt } from './counter'
+export { DeploymentQuotaOutcome, DeploymentQuotaWindow } from './types'
+export type {
+  DeploymentQuotaBudget,
+  DeploymentQuotaLadder,
+  IDeploymentQuota,
+  IpExemption,
+  QuotaClient,
+  QuotaCountResult
+} from './types'

--- a/src/logic/deployment-quota/logic.ts
+++ b/src/logic/deployment-quota/logic.ts
@@ -1,0 +1,163 @@
+import { isIP } from 'net'
+import { EntityType } from '@dcl/schemas'
+import { canonicalizeIpAddress } from '@dcl/rate-limiter-component'
+import { InvalidDeploymentQuotaConfigurationError } from './errors'
+import { DeploymentQuotaLadder, DeploymentQuotaWindow, IpExemption } from './types'
+
+/** Window lengths are fixed; only the budgets are configurable. A tunable "minute" is not a minute. */
+export const DEPLOYMENT_QUOTA_WINDOW_SECONDS: Record<DeploymentQuotaWindow, number> = {
+  [DeploymentQuotaWindow.MINUTE]: 60,
+  [DeploymentQuotaWindow.HOUR]: 60 * 60,
+  [DeploymentQuotaWindow.DAY]: 24 * 60 * 60,
+  [DeploymentQuotaWindow.WEEK]: 7 * 24 * 60 * 60
+}
+
+/**
+ * Evaluation order, shortest window first. A burst trips the minute budget before it can reach the
+ * week's, so a client that keeps retrying while throttled drains only the window it already blew.
+ */
+export const DEPLOYMENT_QUOTA_WINDOWS: readonly DeploymentQuotaWindow[] = [
+  DeploymentQuotaWindow.MINUTE,
+  DeploymentQuotaWindow.HOUR,
+  DeploymentQuotaWindow.DAY,
+  DeploymentQuotaWindow.WEEK
+]
+
+export function budgetFor(
+  ladder: DeploymentQuotaLadder,
+  window: DeploymentQuotaWindow,
+  entityType: EntityType
+): number {
+  const budget = ladder[window]
+  return budget.perEntityType.get(entityType) ?? budget.default
+}
+
+/**
+ * Rejects a ladder whose longer window is tighter than a shorter one: the tighter cap is reached
+ * first, so the shorter window's budget can never be spent and is dead configuration.
+ */
+export function assertMonotonicQuotaLadder(ladder: DeploymentQuotaLadder): void {
+  const overriddenTypes = new Set<EntityType>()
+  for (const window of DEPLOYMENT_QUOTA_WINDOWS) {
+    for (const entityType of ladder[window].perEntityType.keys()) {
+      overriddenTypes.add(entityType)
+    }
+  }
+
+  const ladders: { subject: string; budgets: number[] }[] = [
+    { subject: 'every entity type', budgets: DEPLOYMENT_QUOTA_WINDOWS.map((window) => ladder[window].default) },
+    ...Array.from(overriddenTypes, (entityType) => ({
+      subject: `'${entityType}'`,
+      budgets: DEPLOYMENT_QUOTA_WINDOWS.map((window) => budgetFor(ladder, window, entityType))
+    }))
+  ]
+
+  for (const { subject, budgets } of ladders) {
+    for (let index = 1; index < budgets.length; index++) {
+      if (budgets[index] < budgets[index - 1]) {
+        throw new InvalidDeploymentQuotaConfigurationError(
+          `The deployment quota for ${subject} allows ${budgets[index]} per ${DEPLOYMENT_QUOTA_WINDOWS[index]} ` +
+            `but ${budgets[index - 1]} per ${DEPLOYMENT_QUOTA_WINDOWS[index - 1]}. A longer window must not be ` +
+            `tighter than a shorter one, or the shorter one's budget can never be spent.`
+        )
+      }
+    }
+  }
+}
+
+/** Big-endian bytes of a canonical address, or `null` when it is not one. */
+function ipToBytes(canonicalAddress: string): Uint8Array | null {
+  const version = isIP(canonicalAddress)
+  if (version === 4) {
+    return Uint8Array.from(canonicalAddress.split('.'), Number)
+  }
+  if (version !== 6) {
+    return null
+  }
+  // A canonical IPv6 address is hextets with at most one `::`, never an embedded dotted quad:
+  // canonicalizeIpAddress folds the IPv4-mapped form down to IPv4 before this runs.
+  const [head, tail] = canonicalAddress.split('::')
+  const headHextets = head ? head.split(':') : []
+  const tailHextets = tail ? tail.split(':') : []
+  const hextets = [...headHextets, ...new Array(8 - headHextets.length - tailHextets.length).fill('0'), ...tailHextets]
+  const bytes = new Uint8Array(16)
+  hextets.forEach((hextet, index) => {
+    const value = parseInt(hextet, 16)
+    bytes[index * 2] = value >> 8
+    bytes[index * 2 + 1] = value & 0xff
+  })
+  return bytes
+}
+
+/**
+ * Parses `DEPLOYMENT_QUOTA_EXEMPT_IPS` entries. A bare address is a full-length prefix, so an address
+ * and a CIDR go through one matcher.
+ *
+ * @throws InvalidDeploymentQuotaConfigurationError so a typo cannot silently exempt nothing.
+ */
+export function parseIpExemptions(entries: readonly string[]): IpExemption[] {
+  return entries.map(parseIpExemption)
+}
+
+function parseIpExemption(entry: string): IpExemption {
+  const invalid = (reason: string) =>
+    new InvalidDeploymentQuotaConfigurationError(`Invalid DEPLOYMENT_QUOTA_EXEMPT_IPS entry "${entry}": ${reason}.`)
+
+  const [rawAddress, rawPrefix, ...rest] = entry.split('/')
+  if (rest.length > 0) {
+    throw invalid('expected an IP address or a CIDR')
+  }
+
+  const canonicalAddress = canonicalizeIpAddress(rawAddress)
+  const bytes = canonicalAddress === null ? null : ipToBytes(canonicalAddress)
+  if (bytes === null) {
+    throw invalid(`"${rawAddress}" is not an IP address`)
+  }
+
+  const maxPrefixBits = bytes.length * 8
+  if (rawPrefix === undefined) {
+    return { bytes, prefixBits: maxPrefixBits }
+  }
+  if (!/^\d{1,3}$/.test(rawPrefix)) {
+    throw invalid('the prefix length is not a number')
+  }
+  const prefixBits = parseInt(rawPrefix, 10)
+  if (prefixBits > maxPrefixBits) {
+    throw invalid(`the prefix length must be at most ${maxPrefixBits}`)
+  }
+  return { bytes, prefixBits }
+}
+
+function matchesPrefix(address: Uint8Array, network: Uint8Array, prefixBits: number): boolean {
+  const wholeBytes = prefixBits >> 3
+  for (let index = 0; index < wholeBytes; index++) {
+    if (address[index] !== network[index]) {
+      return false
+    }
+  }
+  const remainingBits = prefixBits & 7
+  if (remainingBits === 0) {
+    return true
+  }
+  const mask = (0xff << (8 - remainingBits)) & 0xff
+  return (address[wholeBytes] & mask) === (network[wholeBytes] & mask)
+}
+
+/**
+ * Whether an address is exempt. An IPv4 exemption never matches an IPv6 client and vice versa, but it
+ * does cover an IPv4-mapped client: canonicalizeIpAddress folds that form down to IPv4 first.
+ */
+export function isExemptIp(address: string, exemptions: readonly IpExemption[]): boolean {
+  if (exemptions.length === 0) {
+    return false
+  }
+  const canonicalAddress = canonicalizeIpAddress(address)
+  const bytes = canonicalAddress === null ? null : ipToBytes(canonicalAddress)
+  if (bytes === null) {
+    return false
+  }
+  return exemptions.some(
+    (exemption) =>
+      exemption.bytes.length === bytes.length && matchesPrefix(bytes, exemption.bytes, exemption.prefixBits)
+  )
+}

--- a/src/logic/deployment-quota/types.ts
+++ b/src/logic/deployment-quota/types.ts
@@ -1,0 +1,67 @@
+import { EntityType } from '@dcl/schemas'
+
+/** The horizons a client's deploy budget is measured over. */
+export enum DeploymentQuotaWindow {
+  MINUTE = 'minute',
+  HOUR = 'hour',
+  DAY = 'day',
+  WEEK = 'week'
+}
+
+/** One window's budget: `default` applies to every entity type without an override of its own. */
+export type DeploymentQuotaBudget = {
+  default: number
+  perEntityType: Map<EntityType, number>
+}
+
+export type DeploymentQuotaLadder = Record<DeploymentQuotaWindow, DeploymentQuotaBudget>
+
+/**
+ * What the quota reads off a request. Structural on purpose: the component does not depend on the
+ * HTTP framework's context type, and a test builds one from a literal.
+ */
+export type QuotaClient = {
+  remoteAddress?: string
+  request: { headers: { get(name: string): string | null } }
+}
+
+/** An address or CIDR whose deployments skip the quota. */
+export type IpExemption = {
+  /** Big-endian address bytes: 4 for IPv4, 16 for IPv6. */
+  bytes: Uint8Array
+  prefixBits: number
+}
+
+/** How an attempt was counted, reported on `dcl_content_deployment_quota_attempts_total`. */
+export enum DeploymentQuotaOutcome {
+  /** Counted and within the budget. */
+  ALLOWED = 'allowed',
+  /** Counted and over the budget, so the deployment was rejected. */
+  LIMITED = 'limited',
+  /**
+   * Not really counted — the counter was unreachable and the attempt was allowed through. Kept apart
+   * from `allowed` so a cache outage cannot pass for healthy traffic on a dashboard.
+   */
+  DEGRADED = 'degraded'
+}
+
+/** The outcome of counting one attempt against one window. */
+export type QuotaCountResult = {
+  allowed: boolean
+  /** The budget this attempt was measured against; the tightened cap in the shared bucket. */
+  limit: number
+  /** Seconds until the window resets, for `Retry-After`. Never below 1. */
+  retryAfterSeconds: number
+  /** True when the counter could not be read or written, so `allowed` reflects failing open. */
+  storeUnavailable: boolean
+}
+
+export type IDeploymentQuota = {
+  /**
+   * Counts one deploy attempt of `entityType` against the client's budget in every window, shortest
+   * first, stopping at the first window that is over.
+   *
+   * @throws DeploymentQuotaExceededError when a window's budget is exhausted.
+   */
+  assertWithinQuota(client: QuotaClient, entityType: EntityType): Promise<void>
+}

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -41,6 +41,15 @@ export const metricsDeclaration = validateMetricsDeclaration({
     labelNames: []
   },
 
+  // One series per window rather than the rate limiter's `rate_limiter_requests_total`: the quota
+  // counts against the cache directly (that component refuses a window longer than a day), and its
+  // bucket label carries no entity type, which is the dimension a quota is tuned on.
+  dcl_content_deployment_quota_attempts_total: {
+    help: 'Deploy attempts counted against the per-client-address, per-entity-type quota',
+    type: 'counter',
+    labelNames: ['entity_type', 'window', 'outcome'] // outcome=(allowed|limited|degraded)
+  },
+
   dcl_content_rate_limited_deployments_total: {
     help: 'Total failed deployments due rate limit',
     type: 'counter',

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,7 @@ import { IEntities } from './logic/entities'
 import { ISnapshots } from './logic/snapshots'
 import { ISyncOrchestrator } from './logic/sync-orchestrator'
 import { IBatchDeployer } from './logic/batch-deployer'
+import { IDeploymentQuota } from './logic/deployment-quota'
 import { IJobComponent } from '@dcl/job-component'
 
 // Minimum amount of needed stuff to make the sync work
@@ -114,6 +115,8 @@ export type AppComponents = {
   server: IHttpServerComponent<GlobalContext>
   /** Per-client request budget, currently mounted only on POST /entities. */
   rateLimiter: IRateLimiterComponent<GlobalContext>
+  /** Per-client-address, per-entity-type deployment budget over a minute, hour, day and week. */
+  deploymentQuota: IDeploymentQuota
   activeEntities: ActiveEntities
   sequentialExecutor: ISequentialTaskExecutorComponent
   denylist: Denylist

--- a/test/integration/controller/deployment-quota.spec.ts
+++ b/test/integration/controller/deployment-quota.spec.ts
@@ -1,0 +1,135 @@
+import { DeploymentData } from 'dcl-catalyst-client/dist/client/utils/DeploymentBuilder'
+import { EnvironmentConfig } from '../../../src/Environment'
+import { makeNoopValidator } from '../../helpers/logic/server-validator/NoOpValidator'
+import { buildDeployData } from '../E2ETestUtils'
+import { createDefaultServer } from '../simpleTestEnvironment'
+import { TestProgram } from '../TestProgram'
+
+/**
+ * Posts a deployment the way the client does, but returns the raw response so a test can read the
+ * status and the headers. `TestProgram.deployEntity` throws on anything not ok, which hides both.
+ */
+async function postEntity(server: TestProgram, deployData: DeploymentData): Promise<Response> {
+  const form = new FormData()
+  form.append('entityId', deployData.entityId)
+  form.append('authChain', JSON.stringify(deployData.authChain))
+  for (const [name, content] of deployData.files) {
+    form.append(name, new Blob([content]), name)
+  }
+  return fetch(`${server.getUrl()}/entities`, { method: 'POST', body: form })
+}
+
+/** Fresh pointers per deploy, so the per-pointer deploy rate limit never confuses the result. */
+async function postScenes(server: TestProgram, count: number): Promise<Response[]> {
+  const responses: Response[] = []
+  for (let index = 1; index <= count; index++) {
+    const { deployData } = await buildDeployData([`${index},${index}`], { metadata: { index } })
+    responses.push(await postEntity(server, deployData))
+  }
+  return responses
+}
+
+/**
+ * A server per test rather than per file: the quota is counted per running process, so a shared server
+ * would carry one test's spent budget into the next and every test after the first would pass — or
+ * fail — for reasons of its own.
+ *
+ * No `LeakDetector` assertion in the teardown, unlike the sibling specs: it needs the only reference to
+ * the server dropped before it measures, which a per-test server cannot promise. The sibling specs
+ * already cover this server's shutdown for leaks once per file, which is what that check is for.
+ */
+async function startServer(overrides: Record<number, any>): Promise<TestProgram> {
+  const server = await createDefaultServer({
+    [EnvironmentConfig.DISABLE_SYNCHRONIZATION]: true,
+    ...overrides
+  })
+  makeNoopValidator(server.components)
+  return server
+}
+
+describe('Integration - Deployment quota', () => {
+  let server: TestProgram
+
+  afterEach(async () => {
+    jest.restoreAllMocks()
+    await server.stopProgram()
+    server = null as any
+  })
+
+  describe('when a client has a budget of two scene deployments per minute', () => {
+    let responses: Response[]
+
+    beforeEach(async () => {
+      server = await startServer({ [EnvironmentConfig.DEPLOYMENT_QUOTA_MAX_PER_MINUTE]: 2 })
+      responses = await postScenes(server, 3)
+    })
+
+    it('should accept the deployments that fit the budget and reject the one past it', () => {
+      expect(responses.map((response) => response.status)).toEqual([200, 200, 429])
+    })
+  })
+
+  describe('and the rejected client reads the response', () => {
+    let rejection: Response
+    let body: unknown
+    let retryAfter: string | null
+
+    beforeEach(async () => {
+      server = await startServer({ [EnvironmentConfig.DEPLOYMENT_QUOTA_MAX_PER_MINUTE]: 1 })
+      rejection = (await postScenes(server, 2))[1]
+      retryAfter = rejection.headers.get('retry-after')
+      body = await rejection.json()
+    })
+
+    it('should be told when to come back', () => {
+      expect(Number(retryAfter)).toBeGreaterThan(0)
+    })
+
+    it('should get the error body the rest of the API uses', () => {
+      expect(body).toEqual({ error: expect.stringContaining('Too many deployments from this address') })
+    })
+
+    it('should not be told which budget or window it hit', () => {
+      expect(JSON.stringify(body)).not.toContain('minute')
+    })
+  })
+
+  describe('and a deployment of another entity type follows a scene rejection', () => {
+    let responses: Response[]
+    let profileResponse: Response
+
+    beforeEach(async () => {
+      server = await startServer({ [EnvironmentConfig.DEPLOYMENT_QUOTA_MAX_PER_MINUTE]: 1 })
+      responses = await postScenes(server, 2)
+      const { deployData } = await buildDeployData(['0x1337e0507eb4ab47e08a179573ed4533d9e22a7b'], {
+        type: 'profile',
+        metadata: { profile: true }
+      } as any)
+      profileResponse = await postEntity(server, deployData)
+    })
+
+    it('should have rejected the second scene', () => {
+      expect(responses[1].status).toBe(429)
+    })
+
+    it('should accept the profile, since the budgets are held per entity type', () => {
+      expect(profileResponse.status).toBe(200)
+    })
+  })
+
+  describe('when the client address is exempt', () => {
+    let responses: Response[]
+
+    beforeEach(async () => {
+      server = await startServer({
+        [EnvironmentConfig.DEPLOYMENT_QUOTA_MAX_PER_MINUTE]: 1,
+        [EnvironmentConfig.DEPLOYMENT_QUOTA_EXEMPT_IPS]: ['127.0.0.1', '::1']
+      })
+      responses = await postScenes(server, 3)
+    })
+
+    it('should accept every deployment, consuming no budget', () => {
+      expect(responses.map((response) => response.status)).toEqual([200, 200, 200])
+    })
+  })
+})

--- a/test/unit/controllers/create-entity-quota.spec.ts
+++ b/test/unit/controllers/create-entity-quota.spec.ts
@@ -1,0 +1,219 @@
+/**
+ * @jest-environment ./test/fetch-environment.js
+ *
+ * The handler reads `context.request.headers`, so these tests need the real `Request` class that
+ * Jest 27's sandboxed `node` environment omits.
+ */
+import { hashV1 } from '@dcl/hashing'
+import { HTTPProvider } from 'eth-connect'
+import { EntityType } from '@dcl/schemas'
+import { createTestMetricsComponent } from '@dcl/metrics'
+import { DeploymentContext } from '../../../src/deployment-types'
+import { createCrypto } from '../../../src/logic/crypto'
+import { DeploymentQuotaExceededError, DeploymentQuotaWindow } from '../../../src/logic/deployment-quota'
+import { IDeploymentQuota } from '../../../src/logic/deployment-quota/types'
+import { createEntity } from '../../../src/controllers/handlers/create-entity-handler'
+import { createErrorHandler } from '../../../src/controllers/middlewares'
+import { TooManyRequestsError } from '../../../src/controllers/errors'
+import { metricsDeclaration } from '../../../src/metrics'
+import { createLogsMockedComponent } from '../../mocks/logger-component-mock'
+
+const DEPLOYER_ADDRESS = '0x1337e0507eb4ab47e08a179573ed4533d9e22a7b'
+const CREATION_TIMESTAMP = 1_780_000_000_000
+
+type HandlerComponents = {
+  logs: ReturnType<typeof createLogsMockedComponent>
+  fs: unknown
+  metrics: ReturnType<typeof createTestMetricsComponent<keyof typeof metricsDeclaration>>
+  deployer: { deployEntity: jest.Mock }
+  crypto: ReturnType<typeof createCrypto>
+  entities: { parse: jest.Mock }
+  deploymentQuota: jest.Mocked<IDeploymentQuota>
+}
+
+/** A serialized entity plus the id it actually hashes to, which is what the deployer looks it up by. */
+async function buildEntityFile(): Promise<{ entityId: string; content: Buffer }> {
+  const content = Buffer.from(
+    JSON.stringify({ type: EntityType.SCENE, pointers: ['0,0'], timestamp: CREATION_TIMESTAMP, content: [] })
+  )
+  return { entityId: await hashV1(content), content }
+}
+
+/** Builds the context the router hands the handler after the multipart parser has run. */
+function buildContext(
+  components: HandlerComponents,
+  entityId: string,
+  files: Record<string, Buffer>,
+  remoteAddress = '203.0.113.7'
+): any {
+  return {
+    components,
+    remoteAddress,
+    request: new Request('http://localhost/entities', { method: 'POST' }),
+    url: new URL('http://localhost/entities'),
+    params: {},
+    formData: {
+      fields: {
+        entityId: { fieldname: 'entityId', value: entityId },
+        authChain: {
+          fieldname: 'authChain',
+          value: JSON.stringify([{ type: 'SIGNER', payload: DEPLOYER_ADDRESS, signature: '' }])
+        }
+      },
+      files: Object.fromEntries(
+        Object.entries(files).map(([name, content]) => [name, { fieldname: name, value: content }])
+      )
+    }
+  }
+}
+
+async function errorCountFor(components: HandlerComponents, kind: string): Promise<number> {
+  const metric = components.metrics.registry.getSingleMetric('dcl_deployments_endpoint_counter')
+  const values = ((await metric?.get())?.values ?? []) as { labels: { kind: string }; value: number }[]
+  return values.filter((value) => value.labels.kind === kind).reduce((total, value) => total + value.value, 0)
+}
+
+describe('when a client posts an entity', () => {
+  let components: HandlerComponents
+  let entityId: string
+  let content: Buffer
+
+  beforeEach(async () => {
+    ;({ entityId, content } = await buildEntityFile())
+    components = {
+      logs: createLogsMockedComponent(),
+      fs: {},
+      metrics: createTestMetricsComponent(metricsDeclaration),
+      deployer: { deployEntity: jest.fn().mockResolvedValue(CREATION_TIMESTAMP) },
+      crypto: createCrypto({} as HTTPProvider, [DEPLOYER_ADDRESS]),
+      entities: { parse: jest.fn().mockReturnValue({ type: EntityType.SCENE, pointers: ['0,0'] }) },
+      deploymentQuota: { assertWithinQuota: jest.fn().mockResolvedValue(undefined) }
+    }
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('and it is within its quota', () => {
+    let response: Awaited<ReturnType<typeof createEntity>>
+
+    beforeEach(async () => {
+      response = await createEntity(buildContext(components, entityId, { [entityId]: content }))
+    })
+
+    it('should deploy the entity', () => {
+      expect(response).toEqual({ status: 200, body: { creationTimestamp: CREATION_TIMESTAMP } })
+    })
+
+    it("should have counted the attempt against the entity's own type", () => {
+      expect(components.deploymentQuota.assertWithinQuota).toHaveBeenCalledWith(
+        expect.objectContaining({ remoteAddress: '203.0.113.7' }),
+        EntityType.SCENE
+      )
+    })
+
+    it('should hand the deployer the hashes it already computed, so nothing is hashed twice', () => {
+      expect(components.deployer.deployEntity).toHaveBeenCalledWith(
+        new Map([[entityId, content]]),
+        entityId,
+        expect.objectContaining({ version: 'v3' }),
+        DeploymentContext.LOCAL
+      )
+    })
+  })
+
+  describe('and the entity file is not named after its hash', () => {
+    beforeEach(async () => {
+      await createEntity(buildContext(components, entityId, { 'scene.json': content }))
+    })
+
+    it('should still count the attempt, since the entity is located by its computed hash', () => {
+      expect(components.deploymentQuota.assertWithinQuota).toHaveBeenCalledWith(expect.anything(), EntityType.SCENE)
+    })
+  })
+
+  describe('and the upload carries no entity file at all', () => {
+    beforeEach(async () => {
+      await createEntity(buildContext(components, entityId, { 'other.txt': Buffer.from('not the entity') }))
+    })
+
+    it('should leave the attempt uncounted rather than guess an entity type', () => {
+      expect(components.deploymentQuota.assertWithinQuota).not.toHaveBeenCalled()
+    })
+
+    it('should still hand the deployment to the deployer, which answers for it', () => {
+      expect(components.deployer.deployEntity).toHaveBeenCalled()
+    })
+  })
+
+  describe('and the entity file cannot be parsed', () => {
+    let response: Awaited<ReturnType<typeof createEntity>>
+
+    beforeEach(async () => {
+      components.entities.parse.mockImplementation(() => {
+        throw new Error('There was a problem parsing the entity')
+      })
+      components.deployer.deployEntity.mockResolvedValue({ errors: ['There was a problem parsing the entity'] })
+      response = await createEntity(buildContext(components, entityId, { [entityId]: content }))
+    })
+
+    it('should leave the attempt uncounted', () => {
+      expect(components.deploymentQuota.assertWithinQuota).not.toHaveBeenCalled()
+    })
+
+    it("should keep the deployer's own 400, rather than change the shape of that response", () => {
+      expect(response).toEqual({ status: 400, body: { errors: ['There was a problem parsing the entity'] } })
+    })
+  })
+
+  describe('and it has exhausted its quota', () => {
+    let thrown: unknown
+
+    beforeEach(async () => {
+      components.deploymentQuota.assertWithinQuota.mockRejectedValue(
+        new DeploymentQuotaExceededError(EntityType.SCENE, DeploymentQuotaWindow.HOUR, 600, 1234)
+      )
+      thrown = await createEntity(buildContext(components, entityId, { [entityId]: content })).catch((error) => error)
+    })
+
+    it('should reject the deployment with the retry delay the quota reported', () => {
+      expect(thrown).toMatchObject({ name: 'TooManyRequestsError', retryAfterSeconds: 1234 })
+    })
+
+    it('should not disclose the limit or the window that was hit', () => {
+      expect((thrown as Error).message).toBe('Too many deployments from this address. Retry in 1234 seconds.')
+    })
+
+    it('should never reach the deployer', () => {
+      expect(components.deployer.deployEntity).not.toHaveBeenCalled()
+    })
+
+    it('should not be counted as an internal error, which the rejected client would otherwise drive', async () => {
+      expect(await errorCountFor(components, 'error')).toBe(0)
+    })
+  })
+})
+
+describe('when the error handler receives a rejection from the deployment quota', () => {
+  let response: any
+
+  beforeEach(async () => {
+    const handler = createErrorHandler({ logs: createLogsMockedComponent() })
+    response = await handler({} as any, async () => {
+      throw new TooManyRequestsError('Too many deployments from this address. Retry in 42 seconds.', 42)
+    })
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should answer 429 with the retry delay and the error body the rest of the API uses', () => {
+    expect(response).toEqual({
+      status: 429,
+      body: { error: 'Too many deployments from this address. Retry in 42 seconds.' },
+      headers: { 'Retry-After': '42' }
+    })
+  })
+})

--- a/test/unit/logic/deployment-quota/component.spec.ts
+++ b/test/unit/logic/deployment-quota/component.spec.ts
@@ -1,0 +1,367 @@
+import { EntityType } from '@dcl/schemas'
+import { createTestMetricsComponent } from '@dcl/metrics'
+import { Registry } from 'prom-client'
+import { Environment, EnvironmentConfig } from '../../../../src/Environment'
+import { metricsDeclaration } from '../../../../src/metrics'
+import {
+  createDeploymentQuota,
+  DeploymentQuotaExceededError,
+  DeploymentQuotaWindow
+} from '../../../../src/logic/deployment-quota'
+import { IDeploymentQuota, QuotaClient } from '../../../../src/logic/deployment-quota/types'
+import { createLogsMockedComponent } from '../../../mocks/logger-component-mock'
+
+type QuotaConfig = {
+  perMinute?: number
+  perHour?: number
+  perDay?: number
+  perWeek?: number
+  perMinuteByEntityType?: Map<EntityType, number>
+  perHourByEntityType?: Map<EntityType, number>
+  exemptIps?: string[]
+  trustedClientIpHeader?: string
+}
+
+/** Every quota config set explicitly, so no test depends on a production default. */
+function buildEnvironment(config: QuotaConfig): Environment {
+  return new Environment()
+    .setConfig(EnvironmentConfig.DEPLOYMENT_QUOTA_MAX_PER_MINUTE, config.perMinute ?? 1000)
+    .setConfig(EnvironmentConfig.DEPLOYMENT_QUOTA_MAX_PER_HOUR, config.perHour ?? 1000)
+    .setConfig(EnvironmentConfig.DEPLOYMENT_QUOTA_MAX_PER_DAY, config.perDay ?? 1000)
+    .setConfig(EnvironmentConfig.DEPLOYMENT_QUOTA_MAX_PER_WEEK, config.perWeek ?? 1000)
+    .setConfig(
+      EnvironmentConfig.DEPLOYMENT_QUOTA_MAX_PER_MINUTE_BY_ENTITY_TYPE,
+      config.perMinuteByEntityType ?? new Map()
+    )
+    .setConfig(EnvironmentConfig.DEPLOYMENT_QUOTA_MAX_PER_HOUR_BY_ENTITY_TYPE, config.perHourByEntityType ?? new Map())
+    .setConfig(EnvironmentConfig.DEPLOYMENT_QUOTA_MAX_PER_DAY_BY_ENTITY_TYPE, new Map())
+    .setConfig(EnvironmentConfig.DEPLOYMENT_QUOTA_MAX_PER_WEEK_BY_ENTITY_TYPE, new Map())
+    .setConfig(EnvironmentConfig.DEPLOYMENT_QUOTA_EXEMPT_IPS, config.exemptIps ?? [])
+    .setConfig(EnvironmentConfig.DEPLOYMENT_QUOTA_CACHE_MAX_KEYS, 1000)
+    .setConfig(EnvironmentConfig.TRUSTED_CLIENT_IP_HEADER, config.trustedClientIpHeader)
+}
+
+/** Only what the quota reads off a request, so no HTTP server or Web globals are involved. */
+function buildClient(remoteAddress: string | undefined, headers: Record<string, string> = {}): QuotaClient {
+  return {
+    remoteAddress,
+    request: { headers: { get: (name: string) => headers[name.toLowerCase()] ?? null } }
+  }
+}
+
+/** Rejects rather than throws, so a test asserts on an outcome instead of a control-flow shape. */
+async function attempt(
+  quota: IDeploymentQuota,
+  client: QuotaClient,
+  entityType: EntityType
+): Promise<'allowed' | DeploymentQuotaExceededError> {
+  try {
+    await quota.assertWithinQuota(client, entityType)
+    return 'allowed'
+  } catch (error) {
+    if (error instanceof DeploymentQuotaExceededError) {
+      return error
+    }
+    throw error
+  }
+}
+
+async function attemptTimes(
+  quota: IDeploymentQuota,
+  client: QuotaClient,
+  entityType: EntityType,
+  times: number
+): Promise<('allowed' | DeploymentQuotaExceededError)[]> {
+  const outcomes: ('allowed' | DeploymentQuotaExceededError)[] = []
+  for (let index = 0; index < times; index++) {
+    outcomes.push(await attempt(quota, client, entityType))
+  }
+  return outcomes
+}
+
+type AttemptSample = { labels: { entity_type: string; window: string; outcome: string }; value: number }
+
+async function attemptSamples(registry: Registry): Promise<AttemptSample[]> {
+  const metric = registry.getSingleMetric('dcl_content_deployment_quota_attempts_total')
+  return ((await metric?.get())?.values ?? []) as AttemptSample[]
+}
+
+/** How many attempts were counted against one window, whatever the outcome. */
+async function attemptsCountedForWindow(registry: Registry, window: DeploymentQuotaWindow): Promise<number> {
+  return (await attemptSamples(registry))
+    .filter((sample) => sample.labels.window === window)
+    .reduce((total, sample) => total + sample.value, 0)
+}
+
+describe('when building the deployment quota', () => {
+  let metrics: ReturnType<typeof createTestMetricsComponent<keyof typeof metricsDeclaration>>
+
+  beforeEach(() => {
+    metrics = createTestMetricsComponent(metricsDeclaration)
+  })
+
+  describe('and a longer window is tighter than a shorter one', () => {
+    let env: Environment
+
+    beforeEach(() => {
+      env = buildEnvironment({ perMinute: 60, perHour: 10 })
+    })
+
+    it('should fail at startup rather than install a ladder whose minute budget is unreachable', () => {
+      expect(() => createDeploymentQuota({ env, logs: createLogsMockedComponent(), metrics })).toThrow(
+        'A longer window must not be tighter than a shorter one'
+      )
+    })
+  })
+
+  describe('and an exempt address is malformed', () => {
+    let env: Environment
+
+    beforeEach(() => {
+      env = buildEnvironment({ exemptIps: ['198.51.100.0/24', 'not-an-ip'] })
+    })
+
+    it('should fail at startup rather than silently exempt nothing', () => {
+      expect(() => createDeploymentQuota({ env, logs: createLogsMockedComponent(), metrics })).toThrow(
+        'Invalid DEPLOYMENT_QUOTA_EXEMPT_IPS entry "not-an-ip"'
+      )
+    })
+  })
+})
+
+describe('when a client attempts a deployment', () => {
+  let metrics: ReturnType<typeof createTestMetricsComponent<keyof typeof metricsDeclaration>>
+  let quota: IDeploymentQuota
+  let client: QuotaClient
+
+  const build = (config: QuotaConfig): IDeploymentQuota =>
+    createDeploymentQuota({ env: buildEnvironment(config), logs: createLogsMockedComponent(), metrics })
+
+  beforeEach(() => {
+    metrics = createTestMetricsComponent(metricsDeclaration)
+    client = buildClient('203.0.113.7')
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('and it stays within every window', () => {
+    let outcomes: ('allowed' | DeploymentQuotaExceededError)[]
+
+    beforeEach(async () => {
+      quota = build({ perMinute: 3 })
+      outcomes = await attemptTimes(quota, client, EntityType.SCENE, 3)
+    })
+
+    it('should allow every attempt', () => {
+      expect(outcomes).toEqual(['allowed', 'allowed', 'allowed'])
+    })
+  })
+
+  describe('and it exceeds the minute budget', () => {
+    let outcome: 'allowed' | DeploymentQuotaExceededError
+    let limitedSamples: AttemptSample[]
+
+    beforeEach(async () => {
+      quota = build({ perMinute: 2 })
+      outcome = (await attemptTimes(quota, client, EntityType.SCENE, 3))[2]
+      limitedSamples = (await attemptSamples(metrics.registry)).filter((sample) => sample.labels.outcome === 'limited')
+    })
+
+    it('should reject the attempt naming the minute window', () => {
+      expect(outcome).toMatchObject({ window: DeploymentQuotaWindow.MINUTE, entityType: EntityType.SCENE, limit: 2 })
+    })
+
+    it('should carry a retry delay within the window it has to wait out', () => {
+      expect((outcome as DeploymentQuotaExceededError).retryAfterSeconds).toBeGreaterThanOrEqual(1)
+    })
+
+    it('should report the rejection as a limited attempt on the entity type and the window', () => {
+      expect(limitedSamples).toEqual([
+        {
+          labels: { entity_type: EntityType.SCENE, window: DeploymentQuotaWindow.MINUTE, outcome: 'limited' },
+          value: 1
+        }
+      ])
+    })
+  })
+
+  describe('and several windows hold the same budget it has just spent', () => {
+    let outcome: 'allowed' | DeploymentQuotaExceededError
+
+    beforeEach(async () => {
+      // A burst can only ever trip the shortest window: the ladder is monotonic, so every longer
+      // window's budget is at least as large and is reached later. The longer horizons bind a client
+      // that paces itself across windows, which is why they exist.
+      quota = build({ perMinute: 2, perHour: 2, perDay: 2, perWeek: 2 })
+      outcome = (await attemptTimes(quota, client, EntityType.SCENE, 3))[2]
+    })
+
+    it('should reject the attempt naming the shortest of them', () => {
+      expect(outcome).toMatchObject({ window: DeploymentQuotaWindow.MINUTE, limit: 2 })
+    })
+  })
+
+  describe('and it keeps retrying after the minute budget is spent', () => {
+    let minuteAttempts: number
+    let hourAttempts: number
+
+    beforeEach(async () => {
+      quota = build({ perMinute: 1, perHour: 5 })
+      await attemptTimes(quota, client, EntityType.SCENE, 4)
+      minuteAttempts = await attemptsCountedForWindow(metrics.registry, DeploymentQuotaWindow.MINUTE)
+      hourAttempts = await attemptsCountedForWindow(metrics.registry, DeploymentQuotaWindow.HOUR)
+    })
+
+    it('should stop at the blown window, leaving the longer budgets unspent by the retries', () => {
+      expect(hourAttempts).toBe(1)
+    })
+
+    it('should still have counted every retry against the window that is already blown', () => {
+      expect(minuteAttempts).toBe(4)
+    })
+  })
+
+  describe('and the entity type has a tighter override', () => {
+    let sceneOutcome: 'allowed' | DeploymentQuotaExceededError
+    let profileOutcome: 'allowed' | DeploymentQuotaExceededError
+
+    beforeEach(async () => {
+      quota = build({ perMinute: 10, perMinuteByEntityType: new Map([[EntityType.SCENE, 1]]) })
+      sceneOutcome = (await attemptTimes(quota, client, EntityType.SCENE, 2))[1]
+      profileOutcome = await attempt(quota, client, EntityType.PROFILE)
+    })
+
+    it('should apply the override to that entity type', () => {
+      expect(sceneOutcome).toMatchObject({ window: DeploymentQuotaWindow.MINUTE, limit: 1 })
+    })
+
+    it('should leave every other entity type on the window default', () => {
+      expect(profileOutcome).toBe('allowed')
+    })
+  })
+
+  describe('and another entity type has already spent its budget', () => {
+    let outcome: 'allowed' | DeploymentQuotaExceededError
+
+    beforeEach(async () => {
+      quota = build({ perMinute: 1 })
+      await attemptTimes(quota, client, EntityType.SCENE, 2)
+      outcome = await attempt(quota, client, EntityType.PROFILE)
+    })
+
+    it('should still allow it, since the budgets are held per entity type', () => {
+      expect(outcome).toBe('allowed')
+    })
+  })
+
+  describe('and another address has already spent its budget', () => {
+    let outcome: 'allowed' | DeploymentQuotaExceededError
+
+    beforeEach(async () => {
+      quota = build({ perMinute: 1 })
+      await attemptTimes(quota, buildClient('198.51.100.1'), EntityType.SCENE, 2)
+      outcome = await attempt(quota, client, EntityType.SCENE)
+    })
+
+    it('should still allow it, since the budgets are held per client address', () => {
+      expect(outcome).toBe('allowed')
+    })
+  })
+
+  describe('and the address is exempt', () => {
+    let outcomes: ('allowed' | DeploymentQuotaExceededError)[]
+
+    beforeEach(async () => {
+      quota = build({ perMinute: 1, exemptIps: ['203.0.113.0/24'] })
+      outcomes = await attemptTimes(quota, client, EntityType.SCENE, 5)
+    })
+
+    it('should allow every attempt, consuming no budget', () => {
+      expect(outcomes).toEqual(['allowed', 'allowed', 'allowed', 'allowed', 'allowed'])
+    })
+  })
+
+  describe('and no client address can be established', () => {
+    let outcome: 'allowed' | DeploymentQuotaExceededError
+
+    beforeEach(async () => {
+      quota = build({ perMinute: 100 })
+      outcome = (await attemptTimes(quota, buildClient(undefined), EntityType.SCENE, 11))[10]
+    })
+
+    it('should measure it against the shared bucket at a tightened cap rather than the full budget', () => {
+      expect(outcome).toMatchObject({ window: DeploymentQuotaWindow.MINUTE, limit: 10 })
+    })
+  })
+})
+
+describe('when a trusted client IP header is configured', () => {
+  let metrics: ReturnType<typeof createTestMetricsComponent<keyof typeof metricsDeclaration>>
+  let quota: IDeploymentQuota
+
+  beforeEach(() => {
+    metrics = createTestMetricsComponent(metricsDeclaration)
+    quota = createDeploymentQuota({
+      env: buildEnvironment({ perMinute: 1, trustedClientIpHeader: 'x-real-ip' }),
+      logs: createLogsMockedComponent(),
+      metrics
+    })
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('and two clients share a socket address but carry different header addresses', () => {
+    let outcome: 'allowed' | DeploymentQuotaExceededError
+
+    beforeEach(async () => {
+      await attemptTimes(quota, buildClient('10.0.0.1', { 'x-real-ip': '203.0.113.7' }), EntityType.SCENE, 2)
+      outcome = await attempt(quota, buildClient('10.0.0.1', { 'x-real-ip': '198.51.100.1' }), EntityType.SCENE)
+    })
+
+    it('should give each its own budget, taking the header over the proxy socket address', () => {
+      expect(outcome).toBe('allowed')
+    })
+  })
+
+  describe('and the header holds a value that is not an address', () => {
+    let outcome: 'allowed' | DeploymentQuotaExceededError
+
+    beforeEach(async () => {
+      await attemptTimes(quota, buildClient('10.0.0.1', { 'x-real-ip': 'garbage' }), EntityType.SCENE, 2)
+      outcome = await attempt(quota, buildClient('10.0.0.1', { 'x-real-ip': 'other-garbage' }), EntityType.SCENE)
+    })
+
+    it('should fall back to the socket address rather than let a caller mint buckets', () => {
+      expect(outcome).toMatchObject({ window: DeploymentQuotaWindow.MINUTE })
+    })
+  })
+})
+
+describe('when no trusted client IP header is configured', () => {
+  let metrics: ReturnType<typeof createTestMetricsComponent<keyof typeof metricsDeclaration>>
+  let quota: IDeploymentQuota
+  let outcome: 'allowed' | DeploymentQuotaExceededError
+
+  beforeEach(async () => {
+    metrics = createTestMetricsComponent(metricsDeclaration)
+    quota = createDeploymentQuota({
+      env: buildEnvironment({ perMinute: 1 }),
+      logs: createLogsMockedComponent(),
+      metrics
+    })
+    await attemptTimes(quota, buildClient('10.0.0.1', { 'x-forwarded-for': '203.0.113.7' }), EntityType.SCENE, 2)
+    outcome = await attempt(quota, buildClient('10.0.0.1', { 'x-forwarded-for': '198.51.100.1' }), EntityType.SCENE)
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should ignore a forwarding header a caller sent and keep both on the socket address budget', () => {
+    expect(outcome).toMatchObject({ window: DeploymentQuotaWindow.MINUTE })
+  })
+})

--- a/test/unit/logic/deployment-quota/config.spec.ts
+++ b/test/unit/logic/deployment-quota/config.spec.ts
@@ -1,0 +1,171 @@
+import { EntityType } from '@dcl/schemas'
+import {
+  DEFAULT_DEPLOYMENT_QUOTA_MAX_PER_DAY,
+  DEFAULT_DEPLOYMENT_QUOTA_MAX_PER_HOUR,
+  DEFAULT_DEPLOYMENT_QUOTA_MAX_PER_MINUTE,
+  DEFAULT_DEPLOYMENT_QUOTA_MAX_PER_WEEK,
+  Environment,
+  EnvironmentBuilder,
+  EnvironmentConfig
+} from '../../../../src/Environment'
+
+describe('when reading the deployment quota configuration', () => {
+  let originalEnv: NodeJS.ProcessEnv
+
+  beforeEach(() => {
+    originalEnv = process.env
+    process.env = { ...originalEnv }
+    for (const name of Object.keys(process.env)) {
+      if (name.startsWith('DEPLOYMENT_QUOTA_')) {
+        delete process.env[name]
+      }
+    }
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+  })
+
+  describe('and nothing is set', () => {
+    let env: Environment
+
+    beforeEach(async () => {
+      env = await new EnvironmentBuilder().build()
+    })
+
+    it('should install the default ladder so the server runs unconfigured', () => {
+      expect([
+        env.getConfig(EnvironmentConfig.DEPLOYMENT_QUOTA_MAX_PER_MINUTE),
+        env.getConfig(EnvironmentConfig.DEPLOYMENT_QUOTA_MAX_PER_HOUR),
+        env.getConfig(EnvironmentConfig.DEPLOYMENT_QUOTA_MAX_PER_DAY),
+        env.getConfig(EnvironmentConfig.DEPLOYMENT_QUOTA_MAX_PER_WEEK)
+      ]).toEqual([
+        DEFAULT_DEPLOYMENT_QUOTA_MAX_PER_MINUTE,
+        DEFAULT_DEPLOYMENT_QUOTA_MAX_PER_HOUR,
+        DEFAULT_DEPLOYMENT_QUOTA_MAX_PER_DAY,
+        DEFAULT_DEPLOYMENT_QUOTA_MAX_PER_WEEK
+      ])
+    })
+
+    it('should leave the default ladder monotonic, so no window is unreachable', () => {
+      expect([
+        DEFAULT_DEPLOYMENT_QUOTA_MAX_PER_MINUTE <= DEFAULT_DEPLOYMENT_QUOTA_MAX_PER_HOUR,
+        DEFAULT_DEPLOYMENT_QUOTA_MAX_PER_HOUR <= DEFAULT_DEPLOYMENT_QUOTA_MAX_PER_DAY,
+        DEFAULT_DEPLOYMENT_QUOTA_MAX_PER_DAY <= DEFAULT_DEPLOYMENT_QUOTA_MAX_PER_WEEK
+      ]).toEqual([true, true, true])
+    })
+
+    it('should exempt no address', () => {
+      expect(env.getConfig(EnvironmentConfig.DEPLOYMENT_QUOTA_EXEMPT_IPS)).toEqual([])
+    })
+
+    it('should leave every window without per-entity-type overrides', () => {
+      expect(env.getConfig(EnvironmentConfig.DEPLOYMENT_QUOTA_MAX_PER_HOUR_BY_ENTITY_TYPE)).toEqual(new Map())
+    })
+  })
+
+  describe('and a window budget is set', () => {
+    let env: Environment
+
+    beforeEach(async () => {
+      process.env.DEPLOYMENT_QUOTA_MAX_PER_MINUTE = '5'
+      env = await new EnvironmentBuilder().build()
+    })
+
+    it('should read it from the environment', () => {
+      expect(env.getConfig(EnvironmentConfig.DEPLOYMENT_QUOTA_MAX_PER_MINUTE)).toBe(5)
+    })
+  })
+
+  describe('and a per-entity-type override is set', () => {
+    let env: Environment
+
+    beforeEach(async () => {
+      process.env.DEPLOYMENT_QUOTA_MAX_PER_HOUR_SCENE = '20'
+      process.env.DEPLOYMENT_QUOTA_MAX_PER_HOUR_OUTFITS = '40'
+      env = await new EnvironmentBuilder().build()
+    })
+
+    it('should collect it under the window it belongs to', () => {
+      expect(env.getConfig(EnvironmentConfig.DEPLOYMENT_QUOTA_MAX_PER_HOUR_BY_ENTITY_TYPE)).toEqual(
+        new Map([
+          [EntityType.SCENE, 20],
+          [EntityType.OUTFITS, 40]
+        ])
+      )
+    })
+
+    it('should not let it leak into another window', () => {
+      expect(env.getConfig(EnvironmentConfig.DEPLOYMENT_QUOTA_MAX_PER_DAY_BY_ENTITY_TYPE)).toEqual(new Map())
+    })
+
+    it("should leave the window's own budget untouched", () => {
+      expect(env.getConfig(EnvironmentConfig.DEPLOYMENT_QUOTA_MAX_PER_HOUR)).toBe(DEFAULT_DEPLOYMENT_QUOTA_MAX_PER_HOUR)
+    })
+  })
+
+  describe('and a window budget is set to zero', () => {
+    beforeEach(() => {
+      process.env.DEPLOYMENT_QUOTA_MAX_PER_DAY = '0'
+    })
+
+    it('should fail at startup rather than install a quota that rejects every deployment', async () => {
+      await expect(new EnvironmentBuilder().build()).rejects.toThrow('Invalid DEPLOYMENT_QUOTA_MAX_PER_DAY')
+    })
+  })
+
+  describe('and a window budget is not a number', () => {
+    beforeEach(() => {
+      process.env.DEPLOYMENT_QUOTA_MAX_PER_WEEK = '10k'
+    })
+
+    it('should fail at startup rather than silently truncate the value', async () => {
+      await expect(new EnvironmentBuilder().build()).rejects.toThrow('Invalid DEPLOYMENT_QUOTA_MAX_PER_WEEK')
+    })
+  })
+
+  describe('and a per-entity-type override is set to zero', () => {
+    beforeEach(() => {
+      process.env.DEPLOYMENT_QUOTA_MAX_PER_MINUTE_SCENE = '0'
+    })
+
+    it('should fail at startup rather than block every scene deployment', async () => {
+      await expect(new EnvironmentBuilder().build()).rejects.toThrow('Invalid DEPLOYMENT_QUOTA_MAX_PER_MINUTE_SCENE')
+    })
+  })
+
+  describe('and a per-entity-type override names something that is not an entity type', () => {
+    beforeEach(() => {
+      process.env.DEPLOYMENT_QUOTA_MAX_PER_MINUTE_SCENES = '20'
+    })
+
+    it('should fail at startup rather than record an override nothing will ever read', async () => {
+      await expect(new EnvironmentBuilder().build()).rejects.toThrow(
+        'Invalid DEPLOYMENT_QUOTA_MAX_PER_MINUTE_SCENES: "SCENES" is not an entity type'
+      )
+    })
+  })
+
+  describe('and the exempt address list is set', () => {
+    let env: Environment
+
+    beforeEach(async () => {
+      process.env.DEPLOYMENT_QUOTA_EXEMPT_IPS = ' 203.0.113.7 , 198.51.100.0/24 ,, '
+      env = await new EnvironmentBuilder().build()
+    })
+
+    it('should split it, trimming each entry and dropping the empty ones', () => {
+      expect(env.getConfig(EnvironmentConfig.DEPLOYMENT_QUOTA_EXEMPT_IPS)).toEqual(['203.0.113.7', '198.51.100.0/24'])
+    })
+  })
+
+  describe('and the counter cache size is set to zero', () => {
+    beforeEach(() => {
+      process.env.DEPLOYMENT_QUOTA_CACHE_MAX_KEYS = '0'
+    })
+
+    it('should fail at startup rather than build a cache that holds no counters', async () => {
+      await expect(new EnvironmentBuilder().build()).rejects.toThrow('Invalid DEPLOYMENT_QUOTA_CACHE_MAX_KEYS')
+    })
+  })
+})

--- a/test/unit/logic/deployment-quota/counter.spec.ts
+++ b/test/unit/logic/deployment-quota/counter.spec.ts
@@ -1,0 +1,159 @@
+import { ICacheStorageComponent } from '@dcl/core-commons'
+import { createInMemoryCacheComponent } from '@dcl/memory-cache-component'
+import { FALLBACK_MAX_DIVISOR, countAttempt } from '../../../../src/logic/deployment-quota'
+import { QuotaCountResult } from '../../../../src/logic/deployment-quota/types'
+
+const MINUTE_SECONDS = 60
+const WEEK_SECONDS = 7 * 24 * 60 * 60
+const NOW = 1_780_000_000_000
+
+describe('when counting an attempt against a window', () => {
+  let cache: ICacheStorageComponent
+
+  beforeEach(() => {
+    cache = createInMemoryCacheComponent({ max: 100, ttl: 0 })
+  })
+
+  describe('and the identity is under its budget', () => {
+    let results: QuotaCountResult[]
+
+    beforeEach(async () => {
+      results = [
+        await countAttempt(cache, 'minute', 'scene:203.0.113.7', 2, MINUTE_SECONDS, NOW),
+        await countAttempt(cache, 'minute', 'scene:203.0.113.7', 2, MINUTE_SECONDS, NOW)
+      ]
+    })
+
+    it('should allow every attempt up to the budget', () => {
+      expect(results.map((result) => result.allowed)).toEqual([true, true])
+    })
+  })
+
+  describe('and the identity goes one over its budget', () => {
+    let result: QuotaCountResult
+
+    beforeEach(async () => {
+      await countAttempt(cache, 'minute', 'scene:203.0.113.7', 1, MINUTE_SECONDS, NOW)
+      result = await countAttempt(cache, 'minute', 'scene:203.0.113.7', 1, MINUTE_SECONDS, NOW)
+    })
+
+    it('should reject it against the configured budget', () => {
+      expect(result).toMatchObject({ allowed: false, limit: 1, storeUnavailable: false })
+    })
+
+    it('should ask the caller to retry no later than the end of the window', () => {
+      expect(result.retryAfterSeconds).toBeGreaterThan(0)
+    })
+
+    it('should never ask the caller to retry immediately', () => {
+      expect(result.retryAfterSeconds).toBeLessThanOrEqual(MINUTE_SECONDS)
+    })
+  })
+
+  describe('and the same identity is counted in two different buckets', () => {
+    let results: QuotaCountResult[]
+
+    beforeEach(async () => {
+      await countAttempt(cache, 'minute', 'scene:203.0.113.7', 1, MINUTE_SECONDS, NOW)
+      results = [
+        await countAttempt(cache, 'minute', 'scene:203.0.113.7', 1, MINUTE_SECONDS, NOW),
+        await countAttempt(cache, 'week', 'scene:203.0.113.7', 1, WEEK_SECONDS, NOW)
+      ]
+    })
+
+    it('should hold a counter per bucket, so one window does not spend another', () => {
+      expect(results.map((result) => result.allowed)).toEqual([false, true])
+    })
+  })
+
+  describe('and the window is longer than the rate limiter would accept', () => {
+    let result: QuotaCountResult
+
+    beforeEach(async () => {
+      result = await countAttempt(cache, 'week', 'scene:203.0.113.7', 1, WEEK_SECONDS, NOW)
+    })
+
+    it('should still count it, which is why the counting is not delegated to consume()', () => {
+      expect(result).toMatchObject({ allowed: true, storeUnavailable: false })
+    })
+
+    it('should hold the retry delay inside the week it belongs to', () => {
+      expect(result.retryAfterSeconds).toBeLessThanOrEqual(WEEK_SECONDS)
+    })
+  })
+
+  describe('and two identities are counted in the same bucket', () => {
+    let results: QuotaCountResult[]
+
+    beforeEach(async () => {
+      await countAttempt(cache, 'minute', 'scene:203.0.113.7', 1, MINUTE_SECONDS, NOW)
+      results = [
+        await countAttempt(cache, 'minute', 'scene:203.0.113.7', 1, MINUTE_SECONDS, NOW),
+        await countAttempt(cache, 'minute', 'scene:198.51.100.1', 1, MINUTE_SECONDS, NOW)
+      ]
+    })
+
+    it('should hold a counter per identity', () => {
+      expect(results.map((result) => result.allowed)).toEqual([false, true])
+    })
+  })
+
+  describe('and the identity is empty because no client address could be established', () => {
+    let results: QuotaCountResult[]
+
+    beforeEach(async () => {
+      results = []
+      for (let attempt = 0; attempt < FALLBACK_MAX_DIVISOR + 1; attempt++) {
+        results.push(await countAttempt(cache, 'minute', '', 100, MINUTE_SECONDS, NOW))
+      }
+    })
+
+    it('should measure it against the budget tightened by the fallback divisor', () => {
+      expect(results[results.length - 1]).toMatchObject({ allowed: false, limit: 10 })
+    })
+  })
+
+  describe('and a budget too small to divide lands in the shared bucket', () => {
+    let result: QuotaCountResult
+
+    beforeEach(async () => {
+      result = await countAttempt(cache, 'minute', '   ', 5, MINUTE_SECONDS, NOW)
+    })
+
+    it('should floor the tightened cap at one rather than at zero, which would reject everything', () => {
+      expect(result).toMatchObject({ allowed: true, limit: 1 })
+    })
+  })
+
+  describe('and the counter cannot be written', () => {
+    let result: QuotaCountResult
+    let increment: jest.Mock
+
+    beforeEach(async () => {
+      increment = jest.fn().mockRejectedValue(new Error('the counter store is unreachable'))
+      result = await countAttempt({ increment }, 'minute', 'scene:203.0.113.7', 1, MINUTE_SECONDS, NOW)
+    })
+
+    afterEach(() => {
+      jest.clearAllMocks()
+    })
+
+    it('should fail open, since an unreachable counter must not stop deployments', () => {
+      expect(result).toMatchObject({ allowed: true, storeUnavailable: true })
+    })
+  })
+
+  describe('and a window boundary is being approached', () => {
+    let result: QuotaCountResult
+
+    beforeEach(async () => {
+      // Any instant inside the window: the phase is derived from the identity, so the test cannot pick
+      // the boundary, only assert the delay stays inside one window's length.
+      result = await countAttempt(cache, 'minute', 'scene:203.0.113.7', 1, MINUTE_SECONDS, NOW + 59_999)
+    })
+
+    it('should never report a delay of zero seconds', () => {
+      expect(result.retryAfterSeconds).toBeGreaterThanOrEqual(1)
+    })
+  })
+})

--- a/test/unit/logic/deployment-quota/logic.spec.ts
+++ b/test/unit/logic/deployment-quota/logic.spec.ts
@@ -1,0 +1,243 @@
+import { EntityType } from '@dcl/schemas'
+import {
+  DEPLOYMENT_QUOTA_WINDOWS,
+  DEPLOYMENT_QUOTA_WINDOW_SECONDS,
+  DeploymentQuotaWindow,
+  assertMonotonicQuotaLadder,
+  budgetFor,
+  isExemptIp,
+  parseIpExemptions
+} from '../../../../src/logic/deployment-quota'
+import { DeploymentQuotaLadder } from '../../../../src/logic/deployment-quota/types'
+
+/** A ladder with the same budget in every window, so a test only states what it changes. */
+function buildLadder(
+  overrides: Partial<Record<DeploymentQuotaWindow, Partial<DeploymentQuotaLadder[DeploymentQuotaWindow]>>> = {}
+): DeploymentQuotaLadder {
+  const ladder = {} as DeploymentQuotaLadder
+  for (const window of DEPLOYMENT_QUOTA_WINDOWS) {
+    ladder[window] = {
+      default: overrides[window]?.default ?? 100,
+      perEntityType: overrides[window]?.perEntityType ?? new Map()
+    }
+  }
+  return ladder
+}
+
+describe('when reading the window table', () => {
+  it('should evaluate the windows shortest first, so a burst trips the minute before the week', () => {
+    expect(DEPLOYMENT_QUOTA_WINDOWS.map((window) => DEPLOYMENT_QUOTA_WINDOW_SECONDS[window])).toEqual([
+      60, 3600, 86400, 604800
+    ])
+  })
+})
+
+describe('when resolving the budget of an entity type', () => {
+  let ladder: DeploymentQuotaLadder
+
+  beforeEach(() => {
+    ladder = buildLadder({
+      [DeploymentQuotaWindow.HOUR]: { default: 600, perEntityType: new Map([[EntityType.SCENE, 20]]) }
+    })
+  })
+
+  describe('and the entity type has an override for that window', () => {
+    it("should return the override instead of the window's default", () => {
+      expect(budgetFor(ladder, DeploymentQuotaWindow.HOUR, EntityType.SCENE)).toBe(20)
+    })
+  })
+
+  describe('and the entity type has no override for that window', () => {
+    it("should fall back to the window's default", () => {
+      expect(budgetFor(ladder, DeploymentQuotaWindow.HOUR, EntityType.PROFILE)).toBe(600)
+    })
+  })
+
+  describe('and the override belongs to a different window', () => {
+    it('should not leak into the window being asked about', () => {
+      expect(budgetFor(ladder, DeploymentQuotaWindow.DAY, EntityType.SCENE)).toBe(100)
+    })
+  })
+})
+
+describe('when validating a quota ladder', () => {
+  describe('and every window is at least as generous as the shorter one', () => {
+    let ladder: DeploymentQuotaLadder
+
+    beforeEach(() => {
+      ladder = buildLadder({
+        [DeploymentQuotaWindow.MINUTE]: { default: 60 },
+        [DeploymentQuotaWindow.HOUR]: { default: 600 },
+        [DeploymentQuotaWindow.DAY]: { default: 3000 },
+        [DeploymentQuotaWindow.WEEK]: { default: 10000 }
+      })
+    })
+
+    it('should accept it', () => {
+      expect(() => assertMonotonicQuotaLadder(ladder)).not.toThrow()
+    })
+  })
+
+  describe('and two windows hold the same budget', () => {
+    let ladder: DeploymentQuotaLadder
+
+    beforeEach(() => {
+      ladder = buildLadder()
+    })
+
+    it('should accept it, since the shorter budget is still reachable', () => {
+      expect(() => assertMonotonicQuotaLadder(ladder)).not.toThrow()
+    })
+  })
+
+  describe('and a longer window is tighter than a shorter one', () => {
+    let ladder: DeploymentQuotaLadder
+
+    beforeEach(() => {
+      ladder = buildLadder({
+        [DeploymentQuotaWindow.MINUTE]: { default: 60 },
+        [DeploymentQuotaWindow.HOUR]: { default: 10 }
+      })
+    })
+
+    it("should reject it, since the shorter window's budget could never be spent", () => {
+      expect(() => assertMonotonicQuotaLadder(ladder)).toThrow(
+        'The deployment quota for every entity type allows 10 per hour but 60 per minute'
+      )
+    })
+  })
+
+  describe('and only one entity type breaks the order through its overrides', () => {
+    let ladder: DeploymentQuotaLadder
+
+    beforeEach(() => {
+      // Every default stays flat, so only the scene override breaks the order.
+      ladder = buildLadder({
+        [DeploymentQuotaWindow.DAY]: { perEntityType: new Map([[EntityType.SCENE, 5]]) }
+      })
+    })
+
+    it('should reject it and name that entity type', () => {
+      expect(() => assertMonotonicQuotaLadder(ladder)).toThrow(
+        "The deployment quota for 'scene' allows 5 per day but 100 per hour"
+      )
+    })
+  })
+})
+
+describe('when parsing the exempt address list', () => {
+  describe('and the list is empty', () => {
+    it('should produce no exemptions', () => {
+      expect(parseIpExemptions([])).toEqual([])
+    })
+  })
+
+  describe('and an entry is a bare IPv4 address', () => {
+    it('should treat it as a full-length prefix', () => {
+      expect(parseIpExemptions(['203.0.113.7'])).toEqual([{ bytes: Uint8Array.from([203, 0, 113, 7]), prefixBits: 32 }])
+    })
+  })
+
+  describe('and an entry is a bare IPv6 address', () => {
+    it('should treat it as a full-length prefix', () => {
+      expect(parseIpExemptions(['2001:db8::1'])[0].prefixBits).toBe(128)
+    })
+  })
+
+  describe('and an entry is not an address', () => {
+    it('should reject it, so a typo cannot silently exempt nothing', () => {
+      expect(() => parseIpExemptions(['not-an-ip'])).toThrow(
+        'Invalid DEPLOYMENT_QUOTA_EXEMPT_IPS entry "not-an-ip": "not-an-ip" is not an IP address'
+      )
+    })
+  })
+
+  describe('and an entry has a non-numeric prefix length', () => {
+    it('should reject it', () => {
+      expect(() => parseIpExemptions(['10.0.0.0/eight'])).toThrow('the prefix length is not a number')
+    })
+  })
+
+  describe('and an entry has a prefix longer than the address', () => {
+    it('should reject it', () => {
+      expect(() => parseIpExemptions(['10.0.0.0/33'])).toThrow('the prefix length must be at most 32')
+    })
+  })
+
+  describe('and an entry carries more than one slash', () => {
+    it('should reject it', () => {
+      expect(() => parseIpExemptions(['10.0.0.0/8/8'])).toThrow('expected an IP address or a CIDR')
+    })
+  })
+})
+
+describe('when matching a client address against the exempt list', () => {
+  describe('and the list is empty', () => {
+    it('should exempt nothing', () => {
+      expect(isExemptIp('203.0.113.7', [])).toBe(false)
+    })
+  })
+
+  describe('and the address is listed exactly', () => {
+    it('should exempt it', () => {
+      expect(isExemptIp('203.0.113.7', parseIpExemptions(['203.0.113.7']))).toBe(true)
+    })
+  })
+
+  describe('and a different address is listed', () => {
+    it('should not exempt it', () => {
+      expect(isExemptIp('203.0.113.8', parseIpExemptions(['203.0.113.7']))).toBe(false)
+    })
+  })
+
+  describe('and the address falls inside a listed IPv4 CIDR', () => {
+    it('should exempt it', () => {
+      expect(isExemptIp('198.51.100.42', parseIpExemptions(['198.51.100.0/24']))).toBe(true)
+    })
+  })
+
+  describe('and the address falls just outside a listed IPv4 CIDR', () => {
+    it('should not exempt it', () => {
+      expect(isExemptIp('198.51.101.1', parseIpExemptions(['198.51.100.0/24']))).toBe(false)
+    })
+  })
+
+  describe('and the CIDR does not end on a byte boundary', () => {
+    it('should compare only the bits inside the prefix', () => {
+      expect([
+        isExemptIp('198.51.100.126', parseIpExemptions(['198.51.100.64/26'])),
+        isExemptIp('198.51.100.128', parseIpExemptions(['198.51.100.64/26']))
+      ]).toEqual([true, false])
+    })
+  })
+
+  describe('and the address falls inside a listed IPv6 CIDR', () => {
+    it('should exempt it', () => {
+      expect(isExemptIp('2001:db8:1234::5', parseIpExemptions(['2001:db8::/32']))).toBe(true)
+    })
+  })
+
+  describe('and the address is an IPv6 spelling of a listed IPv6 address', () => {
+    it('should exempt it, since both are canonicalized first', () => {
+      expect(isExemptIp('2001:0DB8:0000:0000:0000:0000:0000:0001', parseIpExemptions(['2001:db8::1']))).toBe(true)
+    })
+  })
+
+  describe('and the address arrives in IPv4-mapped IPv6 form', () => {
+    it('should be exempted by the IPv4 entry it maps to', () => {
+      expect(isExemptIp('::ffff:203.0.113.7', parseIpExemptions(['203.0.113.7']))).toBe(true)
+    })
+  })
+
+  describe('and an IPv4 CIDR is matched against an IPv6 client', () => {
+    it('should not exempt it, since the families are compared separately', () => {
+      expect(isExemptIp('2001:db8::1', parseIpExemptions(['0.0.0.0/0']))).toBe(false)
+    })
+  })
+
+  describe('and the address is not an address at all', () => {
+    it('should not exempt it', () => {
+      expect(isExemptIp('nonsense', parseIpExemptions(['0.0.0.0/0']))).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
## Why

`POST /entities` had no bound on how much a single client can deploy over time. The two guards that look like they cover it do not: `POST_ENTITIES_RATE_LIMIT_*` is a per-client *request* budget over one 60s window and is blind to entity type, and `DEPLOYMENT_RATE_LIMIT_*` throttles redeployments of the same *pointer* rather than one caller's total. One address could deploy 200 distinct scenes a minute indefinitely with every guard reading healthy.

## What

A `deployment-quota` logic component bounding deploy attempts per (client address, entity type) over a minute, hour, day and week. It is enforced in the `POST /entities` handler rather than at its mount, because the entity type lives inside the uploaded entity file and cannot be known before the multipart parse. The entity is located by its **computed** hash — the multipart field names are the caller's to choose, so keying on them would let anyone skip the quota by renaming the entity file. The resulting hash map is handed to `deployEntity`, so nothing is hashed twice.

Every attempt counts, including one that later fails validation, so a client sending garbage cannot deploy for free. A rejection answers `429` with `Retry-After` and says only when to retry, matching the `RateLimitDisclosure.RETRY_AFTER` convention the rest of the fleet follows.

Defaults are 60/600/3000/10000 so the server runs unconfigured, with `DEPLOYMENT_QUOTA_MAX_PER_{WINDOW}_{ENTITY_TYPE}` overrides and `DEPLOYMENT_QUOTA_EXEMPT_IPS` (addresses and CIDRs) for a backend deploying on behalf of many users from one address. A zero, an unknown entity type, a malformed address, and a ladder whose longer window is tighter than a shorter one all fail startup rather than run misconfigured.

## Note for review

The week tier cannot go through `IRateLimiterComponent.consume`: `MAX_WINDOW_SECONDS = 86400` is enforced in `resolvePolicy`, which both `consume()` and the middleware go through, as a seconds/milliseconds mix-up guard. Rather than weaken that guard in a shared package for one consumer, `counter.ts` counts against the cache directly while reusing the package's exported `windowOffsetFor`, `currentWindow`, `buildCounterKey`, `encodeIdentity`, `FALLBACK_IDENTITY` and both address helpers — so the window arithmetic, key layout and proxy-hop handling stay shared, and only the increment, the fail-open policy and the fallback divisor are owned here. The cost is that quota decisions no longer land on `rate_limiter_requests_total`; `dcl_content_deployment_quota_attempts_total{entity_type, window, outcome}` carries them instead, with `allowed` / `limited` / `degraded`.

Two things worth a second opinion:

- The default ladder is a proposal, not a measured figure.
- Because the ladder must be monotonic, a *burst* can only ever trip the minute window; the longer horizons bind a client that paces itself across windows. That also means the day and week tiers are not reachable within one test run, so they are pinned at the `countAttempt` level instead.

Counters are in memory, so a restart resets them. The limiter takes any cache with `increment`, so a durable store can be swapped in later without touching quota logic.

## Verification

`yarn build`, lint and prettier clean. Unit 463/463 across 40 suites; integration 37/37 suites, 323 passed, with no quota rejection leaking into an existing spec. Local integration ran the way CI does (`CI=true` with an external postgres) because testcontainers/ryuk hangs against Docker 29.4.3 on this machine — unrelated to these changes, but the local testcontainers bootstrap path was not exercised.